### PR TITLE
feat(metrics): performance summary + run history endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -330,6 +330,7 @@ from app.routers.v3.curation_api import router as v3_curation_router  # noqa: E4
 from app.routers.v3.brain_questions import router as v3_brain_questions_router  # noqa: E402
 from app.routers.v3.sources_api import router as v3_sources_router  # noqa: E402
 from app.routers.v3.sessions_api import router as v3_sessions_router  # noqa: E402
+from app.routers.v3.metrics import router as v3_metrics_router  # noqa: E402
 app.include_router(v3_auth_router)
 app.include_router(v3_users_router)
 app.include_router(v3_plugins_router)
@@ -349,3 +350,4 @@ app.include_router(v3_curation_router)
 app.include_router(v3_brain_questions_router)
 app.include_router(v3_sources_router)
 app.include_router(v3_sessions_router)
+app.include_router(v3_metrics_router, prefix="/api/v3")

--- a/app/routers/v3/metrics.py
+++ b/app/routers/v3/metrics.py
@@ -1,0 +1,117 @@
+"""Metrics and performance summary endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.routers.v3.auth import get_current_user
+from app.routers.v3.db import fetch_all, fetch_one
+from app.routers.v3.tenancy import user_org_id
+
+router = APIRouter(prefix="/metrics", tags=["metrics"])
+
+
+@router.get("/summary")
+def get_metrics_summary(
+    days: int = 30,
+    user: dict = Depends(get_current_user),
+) -> dict:
+    """Return performance metrics for the last N days."""
+    org = user_org_id(user)
+    uid = str(user["id"])
+
+    # Run stats — total, succeeded, failed, budget_exhausted
+    run_stats = fetch_one(
+        """SELECT
+             COUNT(*) as total_runs,
+             COUNT(*) FILTER (WHERE status = 'succeeded') as succeeded,
+             COUNT(*) FILTER (WHERE status = 'failed') as failed,
+             COUNT(*) FILTER (WHERE status = 'budget_exhausted') as budget_exhausted,
+             AVG(EXTRACT(EPOCH FROM (finished_at - started_at)))
+               FILTER (WHERE status = 'succeeded' AND finished_at IS NOT NULL) as avg_latency_seconds,
+             PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (finished_at - started_at)))
+               FILTER (WHERE status = 'succeeded' AND finished_at IS NOT NULL) as p50_latency_seconds,
+             PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (finished_at - started_at)))
+               FILTER (WHERE status = 'succeeded' AND finished_at IS NOT NULL) as p95_latency_seconds
+           FROM pipeline_runs
+           WHERE user_id = %s AND org_id = %s
+             AND started_at > NOW() - (%s * INTERVAL '1 day')""",
+        (uid, org, days),
+    ) or {}
+
+    # Step stats — per node_type success/fail rates
+    step_stats = fetch_all(
+        """SELECT
+             pn.node_type,
+             COUNT(*) as total,
+             COUNT(*) FILTER (WHERE psr.status = 'succeeded') as succeeded,
+             AVG(psr.item_count) FILTER (WHERE psr.status = 'succeeded') as avg_items
+           FROM pipeline_step_runs psr
+           JOIN pipeline_nodes pn ON psr.node_id = pn.id
+           JOIN pipeline_runs pr ON psr.run_id = pr.id
+           WHERE pr.user_id = %s AND pr.org_id = %s
+             AND pr.started_at > NOW() - (%s * INTERVAL '1 day')
+           GROUP BY pn.node_type
+           ORDER BY total DESC
+           LIMIT 20""",
+        (uid, org, days),
+    )
+
+    # Strategy usage from research_trails scorecard
+    strategy_stats = fetch_all(
+        """SELECT
+             scorecard->>'strategy' as strategy,
+             COUNT(*) as uses,
+             AVG((scorecard->>'score')::float) FILTER (WHERE scorecard->>'score' ~ '^[0-9.]+$') as avg_score
+           FROM research_trails
+           WHERE user_id = %s AND org_id = %s
+             AND created_at > NOW() - (%s * INTERVAL '1 day')
+             AND scorecard IS NOT NULL AND scorecard->>'strategy' IS NOT NULL
+           GROUP BY scorecard->>'strategy'
+           ORDER BY uses DESC
+           LIMIT 10""",
+        (uid, org, days),
+    )
+
+    return {
+        "period_days": days,
+        "runs": {
+            "total": run_stats.get("total_runs") or 0,
+            "succeeded": run_stats.get("succeeded") or 0,
+            "failed": run_stats.get("failed") or 0,
+            "budget_exhausted": run_stats.get("budget_exhausted") or 0,
+            "success_rate": round(
+                (run_stats.get("succeeded") or 0)
+                / max((run_stats.get("total_runs") or 1), 1)
+                * 100,
+                1,
+            ),
+        },
+        "latency": {
+            "avg_seconds": round(float(run_stats.get("avg_latency_seconds") or 0), 1),
+            "p50_seconds": round(float(run_stats.get("p50_latency_seconds") or 0), 1),
+            "p95_seconds": round(float(run_stats.get("p95_latency_seconds") or 0), 1),
+        },
+        "steps": [dict(r) for r in step_stats],
+        "strategies": [dict(r) for r in strategy_stats],
+    }
+
+
+@router.get("/runs")
+def get_run_history(
+    limit: int = 50,
+    user: dict = Depends(get_current_user),
+) -> list[dict]:
+    """Return recent run history with latency and status."""
+    rows = fetch_all(
+        """SELECT id, status, trigger_type, query,
+             started_at, finished_at,
+             EXTRACT(EPOCH FROM (finished_at - started_at)) as duration_seconds,
+             error_message
+           FROM pipeline_runs
+           WHERE user_id = %s AND org_id = %s
+             AND started_at IS NOT NULL
+           ORDER BY started_at DESC
+           LIMIT %s""",
+        (str(user["id"]), user_org_id(user), limit),
+    )
+    return [dict(r) for r in rows]

--- a/tests/v3/test_metrics.py
+++ b/tests/v3/test_metrics.py
@@ -1,0 +1,173 @@
+"""Tests for GET /api/v3/metrics/summary and /api/v3/metrics/runs.
+
+These tests use dependency_overrides + fetch patches so they run without Postgres.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy optional deps before any app import
+sys.modules.setdefault("qdrant_client", MagicMock())
+sys.modules.setdefault("qdrant_client.models", MagicMock())
+os.environ.setdefault("INFO_BROKER_API_KEY", "test-secret-key")
+os.environ.setdefault("POSTGRES_DB", "info_broker")
+os.environ.setdefault("POSTGRES_USER", "user")
+os.environ.setdefault("POSTGRES_PASSWORD", "password")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.main import app  # noqa: E402
+from app.routers.v3.auth import get_current_user  # noqa: E402
+
+_USER = {"id": "u1", "org_id": "org-1"}
+
+_RUN_STATS = {
+    "total_runs": 10,
+    "succeeded": 8,
+    "failed": 2,
+    "budget_exhausted": 0,
+    "avg_latency_seconds": 45.2,
+    "p50_latency_seconds": 38.0,
+    "p95_latency_seconds": 120.5,
+}
+
+
+def _override_user():
+    return _USER
+
+
+# ---------------------------------------------------------------------------
+# Summary endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_summary_returns_correct_shape():
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_one", return_value=_RUN_STATS), \
+             patch("app.routers.v3.metrics.fetch_all", return_value=[]):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "runs" in data
+        assert "latency" in data
+        assert "steps" in data
+        assert "strategies" in data
+        assert data["runs"]["total"] == 10
+        assert data["runs"]["succeeded"] == 8
+        assert data["runs"]["failed"] == 2
+        assert data["runs"]["success_rate"] == 80.0
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_summary_latency_shape():
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_one", return_value=_RUN_STATS), \
+             patch("app.routers.v3.metrics.fetch_all", return_value=[]):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/summary")
+        assert resp.status_code == 200
+        latency = resp.json()["latency"]
+        assert latency["avg_seconds"] == 45.2
+        assert latency["p50_seconds"] == 38.0
+        assert latency["p95_seconds"] == 120.5
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_summary_handles_no_data():
+    """When there are no runs, all numeric fields default to 0 and success_rate is 0."""
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_one", return_value=None), \
+             patch("app.routers.v3.metrics.fetch_all", return_value=[]):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["runs"]["total"] == 0
+        assert data["runs"]["success_rate"] == 0.0
+        assert data["latency"]["avg_seconds"] == 0.0
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_summary_custom_days_param():
+    partial_stats = dict(_RUN_STATS)
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_one", return_value=partial_stats), \
+             patch("app.routers.v3.metrics.fetch_all", return_value=[]):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/summary?days=7")
+        assert resp.status_code == 200
+        assert resp.json()["period_days"] == 7
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_summary_budget_exhausted_field():
+    stats = dict(_RUN_STATS, budget_exhausted=3)
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_one", return_value=stats), \
+             patch("app.routers.v3.metrics.fetch_all", return_value=[]):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/summary")
+        assert resp.status_code == 200
+        assert resp.json()["runs"]["budget_exhausted"] == 3
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Run history endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_run_history_returns_empty_list():
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_all", return_value=[]):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/runs")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_run_history_returns_rows():
+    _rows = [
+        {
+            "id": "run-1",
+            "status": "succeeded",
+            "trigger_type": "agent_is",
+            "query": "test query",
+            "started_at": "2026-05-01T10:00:00",
+            "finished_at": "2026-05-01T10:01:00",
+            "duration_seconds": 60.0,
+            "error_message": None,
+        }
+    ]
+    app.dependency_overrides[get_current_user] = _override_user
+    try:
+        with patch("app.routers.v3.metrics.fetch_all", return_value=_rows):
+            client = TestClient(app)
+            resp = client.get("/api/v3/metrics/runs")
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "succeeded"
+        assert rows[0]["duration_seconds"] == 60.0
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)


### PR DESCRIPTION
## Summary

- New `GET /api/v3/metrics/summary` endpoint returning run counts (total/succeeded/failed/budget_exhausted), latency percentiles (avg/p50/p95), step success rates per `node_type`, and strategy usage from `research_trails.scorecard`
- New `GET /api/v3/metrics/runs` endpoint returning recent run history with duration and status
- Both endpoints are org+user scoped and accept a `days` (default 30) / `limit` (default 50) query param
- 7 unit tests; run without Postgres via `dependency_overrides` + `fetch_one`/`fetch_all` patches

## Test plan

- [x] `pytest tests/v3/test_metrics.py` — 7/7 pass locally without Postgres
- [ ] QA: hit `/api/v3/metrics/summary` with a live token and verify `runs.total` matches actual DB row count
- [ ] QA: hit `/api/v3/metrics/runs` and confirm rows are ordered by `started_at DESC`

Generated with [Claude Code](https://claude.com/claude-code)