### PR TITLE
fix(prompt): PIR dead-end re-hypothesization + 8 structural prompt tests

### DIFF
--- a/app/is_prompt.py
+++ b/app/is_prompt.py
@@ -283,7 +283,14 @@ For each branch, explore recursively as deep as the research requires (suggested
    - Found a review? Search for more reviews, aggregate scores
 4. Assess each result:
    - FRUIT: specific, verifiable finding — store it with source URL
-   - DEAD END: no data after 2+ searches — mark and stop
+   - DEAD END: no data after 2+ searches on this angle.
+     Do NOT close the PIR immediately. Instead:
+     1. Re-hypothesize: form a new interpretation of the same PIR from a different angle
+        (different locale, name variant, source type, or medium-type assumption).
+     2. Run ≥1 new BROADEN search from the re-hypothesized angle.
+     3. Only mark the PIR closed when BOTH the original AND re-hypothesized angles yield no signal,
+        OR when all declared hypotheses in log_cycle have been exhausted.
+     Log: "DEAD END: [what failed]. RE-HYPOTHESIZE: [new angle tried]. OUTCOME: [result]."
    - BLOCKED: tool returned HTTP 403 / API key missing / rate limit / structural error
      → DO NOT retry. Run the BLOCK CLASSIFICATION + PIVOT PROTOCOL:
 

--- a/tests/test_is_prompt.py
+++ b/tests/test_is_prompt.py
@@ -61,3 +61,60 @@ def test_past_research_is_delimited():
                           session_context="", user_sources="")
     assert "<past_research>" in prompt
     assert "</past_research>" in prompt
+
+
+# --- PIR-bounded cycle structural assertions ---
+
+from app.is_prompt import RESEARCH_PROMPT
+
+
+def test_log_cycle_declaration_required():
+    """log_cycle must be called before any search — core PIR cycle gate."""
+    assert "log_cycle" in RESEARCH_PROMPT
+    assert "CANNOT run any search before calling log_cycle" in RESEARCH_PROMPT
+
+
+def test_hypothesis_first_broaden_gate():
+    """Minimum searches = number of hypotheses (hard gate)."""
+    assert "HYPOTHESIS-FIRST BROADEN" in RESEARCH_PROMPT
+
+
+def test_dead_end_rehypothesization_required():
+    """Dead ends must trigger re-hypothesization, not immediate closure."""
+    assert "RE-HYPOTHESIZE" in RESEARCH_PROMPT or "re-hypothesize" in RESEARCH_PROMPT.lower()
+    # The old "mark and stop" behavior must be gone
+    assert "mark and stop" not in RESEARCH_PROMPT
+
+
+def test_prior_collapse_replan_trigger():
+    """PRIOR COLLAPSE must trigger a replan when hypothesis is contradicted."""
+    assert "PRIOR COLLAPSE" in RESEARCH_PROMPT
+
+
+def test_unconventional_branch_mandatory():
+    """STEP 6 unconventional branch must be declared mandatory."""
+    assert "UNCONVENTIONAL" in RESEARCH_PROMPT
+    assert "mandatory" in RESEARCH_PROMPT.lower()
+
+
+def test_pir_criteria_scoring():
+    """PIR scoring criteria with penalty weighting must be present."""
+    assert "PIR" in RESEARCH_PROMPT
+    assert "penalty" in RESEARCH_PROMPT.lower()
+
+
+def test_child_pir_spawning():
+    """Child PIRs must be spawnable mid-investigation (parent_cycle_id)."""
+    assert "parent_cycle_id" in RESEARCH_PROMPT
+
+
+def test_build_prompt_preserves_all_slots():
+    """build_prompt must accept all injection slots without crashing on None."""
+    result = build_prompt(
+        query="test query",
+        past_research=None,
+        user_sources="",
+        session_context="",
+    )
+    assert "test query" in result or "<user_query>" in result
+    assert len(result) > 100


### PR DESCRIPTION
## Summary

- **is_prompt.py STEP 4**: Dead-end handling now triggers re-hypothesization from a different angle (locale, name variant, source type, medium-type assumption) before closing a PIR. The old one-liner "mark and stop" is replaced with a 3-step protocol: re-hypothesize, run ≥1 new BROADEN search, only mark closed when both original and re-hypothesized angles yield no signal (or all log_cycle hypotheses are exhausted).
- **tests/test_is_prompt.py**: 8 new structural tests that assert the mandatory PIR cycle gates are present and correctly wired in the prompt.

## Test plan

- [x] `test_log_cycle_declaration_required` — log_cycle gate present
- [x] `test_hypothesis_first_broaden_gate` — HYPOTHESIS-FIRST BROADEN present
- [x] `test_dead_end_rehypothesization_required` — RE-HYPOTHESIZE present, "mark and stop" absent
- [x] `test_prior_collapse_replan_trigger` — PRIOR COLLAPSE present
- [x] `test_unconventional_branch_mandatory` — UNCONVENTIONAL + mandatory present
- [x] `test_pir_criteria_scoring` — PIR + penalty present
- [x] `test_child_pir_spawning` — parent_cycle_id present
- [x] `test_build_prompt_preserves_all_slots` — build_prompt accepts None slots without crash
- [x] All 15 tests pass (7 pre-existing + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)