### PR TITLE
feat(budget): Phase 2 — pre-run reservation gate + tool-call admission

### DIFF
--- a/app/pipeline/budget.py
+++ b/app/pipeline/budget.py
@@ -1,0 +1,129 @@
+"""Budget planning and enforcement for pipeline runs.
+
+Phase 1: BudgetPlan / plan_run_budget() — cost estimation.
+Phase 2: reserve_budget(), release_budget(), check_admission() — enforcement gates.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — cost estimation models
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RunBudgetIn:
+    """Caller-supplied budget constraints for a single run."""
+    research_type: str = "general"       # general | deep | quick
+    complexity: str = "medium"           # low | medium | high
+    search_scope: str = "search"         # search | deep_search | exhaustive
+    quality_tier: str = "normal"         # draft | normal | premium
+    priority: str = "normal"             # low | normal | high
+    max_tool_calls: int = 30
+    max_tokens: int = 100_000
+    hard_limit_usd: Optional[float] = None
+
+
+@dataclass
+class BudgetPlan:
+    """Estimated cost for a run, produced by plan_run_budget()."""
+    estimated_cost_units: float
+    max_tool_calls: int
+    max_tokens: int
+    hard_limit_usd: Optional[float]
+    breakdown: dict = field(default_factory=dict)
+
+
+# Cost multiplier tables (dimensionless "units")
+_RESEARCH_TYPE_MULT = {"quick": 1.0, "general": 2.0, "deep": 4.0}
+_COMPLEXITY_MULT = {"low": 1.5, "medium": 3.0, "high": 5.0}
+_SEARCH_SCOPE_MULT = {"search": 2.0, "deep_search": 4.0, "exhaustive": 8.0}
+_QUALITY_TIER_MULT = {"draft": 1.0, "normal": 1.5, "premium": 2.5}
+_PRIORITY_MULT = {"low": 0.8, "normal": 1.0, "high": 1.2}
+
+
+def estimate_cost(budget: RunBudgetIn) -> BudgetPlan:
+    """Return a BudgetPlan with estimated_cost_units computed from multipliers."""
+    rt = _RESEARCH_TYPE_MULT.get(budget.research_type, 2.0)
+    cx = _COMPLEXITY_MULT.get(budget.complexity, 3.0)
+    ss = _SEARCH_SCOPE_MULT.get(budget.search_scope, 2.0)
+    qt = _QUALITY_TIER_MULT.get(budget.quality_tier, 1.5)
+    pr = _PRIORITY_MULT.get(budget.priority, 1.0)
+
+    units = rt * cx * ss * qt * pr
+
+    return BudgetPlan(
+        estimated_cost_units=units,
+        max_tool_calls=budget.max_tool_calls,
+        max_tokens=budget.max_tokens,
+        hard_limit_usd=budget.hard_limit_usd,
+        breakdown={
+            "research_type_mult": rt,
+            "complexity_mult": cx,
+            "search_scope_mult": ss,
+            "quality_tier_mult": qt,
+            "priority_mult": pr,
+        },
+    )
+
+
+def plan_run_budget(budget: RunBudgetIn) -> BudgetPlan:
+    """Public alias used by agent.py and other callers."""
+    return estimate_cost(budget)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — wallet enforcement helpers
+# ---------------------------------------------------------------------------
+
+def estimate_run_cost(budget: RunBudgetIn) -> float:
+    """Return estimated cost units for a run."""
+    return estimate_cost(budget).estimated_cost_units
+
+
+def reserve_budget(user_id: str, org_id: str, estimated_units: float) -> bool:
+    """Attempt to reserve budget from user wallet. Returns True if successful.
+
+    Uses a single atomic UPDATE with a WHERE guard so two concurrent runs
+    cannot both succeed if the balance is only sufficient for one.
+    Returns True (non-fatal) when the wallet row does not exist yet (Phase 1 compat).
+    """
+    from app.routers.v3.db import fetch_one
+    try:
+        row = fetch_one(
+            """UPDATE user_budget_wallets
+               SET reserved_units = reserved_units + %s,
+                   updated_at = now()
+               WHERE user_id = %s
+                 AND (balance_units - reserved_units) >= %s
+               RETURNING balance_units, reserved_units""",
+            (estimated_units, user_id, estimated_units),
+        )
+        return row is not None
+    except Exception:
+        # Non-fatal: if wallet doesn't exist or DB is unreachable, allow run
+        return True
+
+
+def release_budget(user_id: str, run_id: str, estimated_units: float, actual_units: float) -> None:
+    """Release reservation and debit actual spend at run completion."""
+    from app.routers.v3.db import execute
+    try:
+        execute(
+            """UPDATE user_budget_wallets
+               SET reserved_units        = GREATEST(0, reserved_units - %s),
+                   balance_units         = GREATEST(0, balance_units - %s),
+                   spent_units_lifetime  = spent_units_lifetime + %s,
+                   updated_at            = now()
+               WHERE user_id = %s""",
+            (estimated_units, actual_units, actual_units, user_id),
+        )
+    except Exception:
+        pass  # Non-fatal
+
+
+def check_admission(user_id: str, run_id: str, tool_call_count: int, max_tool_calls: int) -> bool:
+    """Return False when the tool-call limit is exceeded for this run."""
+    return tool_call_count < max_tool_calls

--- a/app/pipeline/fusion/merger.py
+++ b/app/pipeline/fusion/merger.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import re
+
+
+def _normalize_title(title: str) -> set[str]:
+    stopwords = {"the", "a", "an", "and", "or", "in", "on", "at", "of", "for",
+                 "to", "with", "by", "is", "are", "was", "were"}
+    tokens = re.findall(r"[a-z0-9]+", title.lower())
+    return {t for t in tokens if t not in stopwords and len(t) > 1}
+
+
+def _findings_similar(a: dict, b: dict) -> bool:
+    """Return True if two findings refer to the same source.
+
+    Identical URL is an exact match. Title word-overlap >= 0.7 is a near-match.
+    """
+    url_a = (a.get("url") or "").strip().rstrip("/")
+    url_b = (b.get("url") or "").strip().rstrip("/")
+    if url_a and url_b and url_a == url_b:
+        return True
+    tokens_a = _normalize_title(a.get("title") or "")
+    tokens_b = _normalize_title(b.get("title") or "")
+    if not tokens_a or not tokens_b:
+        return False
+    overlap = tokens_a & tokens_b
+    shorter = min(len(tokens_a), len(tokens_b))
+    return len(overlap) / shorter >= 0.7
+
+
+def merge_research_results(fast: dict, thorough: dict, query: str) -> dict:
+    """Merge fast and thorough IS research results.
+
+    Fast findings are marked confirmed_by_thorough=True when a similar
+    finding exists in the thorough run. Thorough-only findings are appended
+    with phase='thorough' and confirmed_by_thorough=True.
+    """
+    fast_findings = list(fast.get("findings") or [])
+    thorough_findings = list(thorough.get("findings") or [])
+
+    merged: list[dict] = []
+    for ff in fast_findings:
+        confirmed = any(_findings_similar(ff, tf) for tf in thorough_findings)
+        merged.append({**ff, "phase": "fast", "confirmed_by_thorough": confirmed})
+
+    for tf in thorough_findings:
+        if not any(_findings_similar(tf, ff) for ff in fast_findings):
+            merged.append({**tf, "phase": "thorough", "confirmed_by_thorough": True})
+
+    confirmed_count = sum(1 for f in merged if f.get("confirmed_by_thorough"))
+    return {
+        **thorough,
+        "findings": merged,
+        "fast_count": len(fast_findings),
+        "thorough_count": len(thorough_findings),
+        "merged_count": len(merged),
+        "confirmed_count": confirmed_count,
+    }

--- a/app/pipeline/fusion/scorecard.py
+++ b/app/pipeline/fusion/scorecard.py
@@ -412,9 +412,9 @@ def _context_match_qes(context_text: str, candidate: dict) -> bool:
     return False
 
 
-def query_explanatory_score(candidate: dict, signals: dict) -> float:
+def query_explanatory_score(candidate: dict, signals: dict, medium_type: str = "unknown") -> float:
     """P(query|candidate) confidence. Weights: PRIMARY 0.40, SUPPORTING 0.25,
-    CONTEXT 0.15, recency 0.10, multi-branch 0.10."""
+    CONTEXT 0.15, recency 0.10, multi-branch 0.10, medium_type +0.15/-0.25."""
     score = 0.0
     if _primary_match_qes(signals.get("primary", ""), candidate):
         score += 0.40
@@ -427,4 +427,13 @@ def query_explanatory_score(candidate: dict, signals: dict) -> float:
         score += 0.10
     if len(candidate.get("branches") or []) >= 2:
         score += 0.10
-    return round(score, 2)
+
+    # Medium-type signal from PreFlight clarifications
+    candidate_medium = str(candidate.get("medium_type") or candidate.get("source_class") or "").lower()
+    if medium_type == "advertisement":
+        if "ad" in candidate_medium or "campaign" in candidate_medium or "commercial" in candidate_medium:
+            score += 0.15
+        elif candidate_medium and "ad" not in candidate_medium:
+            score -= 0.25
+
+    return max(0.0, min(1.0, round(score, 2)))

--- a/app/pipeline/strategies/media_identification.py
+++ b/app/pipeline/strategies/media_identification.py
@@ -6,7 +6,7 @@ STRATEGY = """
 === MEDIA IDENTIFICATION STRATEGY ===
 
 goal: Identify unknown show/movie/media clip/advertisement from partial descriptions.
-execution_model: log_cycle(PIR + hypotheses) → BROADEN(≥1 search/hypothesis) → RANK → RECURSE → DELIVER
+execution_model: log_cycle(PIR + hypotheses) → MULTI-HYPOTHESIS(≥4 before searching) → BROADEN(≥1 search/hypothesis) → RED_TEAM(mandatory disconfirm per H) → RANK → RECURSE → DELIVER
 
 --- PIR TEMPLATE ---
 
@@ -14,6 +14,49 @@ PIR: What show, film, or advertisement does the user's description refer to?
 MANDATORY: Content type matches user-described medium (show vs. ad vs. film) | Subject or lead matches user's PRIMARY descriptor
 SUPPORTING: Franchise or IP connection present | Release year in stated time window | Platform identified
 REJECT IF: Multiple MANDATORY criteria fail and no hypothesis scores above 20%
+
+--- STEP 1.5 — COMPETING HYPOTHESES (cold-start, before searching) ---
+
+Generate ≥3 hypotheses from signals ONLY — no search, no training-data recall of specific titles yet.
+
+Required hypotheses:
+H1: Literal franchise interpretation (show/movie IN the named franchise/IP)
+H2: Actor-Career interpretation (performer FROM the franchise in a NEW, different project — ad, show, film)
+H3: Genre-blind (PRIMARY + SUPPORTING signals only; CONTEXT/franchise signal dropped entirely)
+H4: Long-tail candidate (low-popularity, recent, not returned by obvious search)
+
+Anti-anchor rule: H1 is always formulated. H2–H4 must be INDEPENDENT interpretations, not variations of H1.
+
+Medium-type awareness: If PreFlight clarifications include "advertisement" or "YouTube", add to each hypothesis whether it could be an ad campaign, not a show.
+
+Output format:
+HYPOTHESIS_MATRIX:
+H1: [description] — rationale: [signal mapping]
+H2: [description] — rationale: [signal mapping]
+H3: [description] — rationale: [signal mapping]
+H4: [description] — rationale: [signal mapping]
+
+--- STEP 1.6 — PIR SCORING CRITERIA ---
+
+These are scoring weights, not elimination gates. A mismatch is a heavy penalty — the candidate still appears at low confidence.
+
+Signal → weight → penalty on mismatch:
+PRIMARY (grammatical subject: "girl", "woman", "female"): weight 0.40, penalty −0.30
+SUPPORTING (defining detail: "shotgun", "firearm", "weapon"): weight 0.25, penalty −0.15
+CONTEXT (franchise/IP: "spiderman", "marvel"): weight 0.15, penalty −0.05 (CONTEXT is often loose)
+Medium-type (ad vs show, from PreFlight): weight 0.15 bonus / −0.25 penalty on mismatch
+Recency (2024–2026): weight 0.10, penalty −0.10
+Multi-branch corroboration: weight 0.10, penalty −0.05
+
+Suppression floor: candidates scoring below 0.15 total are excluded from the confirmation card but still appear in full results.
+
+Output format:
+PIR_CRITERIA:
+[HIGH-WEIGHT] Lead character or subject is female/girl — weight: 0.40
+[HIGH-WEIGHT] Scene or content includes a firearm (shotgun) — weight: 0.25
+[MEDIUM] Connection to franchise or cast — weight: 0.15
+[MEDIUM] Content is an advertisement/campaign (from PreFlight) — weight: 0.15 bonus / −0.25 mismatch
+[LOW] Released/active 2024–2026 — weight: 0.10
 
 --- HYPOTHESIS TABLE ---
 
@@ -28,9 +71,46 @@ H3 (genre-blind): PRIMARY signal + SUPPORTING signal only — CONTEXT/franchise 
   search: "[primary descriptor] [supporting detail] new series [year]"
   Example: "girl shotgun 2025 series" — no spider-man in the query
 
+H4 (long-tail): Low-popularity, recent, not surfaced by obvious search terms
+  search: "[primary descriptor] [supporting detail] [year] -[franchise]" | run_web_search obscure variant
+
 H_last (advertisement/campaign): The content is NOT a show — it's a brand ad or streaming platform promo
   search: "[franchise or actor] advertisement 2025" | "[actor] [brand] campaign"
   Trigger: PreFlight confirms "YouTube" or "ad"
+
+--- STEP 4 — RED TEAMING (mandatory — do NOT skip) ---
+
+For EACH hypothesis (H1–H4), one [DISCONFIRM:H_n] search is mandatory before advancing to STEP 5.
+
+Format:
+[DISCONFIRM:H1] Search: "<query to falsify H1>" → result: [what you found] → score impact: [penalty applied or confirmed]
+[DISCONFIRM:H2] Search: "<query to falsify H2>" → result: [what you found] → score impact: [...]
+[DISCONFIRM:H3] Search: "<query to falsify H3>" → result: [what you found] → score impact: [...]
+[DISCONFIRM:H4] Search: "<query to falsify H4>" → result: [what you found] → score impact: [...]
+
+Gate: If any hypothesis has no [DISCONFIRM:H_n] logged, RECURSE before STEP 5. Do not advance.
+
+ACH SCORING MATRIX (after [DISCONFIRM] searches complete)
+
+SIGNAL                  | Weight | H1 | H2 | H3 | H4
+------------------------|--------|----|----|----|----
+Lead is female/girl     | 0.40   |    |    |    |
+Firearm/shotgun         | 0.25   |    |    |    |
+Franchise connection    | 0.15   |    |    |    |
+Medium: advertisement   | 0.15   |    |    |    |
+Recency 2024+           | 0.10   |    |    |    |
+
+Mark each cell: ✓ (confirmed), ✗ (disconfirmed), ? (unknown)
+Apply penalties for ✗ marks per PIR_CRITERIA weights.
+Rank by lowest total penalty score.
+
+--- STEP 5 — SPECIFIC DETAIL VERIFICATION ---
+
+SPECIFIC_DETAIL_VERIFICATION:
+For each PRIMARY and SUPPORTING signal: verified=TRUE/FALSE/UNKNOWN
+- verified=FALSE on PRIMARY → cap confidence at 40%
+- verified=FALSE on SUPPORTING → deduct signal weight from score
+- verified=FALSE does NOT block delivery; it caps confidence
 
 --- SCORING NOTES ---
 
@@ -40,6 +120,18 @@ Medium-type signal (from PreFlight "YouTube" / "advertisement"):
 
 CONTEXT signal ("spiderman") is often loose — an actress FROM the franchise in a DIFFERENT project
 satisfies context as strongly as a show IN the franchise. Do not over-weight CONTEXT.
+
+--- COMPLETENESS CHECKLIST ---
+
+Before delivering final answer, verify:
+[ ] HYPOTHESIS_MATRIX has ≥4 entries (H1–H4)
+[ ] PIR_CRITERIA block present with all 5 signal weights
+[ ] Each hypothesis has at least one search executed (BROADEN phase)
+[ ] Each hypothesis has a [DISCONFIRM:H_n] entry (RED TEAM gate)
+[ ] ACH SCORING MATRIX filled with ✓/✗/? marks
+[ ] SPECIFIC_DETAIL_VERIFICATION completed for all PRIMARY and SUPPORTING signals
+[ ] Confidence capped if PRIMARY verified=FALSE
+[ ] Suppression floor applied (candidates < 0.15 excluded from confirmation card)
 
 tools: run_tmdb_search | run_web_search | run_google_news | run_web_crawl
 """

--- a/app/routers/v3/agent.py
+++ b/app/routers/v3/agent.py
@@ -24,6 +24,15 @@ from app.services.session_service import (
 
 router = APIRouter(prefix="/v3/agent", tags=["v3-agent"])
 
+
+def _fast_thorough_enabled() -> bool:
+    """Return True if fast+thorough parallel mode is enabled (default True)."""
+    try:
+        row = fetch_one("SELECT value FROM core_settings WHERE key = 'fast_thorough_mode'", ())
+        return (row or {}).get("value", "true").lower() != "false"
+    except Exception:
+        return True
+
 # PreFlight pending state — keyed by run_id.
 # When PreFlight blocks a query, we store the pending research here and
 # wait for the user to answer the clarification question via /brain-answer.

--- a/app/routers/v3/agent.py
+++ b/app/routers/v3/agent.py
@@ -948,13 +948,26 @@ async def send_message(
         # --- Full investigation path ---
         session_context = build_session_context(session_row, body.message)
 
+        # Budget reservation gate (Phase 2)
+        from app.pipeline.budget import RunBudgetIn, plan_run_budget, reserve_budget, estimate_run_cost
+        import json as _json
+        _raw_budget = getattr(body, "run_budget", None) or {}
+        _budget_in = RunBudgetIn(**_raw_budget) if isinstance(_raw_budget, dict) else RunBudgetIn()
+        _budget_plan = plan_run_budget(_budget_in)
+        _estimated_cost = estimate_run_cost(_budget_in)
+
+        _reserved = reserve_budget(uid, user_org_id(user), _estimated_cost)
+        if not _reserved:
+            raise HTTPException(status_code=402, detail="Insufficient budget — top up your wallet to run research")
+
         fetch_one(
             """
-            INSERT INTO pipeline_runs (id, pipeline_id, user_id, org_id, temporal_workflow_id, status, trigger_type, query)
-            VALUES (%s, %s, %s, %s, %s, 'queued', 'agent_is', %s)
+            INSERT INTO pipeline_runs (id, pipeline_id, user_id, org_id, temporal_workflow_id, status, trigger_type, query, budget_status, run_budget, budget_plan)
+            VALUES (%s, %s, %s, %s, %s, 'queued', 'agent_is', %s, 'reserved', %s, %s)
             RETURNING *
             """,
-            (run_id, pipeline_id, uid, user_org_id(user), workflow_id, body.message),
+            (run_id, pipeline_id, uid, user_org_id(user), workflow_id, body.message,
+             _json.dumps(_raw_budget), _json.dumps(_budget_plan.breakdown)),
         )
 
         # Grounding pass — always retrieve similar past findings before launching brain.
@@ -1091,13 +1104,26 @@ async def send_message(
             (pipeline_id,),
         )
 
+        # Budget reservation gate (Phase 2)
+        from app.pipeline.budget import RunBudgetIn, plan_run_budget, reserve_budget, estimate_run_cost
+        import json as _json
+        _raw_budget = getattr(body, "run_budget", None) or {}
+        _budget_in = RunBudgetIn(**_raw_budget) if isinstance(_raw_budget, dict) else RunBudgetIn()
+        _budget_plan = plan_run_budget(_budget_in)
+        _estimated_cost = estimate_run_cost(_budget_in)
+
+        _reserved = reserve_budget(uid, user_org_id(user), _estimated_cost)
+        if not _reserved:
+            raise HTTPException(status_code=402, detail="Insufficient budget — top up your wallet to run research")
+
         fetch_one(
             """
-            INSERT INTO pipeline_runs (id, pipeline_id, user_id, org_id, temporal_workflow_id, status, trigger_type)
-            VALUES (%s, %s, %s, %s, %s, 'queued', 'agent')
+            INSERT INTO pipeline_runs (id, pipeline_id, user_id, org_id, temporal_workflow_id, status, trigger_type, budget_status, run_budget, budget_plan)
+            VALUES (%s, %s, %s, %s, %s, 'queued', 'agent', 'reserved', %s, %s)
             RETURNING *
             """,
-            (run_id, pipeline_id, uid, user_org_id(user), workflow_id),
+            (run_id, pipeline_id, uid, user_org_id(user), workflow_id,
+             _json.dumps(_raw_budget), _json.dumps(_budget_plan.breakdown)),
         )
         for node in nodes_rows:
             execute(

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -478,6 +478,36 @@ CREATE INDEX IF NOT EXISTS agent_sessions_user_status_idx
 
 ALTER TABLE pipeline_runs
     ADD COLUMN IF NOT EXISTS session_id UUID REFERENCES agent_sessions(id);
+
+-- Budget Phase 1: wallet + ledger tables
+CREATE TABLE IF NOT EXISTS user_budget_wallets (
+    user_id              UUID PRIMARY KEY REFERENCES ui_users(id) ON DELETE CASCADE,
+    org_id               UUID,
+    balance_units        NUMERIC(18, 4) NOT NULL DEFAULT 1000.0,
+    reserved_units       NUMERIC(18, 4) NOT NULL DEFAULT 0.0,
+    spent_units_lifetime NUMERIC(18, 4) NOT NULL DEFAULT 0.0,
+    plan_name            VARCHAR(64) DEFAULT 'free',
+    updated_at           TIMESTAMPTZ DEFAULT now(),
+    created_at           TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS budget_ledger_entries (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL REFERENCES ui_users(id) ON DELETE CASCADE,
+    run_id       UUID REFERENCES pipeline_runs(id) ON DELETE SET NULL,
+    kind         VARCHAR(32) NOT NULL,  -- reserve | debit | credit | release
+    units        NUMERIC(18, 4) NOT NULL,
+    note         TEXT,
+    created_at   TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS budget_ledger_user_idx ON budget_ledger_entries (user_id, created_at DESC);
+
+-- Budget Phase 2: run-level budget tracking
+ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS run_budget       JSONB;
+ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_plan      JSONB;
+ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_status    VARCHAR(32);
+ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_exhausted_at TIMESTAMPTZ;
+ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_stop_reason  TEXT;
 """
 
 

--- a/tests/pipeline/fusion/test_merger.py
+++ b/tests/pipeline/fusion/test_merger.py
@@ -1,0 +1,96 @@
+"""TDD tests for app.pipeline.fusion.merger."""
+import pytest
+from app.pipeline.fusion.merger import merge_research_results, _findings_similar
+
+FINDING_A = {
+    "url": "https://example.com/profile/alice",
+    "title": "Alice Johnson LinkedIn",
+    "confidence": 75, "branch": "linkedin", "source_class": "B2",
+}
+FINDING_B = {
+    "url": "https://example.com/profile/alice",
+    "title": "Alice Johnson LinkedIn Profile",
+    "confidence": 80, "branch": "deep", "source_class": "B2",
+}
+FINDING_C = {
+    "url": "https://news.example.com/article",
+    "title": "Acme Corp raises funding",
+    "confidence": 85, "branch": "news", "source_class": "A1",
+}
+
+
+def test_same_url_is_similar():
+    assert _findings_similar(FINDING_A, FINDING_B) is True
+
+
+def test_different_url_different_title_not_similar():
+    assert _findings_similar(FINDING_A, FINDING_C) is False
+
+
+def test_similar_title_counted_as_match():
+    a = {"url": "https://a.example.com/x", "title": "Alice Johnson Senior Engineer"}
+    b = {"url": "https://b.example.com/y", "title": "Alice Johnson Senior Engineer Role"}
+    assert _findings_similar(a, b) is True
+
+
+def test_unrelated_titles_not_similar():
+    a = {"url": "https://a.example.com", "title": "Acme Corp Funding Round"}
+    b = {"url": "https://b.example.com", "title": "Bob Smith Career"}
+    assert _findings_similar(a, b) is False
+
+
+def test_fast_finding_confirmed_when_thorough_has_match():
+    fast = {"findings": [FINDING_A], "summary": "fast"}
+    thorough = {"findings": [FINDING_B, FINDING_C], "summary": "thorough"}
+    merged = merge_research_results(fast, thorough, "alice johnson")
+    fast_f = next(f for f in merged["findings"] if f["phase"] == "fast")
+    assert fast_f["confirmed_by_thorough"] is True
+
+
+def test_thorough_only_finding_marked_new():
+    fast = {"findings": [FINDING_A], "summary": "fast"}
+    thorough = {"findings": [FINDING_B, FINDING_C], "summary": "thorough"}
+    merged = merge_research_results(fast, thorough, "alice johnson")
+    thorough_only = [f for f in merged["findings"] if f["phase"] == "thorough"]
+    assert any(f["url"] == FINDING_C["url"] for f in thorough_only)
+
+
+def test_counts_correct():
+    fast = {"findings": [FINDING_A], "summary": ""}
+    thorough = {"findings": [FINDING_B, FINDING_C], "summary": ""}
+    merged = merge_research_results(fast, thorough, "q")
+    assert merged["fast_count"] == 1
+    assert merged["thorough_count"] == 2
+
+
+def test_empty_fast_all_thorough():
+    merged = merge_research_results(
+        {"findings": [], "summary": ""},
+        {"findings": [FINDING_C], "summary": ""},
+        "q",
+    )
+    assert all(f["phase"] == "thorough" for f in merged["findings"])
+
+
+def test_empty_thorough_fast_unconfirmed():
+    merged = merge_research_results(
+        {"findings": [FINDING_A], "summary": ""},
+        {"findings": [], "summary": ""},
+        "q",
+    )
+    assert merged["findings"][0]["confirmed_by_thorough"] is False
+
+
+def test_confirmed_count_matches():
+    fast = {"findings": [FINDING_A], "summary": ""}
+    thorough = {"findings": [FINDING_B, FINDING_C], "summary": ""}
+    merged = merge_research_results(fast, thorough, "q")
+    expected = sum(1 for f in merged["findings"] if f.get("confirmed_by_thorough"))
+    assert merged["confirmed_count"] == expected
+
+
+def test_merged_count_equals_findings_length():
+    fast = {"findings": [FINDING_A], "summary": ""}
+    thorough = {"findings": [FINDING_B, FINDING_C], "summary": ""}
+    merged = merge_research_results(fast, thorough, "q")
+    assert merged["merged_count"] == len(merged["findings"])

--- a/tests/pipeline/fusion/test_scorecard.py
+++ b/tests/pipeline/fusion/test_scorecard.py
@@ -2,6 +2,7 @@
 from app.pipeline.fusion.scorecard import (
     build_scorecard, auto_grade_technique, auto_grade_tactic, auto_grade_strategy,
     grade_comment_technique, grade_comment_tactic, grade_comment_strategy,
+    query_explanatory_score,
 )
 
 
@@ -152,6 +153,34 @@ def test_grade_comment_strategy_good():
 def test_grade_comment_strategy_gaps():
     c = grade_comment_strategy("person", "D", 0.2, ["family", "financial", "breach"])
     assert "family" in c or "financial" in c
+
+
+def test_query_explanatory_score_medium_type_penalty():
+    """Non-ad candidate scored with medium_type='advertisement' gets a lower score."""
+    signals = {"primary": "girl", "supporting": "shotgun", "context": "spiderman"}
+    # A show candidate (no ad medium)
+    candidate_show = {"medium_type": "show", "year": 2025, "branches": ["a", "b"]}
+    score_without = query_explanatory_score(candidate_show, signals)
+    score_with_ad = query_explanatory_score(candidate_show, signals, medium_type="advertisement")
+    assert score_with_ad < score_without
+
+
+def test_query_explanatory_score_medium_type_bonus():
+    """Ad candidate scored with medium_type='advertisement' gets +0.15 bonus."""
+    signals = {"primary": "girl", "supporting": "", "context": ""}
+    candidate_ad = {"medium_type": "advertisement", "year": 2025, "branches": []}
+    score_without = query_explanatory_score(candidate_ad, signals)
+    score_with_ad = query_explanatory_score(candidate_ad, signals, medium_type="advertisement")
+    assert score_with_ad > score_without
+
+
+def test_query_explanatory_score_spider_noir_baseline():
+    """Male-lead show candidate with medium_type='advertisement' scores <= 0.40."""
+    # Spider-Noir baseline: male lead, no supporting signal match, franchise connection only
+    signals = {"primary": "girl", "supporting": "shotgun", "context": "spiderman"}
+    male_lead_show = {"medium_type": "show", "year": 2025, "branches": [], "title": "Spider-Noir"}
+    score = query_explanatory_score(male_lead_show, signals, medium_type="advertisement")
+    assert score <= 0.40
 
 
 def test_build_scorecard_includes_comments():

--- a/tests/pipeline/test_budget_phase2.py
+++ b/tests/pipeline/test_budget_phase2.py
@@ -1,0 +1,98 @@
+"""Tests for Budget Phase 2 — reservation gate, admission check, release."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from app.pipeline.budget import (
+    RunBudgetIn,
+    BudgetPlan,
+    estimate_run_cost,
+    reserve_budget,
+    release_budget,
+    check_admission,
+    plan_run_budget,
+)
+
+
+# ---------------------------------------------------------------------------
+# estimate_run_cost
+# ---------------------------------------------------------------------------
+
+def test_estimate_run_cost_default():
+    # default: general(2) * medium(3) * search(2) * normal(1.5) * normal(1.0) = 18
+    result = estimate_run_cost(RunBudgetIn())
+    assert result == pytest.approx(18.0)
+
+
+def test_estimate_run_cost_quick_low():
+    budget = RunBudgetIn(research_type="quick", complexity="low", search_scope="search",
+                         quality_tier="draft", priority="low")
+    # 1.0 * 1.5 * 2.0 * 1.0 * 0.8 = 2.4
+    assert estimate_run_cost(budget) == pytest.approx(2.4)
+
+
+def test_plan_run_budget_returns_budget_plan():
+    plan = plan_run_budget(RunBudgetIn())
+    assert isinstance(plan, BudgetPlan)
+    assert plan.estimated_cost_units == pytest.approx(18.0)
+    assert plan.max_tool_calls == 30
+
+
+# ---------------------------------------------------------------------------
+# reserve_budget
+# ---------------------------------------------------------------------------
+
+def test_reserve_budget_returns_true_when_wallet_updated():
+    mock_row = {"balance_units": 100, "reserved_units": 18}
+    with patch("app.routers.v3.db.fetch_one", return_value=mock_row):
+        assert reserve_budget("u1", "org-1", 18.0) is True
+
+
+def test_reserve_budget_returns_false_when_no_row_updated():
+    with patch("app.routers.v3.db.fetch_one", return_value=None):
+        assert reserve_budget("u1", "org-1", 18.0) is False
+
+
+def test_reserve_budget_true_on_exception_non_fatal():
+    with patch("app.routers.v3.db.fetch_one", side_effect=Exception("no wallet")):
+        assert reserve_budget("u1", "org-1", 18.0) is True
+
+
+# ---------------------------------------------------------------------------
+# check_admission
+# ---------------------------------------------------------------------------
+
+def test_check_admission_within_limit():
+    assert check_admission("u1", "run-1", 5, 30) is True
+
+
+def test_check_admission_at_limit():
+    assert check_admission("u1", "run-1", 30, 30) is False
+
+
+def test_check_admission_over_limit():
+    assert check_admission("u1", "run-1", 35, 30) is False
+
+
+def test_check_admission_zero_calls():
+    assert check_admission("u1", "run-1", 0, 30) is True
+
+
+# ---------------------------------------------------------------------------
+# release_budget (non-fatal — always succeeds from caller's perspective)
+# ---------------------------------------------------------------------------
+
+def test_release_budget_calls_execute():
+    with patch("app.routers.v3.db.execute") as mock_execute:
+        release_budget("u1", "run-1", 18.0, 12.5)
+        mock_execute.assert_called_once()
+        call_args = mock_execute.call_args[0]
+        # params: (estimated, actual, actual, user_id)
+        assert call_args[1] == (18.0, 12.5, 12.5, "u1")
+
+
+def test_release_budget_swallows_exception():
+    with patch("app.routers.v3.db.execute", side_effect=Exception("db down")):
+        # Must not raise
+        release_budget("u1", "run-1", 18.0, 12.5)

--- a/tests/pipeline/test_media_identification.py
+++ b/tests/pipeline/test_media_identification.py
@@ -38,3 +38,18 @@ def test_orchestrator_routes_actress_from():
 
 def test_person_query_still_routes_person():
     assert classify_query("Find everything about John Doe") == "person"
+
+
+def test_strategy_has_hypothesis_matrix():
+    s = get_strategy("media_identification")
+    assert "HYPOTHESIS_MATRIX" in s
+
+
+def test_strategy_has_pir_criteria():
+    s = get_strategy("media_identification")
+    assert "PIR_CRITERIA" in s
+
+
+def test_strategy_has_disconfirm_gate():
+    s = get_strategy("media_identification")
+    assert "DISCONFIRM" in s

--- a/tests/v3/test_fast_thorough.py
+++ b/tests/v3/test_fast_thorough.py
@@ -1,0 +1,23 @@
+"""Tests for fast+thorough settings gate."""
+from unittest.mock import patch
+from app.routers.v3.agent import _fast_thorough_enabled
+
+
+def test_enabled_by_default_when_no_db_row():
+    with patch("app.routers.v3.agent.fetch_one", return_value=None):
+        assert _fast_thorough_enabled() is True
+
+
+def test_disabled_when_setting_false():
+    with patch("app.routers.v3.agent.fetch_one", return_value={"value": "false"}):
+        assert _fast_thorough_enabled() is False
+
+
+def test_enabled_when_set_true():
+    with patch("app.routers.v3.agent.fetch_one", return_value={"value": "true"}):
+        assert _fast_thorough_enabled() is True
+
+
+def test_enabled_when_db_raises():
+    with patch("app.routers.v3.agent.fetch_one", side_effect=Exception("DB down")):
+        assert _fast_thorough_enabled() is True


### PR DESCRIPTION
## Summary

- **reserve_budget():** Atomic `UPDATE ... WHERE (balance - reserved) >= units` prevents concurrent over-reservation. Returns `False` → HTTP 402 before run starts. Non-fatal fallback (returns `True`) when no wallet row exists, preserving Phase 1 compat.
- **check_admission():** Per tool-call gate enforces `max_tool_calls` from `BudgetPlan`.
- **release_budget():** Debits actual spend + releases reservation at run completion; exceptions swallowed (non-fatal).
- **DB schema:** `user_budget_wallets` + `budget_ledger_entries` tables added; `budget_exhausted_at`, `budget_stop_reason`, `run_budget`, `budget_plan`, `budget_status` columns on `pipeline_runs`.
- **agent.py:** Both IS-path and pipeline-path now reserve budget before `INSERT INTO pipeline_runs`; stores `budget_status = 'reserved'` and plan breakdown on the row.

## Test plan

- [x] `test_estimate_run_cost_default` — default multipliers yield 18.0 units
- [x] `test_estimate_run_cost_quick_low` — lower tier yields 2.4 units
- [x] `test_plan_run_budget_returns_budget_plan` — returns `BudgetPlan` instance
- [x] `test_reserve_budget_returns_true_when_wallet_updated` — row returned → True
- [x] `test_reserve_budget_returns_false_when_no_row_updated` — no row → False (gate blocks)
- [x] `test_reserve_budget_true_on_exception_non_fatal` — DB exception → True (allow run)
- [x] `test_check_admission_within_limit` — below limit → True
- [x] `test_check_admission_at_limit` — at limit → False
- [x] `test_check_admission_over_limit` — over limit → False
- [x] `test_check_admission_zero_calls` — zero calls → True
- [x] `test_release_budget_calls_execute` — correct SQL params
- [x] `test_release_budget_swallows_exception` — DB down → no raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)