### PR TITLE
feat(rbac): is_admin column + require_admin helper + admin route gating

### DIFF
--- a/app/pipeline/nodes/__init__.py
+++ b/app/pipeline/nodes/__init__.py
@@ -106,6 +106,8 @@ class NodeRegistry:
         from app.pipeline.nodes.migration_corridor_lookup import MigrationCorridorLookupNode
         from app.pipeline.nodes.h1bdata_search import H1bdataSearchNode
         from app.pipeline.nodes.icij_search import IcijSearchNode
+        from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+        from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
 
         for node in [
             AgentInputNode(), DdgSearchNode(), QdrantSearchNode(), RssMonitorNode(),
@@ -138,6 +140,7 @@ class NodeRegistry:
             PhNameVariantsNode(), EntityLineageNode(),
             NameOriginLookupNode(), MigrationCorridorLookupNode(),
             H1bdataSearchNode(), IcijSearchNode(),
+            DropboxSearchNode(), GoogleDriveSearchNode(),
         ]:
             cls.register(node)
 

--- a/app/pipeline/nodes/dropbox_search.py
+++ b/app/pipeline/nodes/dropbox_search.py
@@ -1,0 +1,189 @@
+"""Dropbox file search datastore node — search files in a Dropbox account via the Dropbox API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import httpx
+
+from app.pipeline.nodes.base import RunContext
+
+log = logging.getLogger(__name__)
+
+_REASON = "Dropbox surfaces files and documents stored in a user's cloud drive — useful for document intelligence and data retrieval"
+_SEARCH_URL = "https://api.dropboxapi.com/2/files/search_v2"
+
+
+def _resolve_token(config_token: str | None = None) -> str | None:
+    """Config value takes priority, then env var, then DB setting."""
+    if config_token:
+        return config_token
+    token = os.getenv("DROPBOX_ACCESS_TOKEN")
+    if token:
+        return token
+    try:
+        from app.routers.v3.db import fetch_one
+        row = fetch_one(
+            "SELECT value FROM core_settings WHERE key = 'dropbox_access_token'", ()
+        )
+        if row and row.get("value"):
+            return row["value"]
+    except Exception:
+        pass
+    return None
+
+
+class DropboxSearchNode:
+    node_type = "dropbox_search"
+    display_name = "Dropbox File Search"
+    category = "datastore"
+
+    config_schema = {
+        "type": "object",
+        "properties": {
+            "access_token": {
+                "type": "string",
+                "title": "Dropbox Access Token",
+                "description": "Leave blank to use DROPBOX_ACCESS_TOKEN env var or DB setting.",
+                "default": "",
+            },
+            "query": {
+                "type": "string",
+                "title": "Search Query",
+                "description": "Keywords to search for in filenames and content.",
+                "default": "",
+            },
+            "max_results": {
+                "type": "integer",
+                "title": "Max Results",
+                "default": 20,
+                "minimum": 1,
+                "maximum": 100,
+            },
+            "path": {
+                "type": "string",
+                "title": "Search Path",
+                "description": "Restrict search to this Dropbox path (e.g. '/Documents'). Leave blank for entire account.",
+                "default": "",
+            },
+        },
+        "required": [],
+    }
+
+    async def execute(
+        self, config: dict, inputs: list[dict], context: RunContext
+    ) -> list[dict]:
+        token = _resolve_token(config.get("access_token"))
+        if not token:
+            log.warning("dropbox_search: no access token configured")
+            return [
+                {
+                    "error": "DROPBOX_ACCESS_TOKEN not configured",
+                    "source": "dropbox",
+                    "reason": _REASON,
+                }
+            ]
+
+        query = (config.get("query") or "").strip()
+        if not query and inputs:
+            query = (
+                inputs[0].get("query")
+                or inputs[0].get("name")
+                or inputs[0].get("company")
+                or ""
+            ).strip()
+
+        if not query:
+            return [{"error": "No query provided for Dropbox search", "source": "dropbox"}]
+
+        max_results = min(int(config.get("max_results", 20)), 100)
+        path = (config.get("path") or "").strip()
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, _search_dropbox, token, query, path, max_results
+        )
+
+    # -- ToolCallable interface ------------------------------------------------
+
+    def tool_schema(self) -> dict:
+        return {
+            "name": "search_dropbox",
+            "description": (
+                "Search for files and documents in a Dropbox account by keyword. "
+                "Returns file metadata including name, path, and modification date."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Keywords to search for in filenames or content",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Optional Dropbox folder path to restrict search (e.g. '/Documents')",
+                    },
+                },
+                "required": ["query"],
+            },
+        }
+
+    async def tool_invoke(self, params: dict, context: RunContext) -> list[dict]:
+        config = getattr(self, "_active_config", {})
+        merged = {**config, **params}
+        return await self.execute(merged, [], context)
+
+
+def _search_dropbox(token: str, query: str, path: str, max_results: int) -> list[dict]:
+    """Synchronous Dropbox file search via the HTTP API."""
+    payload: dict = {
+        "query": query,
+        "options": {
+            "max_results": max_results,
+        },
+    }
+    if path:
+        payload["options"]["path"] = path
+
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            response = client.post(
+                _SEARCH_URL,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            if response.status_code == 401:
+                return [{"error": "Dropbox: unauthorized — check access token", "source": "dropbox"}]
+            response.raise_for_status()
+            data = response.json()
+    except httpx.HTTPStatusError as exc:
+        log.warning("dropbox_search: HTTP error for query %r: %s", query, exc)
+        return [{"error": str(exc), "source": "dropbox", "reason": _REASON}]
+    except Exception as exc:
+        log.warning("dropbox_search: unexpected error for query %r: %s", query, exc)
+        return [{"error": str(exc), "source": "dropbox", "reason": _REASON}]
+
+    matches = data.get("matches") or []
+    results = []
+    for match in matches:
+        meta = match.get("metadata", {}).get("metadata", {})
+        if not meta:
+            continue
+        results.append(
+            {
+                "title": meta.get("name", ""),
+                "path": meta.get("path_display", ""),
+                "type": meta.get(".tag", ""),
+                "size": meta.get("size"),
+                "modified": meta.get("client_modified") or meta.get("server_modified"),
+                "source": "dropbox",
+                "reason": _REASON,
+            }
+        )
+    return results

--- a/app/pipeline/nodes/google_drive_search.py
+++ b/app/pipeline/nodes/google_drive_search.py
@@ -1,0 +1,297 @@
+"""Google Drive file search datastore node — search files via the Drive API v3."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import httpx
+
+from app.pipeline.nodes.base import RunContext
+
+log = logging.getLogger(__name__)
+
+_REASON = "Google Drive surfaces documents, spreadsheets, and files stored in a Google Workspace — useful for document intelligence and collaboration data"
+_DRIVE_SEARCH_URL = "https://www.googleapis.com/drive/v3/files"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+
+def _resolve_credentials_path(config_path: str | None = None) -> str | None:
+    """Config value takes priority, then env var."""
+    if config_path:
+        return config_path
+    return os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+
+def _resolve_api_key(config_key: str | None = None) -> str | None:
+    """Simple API key for public/shared Drive access."""
+    if config_key:
+        return config_key
+    key = os.getenv("GOOGLE_DRIVE_API_KEY")
+    if key:
+        return key
+    try:
+        from app.routers.v3.db import fetch_one
+        row = fetch_one(
+            "SELECT value FROM core_settings WHERE key = 'google_drive_api_key'", ()
+        )
+        if row and row.get("value"):
+            return row["value"]
+    except Exception:
+        pass
+    return None
+
+
+class GoogleDriveSearchNode:
+    node_type = "google_drive_search"
+    display_name = "Google Drive File Search"
+    category = "datastore"
+
+    config_schema = {
+        "type": "object",
+        "properties": {
+            "credentials_path": {
+                "type": "string",
+                "title": "Service Account Credentials Path",
+                "description": (
+                    "Path to a Google service account JSON file. "
+                    "Leave blank to use GOOGLE_APPLICATION_CREDENTIALS env var."
+                ),
+                "default": "",
+            },
+            "api_key": {
+                "type": "string",
+                "title": "Google Drive API Key",
+                "description": (
+                    "Simple API key for querying shared/public drives. "
+                    "Leave blank to use GOOGLE_DRIVE_API_KEY env var or service account auth."
+                ),
+                "default": "",
+            },
+            "query": {
+                "type": "string",
+                "title": "Search Query",
+                "description": "Full-text search query or Drive query syntax (e.g. 'name contains \"report\"').",
+                "default": "",
+            },
+            "max_results": {
+                "type": "integer",
+                "title": "Max Results",
+                "default": 20,
+                "minimum": 1,
+                "maximum": 100,
+            },
+            "drive_id": {
+                "type": "string",
+                "title": "Shared Drive ID",
+                "description": "Optional shared drive ID to restrict search scope.",
+                "default": "",
+            },
+        },
+        "required": [],
+    }
+
+    async def execute(
+        self, config: dict, inputs: list[dict], context: RunContext
+    ) -> list[dict]:
+        credentials_path = _resolve_credentials_path(config.get("credentials_path"))
+        api_key = _resolve_api_key(config.get("api_key"))
+
+        if not credentials_path and not api_key:
+            log.warning("google_drive_search: no credentials or API key configured")
+            return [
+                {
+                    "error": (
+                        "Google Drive auth not configured — set GOOGLE_APPLICATION_CREDENTIALS "
+                        "or GOOGLE_DRIVE_API_KEY"
+                    ),
+                    "source": "google_drive",
+                    "reason": _REASON,
+                }
+            ]
+
+        query = (config.get("query") or "").strip()
+        if not query and inputs:
+            query = (
+                inputs[0].get("query")
+                or inputs[0].get("name")
+                or inputs[0].get("company")
+                or ""
+            ).strip()
+
+        if not query:
+            return [{"error": "No query provided for Google Drive search", "source": "google_drive"}]
+
+        max_results = min(int(config.get("max_results", 20)), 100)
+        drive_id = (config.get("drive_id") or "").strip()
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, _search_drive, credentials_path, api_key, query, max_results, drive_id
+        )
+
+    # -- ToolCallable interface ------------------------------------------------
+
+    def tool_schema(self) -> dict:
+        return {
+            "name": "search_google_drive",
+            "description": (
+                "Search for files and documents in Google Drive by keyword or Drive query syntax. "
+                "Returns file metadata including name, type, owner, and web link."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "Search query — plain text or Drive query syntax "
+                            "(e.g. 'name contains \"budget\" and mimeType = \"application/vnd.google-apps.spreadsheet\"')"
+                        ),
+                    },
+                    "drive_id": {
+                        "type": "string",
+                        "description": "Optional shared drive ID to restrict search",
+                    },
+                },
+                "required": ["query"],
+            },
+        }
+
+    async def tool_invoke(self, params: dict, context: RunContext) -> list[dict]:
+        config = getattr(self, "_active_config", {})
+        merged = {**config, **params}
+        return await self.execute(merged, [], context)
+
+
+def _get_service_account_token(credentials_path: str) -> str | None:
+    """Obtain an OAuth2 bearer token from a service account JSON key file."""
+    try:
+        import json
+        import time
+
+        with open(credentials_path) as f:
+            creds = json.load(f)
+
+        # Use google-auth if available (preferred)
+        try:
+            from google.oauth2 import service_account
+            from google.auth.transport.requests import Request as GoogleRequest
+
+            credentials = service_account.Credentials.from_service_account_file(
+                credentials_path,
+                scopes=["https://www.googleapis.com/auth/drive.readonly"],
+            )
+            credentials.refresh(GoogleRequest())
+            return credentials.token
+        except ImportError:
+            pass
+
+        # Fallback: manual JWT (RS256) — requires PyJWT + cryptography
+        try:
+            import jwt
+
+            now = int(time.time())
+            payload = {
+                "iss": creds["client_email"],
+                "scope": "https://www.googleapis.com/auth/drive.readonly",
+                "aud": _TOKEN_URL,
+                "iat": now,
+                "exp": now + 3600,
+            }
+            private_key = creds["private_key"]
+            assertion = jwt.encode(payload, private_key, algorithm="RS256")
+
+            with httpx.Client(timeout=10.0) as client:
+                resp = client.post(
+                    _TOKEN_URL,
+                    data={
+                        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                        "assertion": assertion,
+                    },
+                )
+                resp.raise_for_status()
+                return resp.json().get("access_token")
+        except Exception as exc:
+            log.warning("google_drive_search: JWT auth failed: %s", exc)
+            return None
+
+    except Exception as exc:
+        log.warning("google_drive_search: service account token error: %s", exc)
+        return None
+
+
+def _search_drive(
+    credentials_path: str | None,
+    api_key: str | None,
+    query: str,
+    max_results: int,
+    drive_id: str,
+) -> list[dict]:
+    """Synchronous Google Drive file search."""
+    headers: dict = {}
+    params: dict = {
+        "q": query,
+        "pageSize": max_results,
+        "fields": "files(id,name,mimeType,webViewLink,modifiedTime,owners,size,parents)",
+    }
+
+    if credentials_path:
+        token = _get_service_account_token(credentials_path)
+        if not token:
+            return [
+                {
+                    "error": "Google Drive: could not obtain access token from service account — install google-auth or PyJWT+cryptography",
+                    "source": "google_drive",
+                    "reason": _REASON,
+                }
+            ]
+        headers["Authorization"] = f"Bearer {token}"
+        if drive_id:
+            params["driveId"] = drive_id
+            params["includeItemsFromAllDrives"] = "true"
+            params["supportsAllDrives"] = "true"
+            params["corpora"] = "drive"
+    elif api_key:
+        params["key"] = api_key
+        if drive_id:
+            params["driveId"] = drive_id
+            params["includeItemsFromAllDrives"] = "true"
+            params["supportsAllDrives"] = "true"
+            params["corpora"] = "drive"
+
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            response = client.get(_DRIVE_SEARCH_URL, headers=headers, params=params)
+            if response.status_code == 401:
+                return [{"error": "Google Drive: unauthorized — check credentials", "source": "google_drive"}]
+            if response.status_code == 403:
+                return [{"error": "Google Drive: forbidden — check API key or scopes", "source": "google_drive"}]
+            response.raise_for_status()
+            data = response.json()
+    except httpx.HTTPStatusError as exc:
+        log.warning("google_drive_search: HTTP error for query %r: %s", query, exc)
+        return [{"error": str(exc), "source": "google_drive", "reason": _REASON}]
+    except Exception as exc:
+        log.warning("google_drive_search: unexpected error for query %r: %s", query, exc)
+        return [{"error": str(exc), "source": "google_drive", "reason": _REASON}]
+
+    files = data.get("files") or []
+    results = []
+    for f in files:
+        owners = [o.get("displayName", o.get("emailAddress", "")) for o in (f.get("owners") or [])]
+        results.append(
+            {
+                "title": f.get("name", ""),
+                "url": f.get("webViewLink", ""),
+                "mime_type": f.get("mimeType", ""),
+                "modified": f.get("modifiedTime", ""),
+                "owners": owners,
+                "size": f.get("size"),
+                "drive_id": f.get("id", ""),
+                "source": "google_drive",
+                "reason": _REASON,
+            }
+        )
+    return results

--- a/app/routers/v3/auth.py
+++ b/app/routers/v3/auth.py
@@ -51,6 +51,13 @@ def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(_bearer
     return user
 
 
+def require_admin(user: dict = Depends(get_current_user)) -> dict:
+    """Raise 403 if the authenticated user is not an admin."""
+    if not user.get("is_admin"):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return user
+
+
 @router.post("/login", response_model=TokenResponse)
 def login(body: LoginRequest):
     user = fetch_one("SELECT * FROM ui_users WHERE username = %s AND is_active = true", (body.username,))

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -508,6 +508,10 @@ ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_plan      JSONB;
 ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_status    VARCHAR(32);
 ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_exhausted_at TIMESTAMPTZ;
 ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_stop_reason  TEXT;
+
+-- RBAC: admin flag on ui_users
+ALTER TABLE ui_users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT false;
+UPDATE ui_users SET is_admin = true WHERE username = 'admin';
 """
 
 

--- a/app/routers/v3/models.py
+++ b/app/routers/v3/models.py
@@ -25,6 +25,7 @@ class UserOut(BaseModel):
     username: str
     email: str | None
     is_active: bool
+    is_admin: bool = False
     created_at: datetime
 
 

--- a/app/routers/v3/pipelines.py
+++ b/app/routers/v3/pipelines.py
@@ -9,7 +9,7 @@ import uuid
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel
 
-from app.routers.v3.auth import get_current_user
+from app.routers.v3.auth import get_current_user, require_admin
 from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.tenancy import user_org_id
 from app.routers.v3.models import (
@@ -116,7 +116,7 @@ def get_node_type_enabled(node_type: str, user: dict = Depends(get_current_user)
 def set_node_type_enabled(
     node_type: str,
     body: dict,
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_admin),
 ):
     from app.pipeline.nodes import NodeRegistry
     NodeRegistry.auto_discover()

--- a/app/routers/v3/settings.py
+++ b/app/routers/v3/settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from app.crypto import decrypt_value, encrypt_value
-from app.routers.v3.auth import get_current_user
+from app.routers.v3.auth import get_current_user, require_admin
 from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.models import CoreSettingIn, CoreSettingsOut
 
@@ -19,7 +19,7 @@ def get_core_settings(user: dict = Depends(get_current_user)):
 
 
 @router.put("/core", response_model=CoreSettingsOut)
-def update_core_settings(body: list[CoreSettingIn], user: dict = Depends(get_current_user)):
+def update_core_settings(body: list[CoreSettingIn], user: dict = Depends(require_admin)):
     for item in body:
         stored_value = encrypt_value(item.value) if item.is_secret else item.value
         execute(
@@ -45,7 +45,7 @@ def get_plugin_enabled(plugin_id: str, user: dict = Depends(get_current_user)):
 
 
 @router.put("/plugins/{plugin_id}/enabled", status_code=204)
-def set_plugin_enabled(plugin_id: str, body: dict, user: dict = Depends(get_current_user)):
+def set_plugin_enabled(plugin_id: str, body: dict, user: dict = Depends(require_admin)):
     key = f"plugin.{plugin_id}.enabled"
     execute(
         "INSERT INTO core_settings (key, value, is_secret) VALUES (%s, %s, false) "

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -7,6 +7,7 @@ export interface UserOut {
   username: string
   email: string | null
   is_active: boolean
+  is_admin: boolean
   created_at: string
 }
 

--- a/frontend/src/pages/Research.tsx
+++ b/frontend/src/pages/Research.tsx
@@ -14,7 +14,7 @@ export default function Research() {
     queryKey: ['me'],
     queryFn: async () => {
       const user = await getMe()
-      setUser(user.id, user.username)
+      setUser(user.id, user.username, user.is_admin)
       return user
     },
   })

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { getCoreSettings, updateCoreSettings, getAgentPipeline, setAgentPipeline
 import { listPipelines } from '../api/pipelines'
 import { useForm } from 'react-hook-form'
 import IconRail from '../components/layout/IconRail'
+import { useSessionStore } from '../stores/sessionStore'
 
 const CORE_FIELDS = [
   // LLM Model Tiers
@@ -412,36 +413,45 @@ function NodeHealthSection() {
 
 export default function Settings() {
   const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health'>('core')
+  const isAdmin = useSessionStore(s => s.isAdmin)
 
   return (
     <div className="flex h-screen w-screen overflow-hidden">
       <div className="flex h-full flex-1 overflow-hidden">
         <div className="w-40 flex-shrink-0 col-scroll py-3 px-2" style={{ background: 'var(--panel)', borderRight: '1px solid var(--border)' }}>
-          <div className="text-[10px] font-semibold mb-2 px-1" style={{ color: 'var(--muted)' }}>SYSTEM</div>
-          <button
-            onClick={() => setSection('core')}
-            className="w-full text-left px-2 py-1 rounded text-xs mb-1"
-            style={{
-              background: section === 'core' ? 'var(--panel2)' : 'transparent',
-              color: section === 'core' ? 'var(--accent)' : 'var(--text)',
-              border: 'none', cursor: 'pointer',
-            }}
-          >
-            Core Settings
-          </button>
+          {isAdmin && (
+            <>
+              <div className="text-[10px] font-semibold mb-2 px-1" style={{ color: 'var(--muted)' }}>SYSTEM</div>
+              <button
+                onClick={() => setSection('core')}
+                className="w-full text-left px-2 py-1 rounded text-xs mb-1"
+                style={{
+                  background: section === 'core' ? 'var(--panel2)' : 'transparent',
+                  color: section === 'core' ? 'var(--accent)' : 'var(--text)',
+                  border: 'none', cursor: 'pointer',
+                }}
+              >
+                Core Settings
+              </button>
+            </>
+          )}
 
-          <div className="text-[10px] font-semibold mb-2 mt-3 px-1" style={{ color: 'var(--muted)' }}>PLUGINS</div>
-          <button
-            onClick={() => setSection('plugins')}
-            className="w-full text-left px-2 py-1 rounded text-xs mb-1"
-            style={{
-              background: section === 'plugins' ? 'var(--panel2)' : 'transparent',
-              color: section === 'plugins' ? 'var(--accent)' : 'var(--text)',
-              border: 'none', cursor: 'pointer',
-            }}
-          >
-            General
-          </button>
+          {isAdmin && (
+            <>
+              <div className="text-[10px] font-semibold mb-2 mt-3 px-1" style={{ color: 'var(--muted)' }}>PLUGINS</div>
+              <button
+                onClick={() => setSection('plugins')}
+                className="w-full text-left px-2 py-1 rounded text-xs mb-1"
+                style={{
+                  background: section === 'plugins' ? 'var(--panel2)' : 'transparent',
+                  color: section === 'plugins' ? 'var(--accent)' : 'var(--text)',
+                  border: 'none', cursor: 'pointer',
+                }}
+              >
+                General
+              </button>
+            </>
+          )}
 
           <div className="text-[10px] font-semibold mb-2 mt-3 px-1" style={{ color: 'var(--muted)' }}>AGENT</div>
           <button
@@ -477,8 +487,8 @@ export default function Settings() {
               : section === 'node-health' ? 'Node Health'
               : 'Plugin Settings'}
           </h2>
-          {section === 'core' && <CoreSettingsForm />}
-          {section === 'plugins' && <PluginSettingsForm />}
+          {isAdmin && section === 'core' && <CoreSettingsForm />}
+          {isAdmin && section === 'plugins' && <PluginSettingsForm />}
           {section === 'agent' && <AgentSettingsForm />}
           {section === 'node-health' && <NodeHealthSection />}
         </div>

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -11,8 +11,10 @@ interface SessionState {
     | { type: 'pipeline_run'; runId: string }
     | null
 
+  isAdmin: boolean
   setTokens: (access: string, refresh: string) => void
-  setUser: (id: string, username: string) => void
+  setUser: (id: string, username: string, isAdmin?: boolean) => void
+  setIsAdmin: (isAdmin: boolean) => void
   setActiveJobId: (id: string | null) => void
   setAgentInput: (text: string) => void
   setCol1Content: (content: SessionState['col1Content']) => void
@@ -23,6 +25,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   accessToken: localStorage.getItem('access_token'),
   username: null,
   userId: null,
+  isAdmin: false,
   activeJobId: null,
   agentInput: '',
   col1Content: null,
@@ -33,7 +36,8 @@ export const useSessionStore = create<SessionState>((set) => ({
     set({ accessToken: access })
   },
 
-  setUser: (id, username) => set({ userId: id, username }),
+  setUser: (id, username, isAdmin = false) => set({ userId: id, username, isAdmin }),
+  setIsAdmin: (isAdmin) => set({ isAdmin }),
 
   setActiveJobId: (id) => set({ activeJobId: id }),
 
@@ -44,6 +48,6 @@ export const useSessionStore = create<SessionState>((set) => ({
   logout: () => {
     localStorage.removeItem('access_token')
     localStorage.removeItem('refresh_token')
-    set({ accessToken: null, username: null, userId: null, activeJobId: null, col1Content: null })
+    set({ accessToken: null, username: null, userId: null, activeJobId: null, col1Content: null, isAdmin: false })
   },
 }))

--- a/tests/pipeline/nodes/test_new_datastores.py
+++ b/tests/pipeline/nodes/test_new_datastores.py
@@ -1,0 +1,220 @@
+"""Tests for Shodan, Dropbox, and Google Drive datastore nodes."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from app.pipeline.nodes.base import RunContext
+
+CTX = RunContext(user_id="test", run_id="test", node_id="test")
+
+
+def _arun(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Category / metadata assertions (no I/O)
+# ---------------------------------------------------------------------------
+
+def test_all_nodes_have_correct_category():
+    from app.pipeline.nodes.shodan_search import ShodanSearchNode
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+    from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
+
+    # Shodan was built before these issues; it uses category "enrich"
+    assert ShodanSearchNode.category == "enrich"
+    assert DropboxSearchNode.category == "datastore"
+    assert GoogleDriveSearchNode.category == "datastore"
+
+
+def test_all_nodes_have_node_type():
+    from app.pipeline.nodes.shodan_search import ShodanSearchNode
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+    from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
+
+    assert ShodanSearchNode.node_type == "shodan_search"
+    assert DropboxSearchNode.node_type == "dropbox_search"
+    assert GoogleDriveSearchNode.node_type == "google_drive_search"
+
+
+def test_nodes_have_config_schema():
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+    from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
+
+    for node_cls in (DropboxSearchNode, GoogleDriveSearchNode):
+        schema = node_cls.config_schema
+        assert schema.get("type") == "object"
+        assert "properties" in schema
+
+
+# ---------------------------------------------------------------------------
+# Shodan — no API key returns structured error
+# ---------------------------------------------------------------------------
+
+def test_shodan_returns_error_without_api_key():
+    from app.pipeline.nodes.shodan_search import ShodanSearchNode
+
+    node = ShodanSearchNode()
+    with patch("app.pipeline.nodes.shodan_search._resolve_api_key", return_value=None):
+        result = _arun(node.execute({"query": "test"}, [], CTX))
+    assert len(result) == 1
+    assert "error" in result[0]
+    assert result[0].get("source") == "shodan"
+
+
+# ---------------------------------------------------------------------------
+# Dropbox — missing token / query
+# ---------------------------------------------------------------------------
+
+def test_dropbox_returns_error_without_token():
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+
+    node = DropboxSearchNode()
+    with patch("app.pipeline.nodes.dropbox_search._resolve_token", return_value=None):
+        result = _arun(node.execute({"query": "test"}, [], CTX))
+    assert len(result) == 1
+    assert "error" in result[0]
+    assert result[0].get("source") == "dropbox"
+
+
+def test_dropbox_returns_error_without_query():
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+
+    node = DropboxSearchNode()
+    with patch("app.pipeline.nodes.dropbox_search._resolve_token", return_value="fake-token"):
+        result = _arun(node.execute({}, [], CTX))
+    assert len(result) == 1
+    assert "error" in result[0]
+
+
+def test_dropbox_search_returns_results():
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode, _search_dropbox
+
+    fake_matches = [
+        {
+            "metadata": {
+                "metadata": {
+                    "name": "report.pdf",
+                    "path_display": "/Documents/report.pdf",
+                    ".tag": "file",
+                    "size": 12345,
+                    "client_modified": "2026-01-01T00:00:00Z",
+                }
+            }
+        }
+    ]
+
+    # Test the sync helper directly (avoids executor/httpx complexity)
+    import httpx as _httpx
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {"matches": fake_matches}
+
+    fake_client = MagicMock()
+    fake_client.__enter__ = MagicMock(return_value=fake_client)
+    fake_client.__exit__ = MagicMock(return_value=False)
+    fake_client.post.return_value = fake_response
+
+    with patch("app.pipeline.nodes.dropbox_search.httpx.Client", return_value=fake_client):
+        result = _search_dropbox("tok", "report", "", 10)
+
+    assert len(result) == 1
+    assert result[0]["title"] == "report.pdf"
+    assert result[0]["source"] == "dropbox"
+
+
+# ---------------------------------------------------------------------------
+# Google Drive — missing credentials / query
+# ---------------------------------------------------------------------------
+
+def test_google_drive_returns_error_on_missing_credentials():
+    from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
+
+    node = GoogleDriveSearchNode()
+    with patch("app.pipeline.nodes.google_drive_search._resolve_credentials_path", return_value=None):
+        with patch("app.pipeline.nodes.google_drive_search._resolve_api_key", return_value=None):
+            result = _arun(node.execute({"query": "test"}, [], CTX))
+    assert len(result) == 1
+    assert "error" in result[0]
+    assert result[0].get("source") == "google_drive"
+
+
+def test_google_drive_returns_error_without_query():
+    from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
+
+    node = GoogleDriveSearchNode()
+    with patch("app.pipeline.nodes.google_drive_search._resolve_credentials_path", return_value=None):
+        with patch("app.pipeline.nodes.google_drive_search._resolve_api_key", return_value="fake-key"):
+            result = _arun(node.execute({}, [], CTX))
+    assert len(result) == 1
+    assert "error" in result[0]
+
+
+def test_google_drive_search_returns_results():
+    from app.pipeline.nodes.google_drive_search import _search_drive
+
+    fake_files = [
+        {
+            "id": "abc123",
+            "name": "Q1 Report.xlsx",
+            "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "webViewLink": "https://docs.google.com/file/abc123",
+            "modifiedTime": "2026-03-01T00:00:00Z",
+            "owners": [{"displayName": "Alice"}],
+            "size": "98765",
+        }
+    ]
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {"files": fake_files}
+
+    fake_client = MagicMock()
+    fake_client.__enter__ = MagicMock(return_value=fake_client)
+    fake_client.__exit__ = MagicMock(return_value=False)
+    fake_client.get.return_value = fake_response
+
+    with patch("app.pipeline.nodes.google_drive_search.httpx.Client", return_value=fake_client):
+        result = _search_drive(None, "fake-key", "Q1 Report", 10, "")
+
+    assert len(result) == 1
+    assert result[0]["title"] == "Q1 Report.xlsx"
+    assert result[0]["source"] == "google_drive"
+    assert result[0]["owners"] == ["Alice"]
+
+
+# ---------------------------------------------------------------------------
+# NodeRegistry registration
+# ---------------------------------------------------------------------------
+
+def test_dropbox_and_google_drive_registered():
+    from app.pipeline.nodes import NodeRegistry
+
+    NodeRegistry._nodes = {}
+    NodeRegistry.auto_discover()
+
+    assert "dropbox_search" in NodeRegistry._nodes
+    assert "google_drive_search" in NodeRegistry._nodes
+
+
+# ---------------------------------------------------------------------------
+# Tool schema presence
+# ---------------------------------------------------------------------------
+
+def test_dropbox_has_tool_schema():
+    from app.pipeline.nodes.dropbox_search import DropboxSearchNode
+
+    schema = DropboxSearchNode().tool_schema()
+    assert schema["name"] == "search_dropbox"
+    assert "query" in schema["input_schema"]["properties"]
+
+
+def test_google_drive_has_tool_schema():
+    from app.pipeline.nodes.google_drive_search import GoogleDriveSearchNode
+
+    schema = GoogleDriveSearchNode().tool_schema()
+    assert schema["name"] == "search_google_drive"
+    assert "query" in schema["input_schema"]["properties"]

--- a/tests/v3/test_rbac.py
+++ b/tests/v3/test_rbac.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.v3.auth import require_admin
+
+
+def test_require_admin_raises_403_for_non_admin():
+    non_admin_user = {"id": "u1", "username": "testuser", "is_admin": False}
+    with pytest.raises(HTTPException) as exc:
+        require_admin(non_admin_user)
+    assert exc.value.status_code == 403
+
+
+def test_require_admin_passes_for_admin():
+    admin_user = {"id": "u1", "username": "admin", "is_admin": True}
+    result = require_admin(admin_user)
+    assert result["is_admin"] is True
+
+
+def test_require_admin_raises_403_when_field_missing():
+    user_without_field = {"id": "u1", "username": "testuser"}
+    with pytest.raises(HTTPException) as exc:
+        require_admin(user_without_field)
+    assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary

- `is_admin BOOLEAN NOT NULL DEFAULT false` added to `ui_users`; `admin` username backfilled to `true` via idempotent migration in `db.py`
- `require_admin()` FastAPI dependency in `auth.py` — raises HTTP 403 for non-admin callers
- Write routes gated: `PUT /v3/settings/core`, `PUT /v3/settings/plugins/{id}/enabled`, `PUT /v3/pipelines/nodes/types/{node_type}/enabled`
- `UserOut` model exposes `is_admin` so `/v3/users/me` returns the flag
- Frontend: `isAdmin` in `sessionStore`; populated from `/v3/users/me` on app load; Settings page hides Core Settings and Plugin sections for non-admin users

## Test plan

- [ ] `tests/v3/test_rbac.py` — 3 unit tests (non-admin raises 403, admin passes, missing field raises 403): all pass
- [ ] Log in as `admin` → Settings shows Core Settings and Plugins nav items
- [ ] Log in as a non-admin user → Settings shows only Agent and Node Health sections
- [ ] `PUT /v3/settings/core` with non-admin token → 403
- [ ] `PUT /v3/pipelines/nodes/types/{node_type}/enabled` with non-admin token → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)