### PR TITLE
fix(audio): treat yt-dlp exit code 101 as success

### DIFF
--- a/app/adapters/audio.py
+++ b/app/adapters/audio.py
@@ -56,7 +56,9 @@ async def source_audio(title: str, artist: str, output_dir: str | None = None) -
             proc.kill()
             raise AudioSourceUnavailable(f"yt-dlp timed out for: {query}") from exc
 
-        if proc.returncode != 0:
+        # Exit code 101 means "--max-downloads reached" — the requested download
+        # completed successfully; yt-dlp just signals there are no more items.
+        if proc.returncode not in (0, 101):
             stderr_bytes = b""
             if proc.stderr:
                 stderr_bytes = await proc.stderr.read()


### PR DESCRIPTION
## Summary
- yt-dlp exits with code 101 when `--max-downloads 1` is used and the download completes — this is expected, not an error
- The audio adapter was treating any non-zero exit code as failure, causing all audio sourcing to silently fail
- Root cause discovered: local testing showed the MP3 file was written successfully despite code 101

## Test plan
- [ ] Single song source returns completed status (not failed)
- [ ] Playlist source job downloads songs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)