### PR TITLE
feat(ui): Fast+Thorough Phase C — phase indicators and confirmation badges

### DIFF
--- a/frontend/src/components/results/ResultsPanel.tsx
+++ b/frontend/src/components/results/ResultsPanel.tsx
@@ -574,6 +574,7 @@ function ResearchResults({
       await submitFindingFeedback(runId, index, score, reason, title)
     }
   }
+  const thoroughInProgress = useChatStore(s => s.thoroughInProgress)
   const { findings, trail } = research
   // Always allow Go Deeper when findings exist — use trail leads if available, else derive from findings
   const canGoDeeper = findings.length > 0
@@ -735,6 +736,19 @@ function ResearchResults({
                 <span style={{ color: 'var(--subtext)', fontWeight: 600, opacity: isError ? 0.6 : 1 }}>
                   {f.title ?? 'Finding'}
                 </span>
+                {/* Phase badge — shown when finding has phase metadata */}
+                {(f as any).phase === 'fast' && (f as any).confirmed_by_thorough && (
+                  <span style={{
+                    fontSize: 9, color: '#4ade80', marginLeft: 6, fontWeight: 700,
+                    background: '#14532d44', padding: '1px 5px', borderRadius: 3,
+                  }}>✓</span>
+                )}
+                {(f as any).phase === 'thorough' && (
+                  <span style={{
+                    fontSize: 9, color: '#60a5fa', marginLeft: 6, fontWeight: 700,
+                    background: '#1e3a5f44', padding: '1px 5px', borderRadius: 3,
+                  }}>NEW</span>
+                )}
                 {f.branch && (
                   <span style={{ color: 'var(--muted)', fontSize: 9, marginLeft: 'auto' }}>
                     {f.branch} d{f.depth}
@@ -890,6 +904,18 @@ function ResearchResults({
           )
         })}
       </div>
+
+      {/* Thorough research in-progress indicator */}
+      {thoroughInProgress && (
+        <div style={{
+          padding: '8px 12px', fontSize: 11, color: '#94a3b8',
+          borderTop: '1px solid #1e293b',
+          display: 'flex', alignItems: 'center', gap: 6,
+        }}>
+          <span style={{ animation: 'pulse 1.5s infinite' }}>⏳</span>
+          Thorough research in progress…
+        </div>
+      )}
 
       {/* Investigation Breakdown scorecard */}
       {runId && <InvestigationBreakdown runId={runId} />}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import { useEffect, useRef, useCallback } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
+import { useChatStore } from '../stores/chatStore'
 
 export type WsEvent = {
   type: string
@@ -48,6 +49,24 @@ function connect(token: string) {
     try {
       const event: WsEvent = JSON.parse(e.data)
       if (event.type !== 'ping') {
+        // Handle fast+thorough phase events centrally
+        switch (event.type) {
+          case 'research.fast.started':
+            useChatStore.getState().setThoroughInProgress(true)
+            break
+          case 'research.fast.completed':
+            useChatStore.getState().setFastResearchDone(true)
+            // Fast findings arrive via existing job.update/findings mechanism
+            // This event signals "preview ready, thorough still running"
+            break
+          case 'research.thorough.started':
+            // Both runs are underway — no extra state change needed
+            break
+          case 'research.thorough.completed':
+            useChatStore.getState().setFastResearchDone(false)
+            useChatStore.getState().setThoroughInProgress(false)
+            break
+        }
         _handlers.forEach(h => h(event))
       }
     } catch {

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -15,6 +15,9 @@ interface ChatState {
   sessionId: string | null
   genesisQuery: string | null
   sessionRunIds: string[]
+  // Phase state for fast+thorough two-phase display
+  fastResearchDone: boolean
+  thoroughInProgress: boolean
   addMessage: (msg: Message) => void
   updateMessage: (id: string, patch: Partial<Message>) => void
   setMessages: (msgs: Message[]) => void
@@ -22,6 +25,8 @@ interface ChatState {
   setGenesisQuery: (q: string) => void
   pushSessionRun: (runId: string) => void
   clearMessages: () => void
+  setFastResearchDone: (done: boolean) => void
+  setThoroughInProgress: (inProgress: boolean) => void
 }
 
 export const useChatStore = create<ChatState>()(
@@ -31,6 +36,8 @@ export const useChatStore = create<ChatState>()(
       sessionId: null,
       genesisQuery: null,
       sessionRunIds: [],
+      fastResearchDone: false,
+      thoroughInProgress: false,
       addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
       updateMessage: (id, patch) =>
         set((s) => ({
@@ -40,7 +47,9 @@ export const useChatStore = create<ChatState>()(
       setSessionId: (id) => set({ sessionId: id }),
       setGenesisQuery: (q) => set({ genesisQuery: q }),
       pushSessionRun: (runId) => set((s) => ({ sessionRunIds: [...s.sessionRunIds, runId] })),
-      clearMessages: () => set({ messages: [], sessionId: null, genesisQuery: null, sessionRunIds: [] }),
+      clearMessages: () => set({ messages: [], sessionId: null, genesisQuery: null, sessionRunIds: [], fastResearchDone: false, thoroughInProgress: false }),
+      setFastResearchDone: (done) => set({ fastResearchDone: done }),
+      setThoroughInProgress: (inProgress) => set({ thoroughInProgress: inProgress }),
     }),
     {
       name: 'ib-chat',


### PR DESCRIPTION
Phase C of the fast+thorough spec.

## Changes

- **chatStore**: `fastResearchDone` + `thoroughInProgress` booleans with setters; both reset to `false` on `clearMessages` so new jobs start clean
- **useWebSocket**: four new `switch` cases in the singleton `onmessage` handler — `research.fast.started` sets `thoroughInProgress`, `research.fast.completed` sets `fastResearchDone`, `research.thorough.completed` clears both, `research.thorough.started` is a no-op comment placeholder
- **ResultsPanel**: `thoroughInProgress` from store drives an ⏳ spinner row below the findings list; per-finding badges render `✓` (green) when `phase === 'fast' && confirmed_by_thorough`, and `NEW` (blue) when `phase === 'thorough'`

## Dependencies

Requires Phase A (merger.py sets `phase` / `confirmed_by_thorough` on findings) and Phase B (asyncio.gather emits the four WS events).

## Test results

```
Test Files  1 passed (1)
     Tests  21 passed (21)
```