### PR TITLE
feat(admin): user management page

### DIFF
--- a/app/routers/v3/auth.py
+++ b/app/routers/v3/auth.py
@@ -9,7 +9,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
-from app.routers.v3.db import execute, fetch_one
+from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.models import LoginRequest, RefreshRequest, TokenResponse
 
 router = APIRouter(prefix="/v3/auth", tags=["v3-auth"])
@@ -83,3 +83,42 @@ def refresh(body: RefreshRequest):
         access_token=_make_access_token(user_id),
         refresh_token=_make_refresh_token(user_id),
     )
+
+
+
+
+@router.get("/users", dependencies=[Depends(require_admin)])
+def list_users(current_user: dict = Depends(get_current_user)) -> list[dict]:
+    """List all users. Admin only."""
+    rows = fetch_all(
+        """SELECT id, username, email, is_admin, is_active, org_id, created_at
+           FROM ui_users
+           ORDER BY created_at DESC""",
+        (),
+    )
+    return [dict(r) for r in rows]
+
+
+@router.patch("/users/{user_id}", dependencies=[Depends(require_admin)])
+def update_user(
+    user_id: str,
+    body: dict,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """Update user is_admin or is_active. Admin only."""
+    if str(user_id) == str(current_user["id"]) and body.get("is_admin") is False:
+        raise HTTPException(status_code=400, detail="Cannot remove your own admin status")
+
+    allowed = {k: v for k, v in body.items() if k in ("is_admin", "is_active")}
+    if not allowed:
+        raise HTTPException(status_code=422, detail="Only is_admin and is_active are patchable")
+
+    set_clause = ", ".join(f"{k} = %s" for k in allowed)
+    values = list(allowed.values()) + [user_id]
+    row = fetch_one(
+        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING id, username, is_admin, is_active",
+        tuple(values),
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="User not found")
+    return dict(row)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import AuthGuard from './components/AuthGuard'
+import AuthGuard from '.[REDACTED:high-entropy-base64:21ch:hash=8bcbde38]'
 import Login from './pages/Login'
 import { useLayoutStore } from './stores/layoutStore'
 import { applyTheme } from './lib/theme'
@@ -19,6 +19,7 @@ const PipelinePage   = lazy(() => import('./pages/PipelinePage'))
 const LiveProcessesPage = lazy(() => import('./pages/LiveProcessesPage'))
 const KnowledgeGraphPage = lazy(() => import('./pages/KnowledgeGraphPage'))
 const PerformanceDashboardPage = lazy(() => import('./pages/PerformanceDashboardPage'))
+const AdminUsersPage = lazy(() => import('./pages/AdminUsersPage'))
 
 const qc = new QueryClient({
   defaultOptions: { queries: { retry: 1, staleTime: 30_000 } },
@@ -57,6 +58,7 @@ export default function App() {
             <Route path="/settings" element={<AuthGuard><Settings /></AuthGuard>} />
             <Route path="/settings/plugins/:name" element={<AuthGuard><Settings /></AuthGuard>} />
             <Route path="/admin/processes" element={<AuthGuard><LiveProcessesPage /></AuthGuard>} />
+            <Route path="/admin/users" element={<AuthGuard><AdminUsersPage /></AuthGuard>} />
             <Route path="/knowledge" element={<AuthGuard><KnowledgeGraphPage /></AuthGuard>} />
             <Route path="/performance" element={<AuthGuard><PerformanceDashboardPage /></AuthGuard>} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -422,3 +422,24 @@ export const getMetricsSummary = (days = 30): Promise<MetricsSummary> =>
 
 export const getRunHistory = (limit = 50): Promise<RunHistoryItem[]> =>
   api.get(`/v3/metrics/runs?limit=${limit}`).then(r => r.data)
+
+// --- Admin: User Management ---
+
+export interface UserRecord {
+  id: string
+  username: string
+  email: string | null
+  is_admin: boolean
+  is_active: boolean
+  org_id: string
+  created_at: string
+}
+
+export const listUsers = (): Promise<UserRecord[]> =>
+  api.get('/v3/auth/users').then(r => r.data)
+
+export const patchUser = (
+  userId: string,
+  body: Partial<Pick<UserRecord, 'is_admin' | 'is_active'>>,
+): Promise<UserRecord> =>
+  api.patch(`/v3/auth/users/${userId}`, body).then(r => r.data)

--- a/frontend/src/components/layout/IconRail.tsx
+++ b/frontend/src/components/layout/IconRail.tsx
@@ -17,11 +17,15 @@ const NAV = [
   { icon: '⚙', path: '/settings',  label: 'Settings' },
 ]
 
+const NAV_ADMIN = [
+  { icon: '◫', path: '/admin/users', label: 'User Management' },
+]
+
 export default function IconRail() {
   const navigate  = useNavigate()
   const location  = useLocation()
   const { theme, toggle } = useTheme()
-  const { logout, username } = useSessionStore()
+  const { logout, username, isAdmin } = useSessionStore()
 
   const { data: pluginRequests } = useQuery({
     queryKey: ['plugin-requests'],
@@ -29,6 +33,8 @@ export default function IconRail() {
     refetchInterval: 30000,
   })
   const pendingCount = pluginRequests?.filter(r => r.status === 'pending').length ?? 0
+
+  const allNav = isAdmin ? [...NAV, ...NAV_ADMIN] : NAV
 
   return (
     <div
@@ -42,7 +48,7 @@ export default function IconRail() {
       <span style={{ color: 'var(--accent)', fontSize: 14 }}>✦</span>
 
       <div className="flex-1 flex flex-col items-center gap-3 mt-2">
-        {NAV.map(({ icon, path, label }) => {
+        {allNav.map(({ icon, path, label }) => {
           const active = location.pathname === path
           const hasBadge = path === '/plugins' && pendingCount > 0
           return (

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,196 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { listUsers, patchUser, UserRecord } from '../api/v3'
+import IconRail from '../components/layout/IconRail'
+import { useSessionStore } from '../stores/sessionStore'
+
+function Toggle({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean
+  onChange: (v: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => !disabled && onChange(!checked)}
+      style={{
+        width: 34,
+        height: 18,
+        borderRadius: 9,
+        background: checked ? 'var(--accent)' : 'var(--border)',
+        border: 'none',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        position: 'relative',
+        opacity: disabled ? 0.5 : 1,
+        flexShrink: 0,
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          top: 2,
+          left: checked ? 18 : 2,
+          width: 14,
+          height: 14,
+          borderRadius: '50%',
+          background: 'var(--bg)',
+          transition: 'left 0.15s',
+        }}
+      />
+    </button>
+  )
+}
+
+export default function AdminUsersPage() {
+  const qc = useQueryClient()
+  const { userId } = useSessionStore()
+
+  const { data: users = [], isLoading, error } = useQuery<UserRecord[]>({
+    queryKey: ['admin-users'],
+    queryFn: listUsers,
+  })
+
+  const patch = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: Partial<Pick<UserRecord, 'is_admin' | 'is_active'>> }) =>
+      patchUser(id, body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-users'] }),
+  })
+
+  const adminCount = users.filter(u => u.is_admin).length
+  const totalCount = users.length
+
+  return (
+    <div
+      className="flex"
+      style={{ height: '100vh', background: 'var(--bg)', color: 'var(--text)' }}
+    >
+      <IconRail />
+
+      <div className="flex flex-col flex-1 overflow-hidden">
+        {/* Header */}
+        <div
+          className="flex items-center gap-4 px-6 py-4 flex-shrink-0"
+          style={{ borderBottom: '1px solid var(--border)', background: 'var(--panel)' }}
+        >
+          <span style={{ color: 'var(--accent)', fontSize: 16 }}>◫</span>
+          <div>
+            <h1 style={{ fontSize: 14, fontWeight: 600, color: 'var(--text)', margin: 0 }}>
+              User Management
+            </h1>
+            <p style={{ fontSize: 11, color: 'var(--subtext)', margin: 0 }}>
+              {totalCount} {totalCount === 1 ? 'user' : 'users'} — {adminCount} admin{adminCount !== 1 ? 's' : ''}
+            </p>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-auto p-6">
+          {isLoading && (
+            <p style={{ color: 'var(--muted)', fontSize: 12 }}>Loading users…</p>
+          )}
+
+          {error && (
+            <p style={{ color: '#f87171', fontSize: 12 }}>
+              Failed to load users. Are you an admin?
+            </p>
+          )}
+
+          {!isLoading && !error && users.length === 0 && (
+            <p style={{ color: 'var(--muted)', fontSize: 12 }}>No users found.</p>
+          )}
+
+          {!isLoading && !error && users.length > 0 && (
+            <div style={{ overflowX: 'auto' }}>
+              <table
+                style={{
+                  width: '100%',
+                  borderCollapse: 'collapse',
+                  fontSize: 12,
+                }}
+              >
+                <thead>
+                  <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                    {['Username', 'Email', 'Org', 'Admin', 'Active', 'Created'].map(h => (
+                      <th
+                        key={h}
+                        style={{
+                          padding: '6px 12px',
+                          textAlign: 'left',
+                          color: 'var(--subtext)',
+                          fontWeight: 500,
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {users.map(user => {
+                    const isSelf = user.id === userId
+                    return (
+                      <tr
+                        key={user.id}
+                        style={{
+                          borderBottom: '1px solid var(--border)',
+                          background: isSelf ? 'var(--panel2)' : 'transparent',
+                        }}
+                      >
+                        <td style={{ padding: '8px 12px', color: 'var(--text)', fontWeight: isSelf ? 600 : 400 }}>
+                          {user.username}
+                          {isSelf && (
+                            <span
+                              style={{
+                                marginLeft: 6,
+                                fontSize: 10,
+                                color: 'var(--accent)',
+                                background: 'var(--panel)',
+                                padding: '1px 5px',
+                                borderRadius: 3,
+                              }}
+                            >
+                              you
+                            </span>
+                          )}
+                        </td>
+                        <td style={{ padding: '8px 12px', color: 'var(--subtext)' }}>
+                          {user.email ?? '—'}
+                        </td>
+                        <td style={{ padding: '8px 12px', color: 'var(--subtext)', fontFamily: 'monospace', fontSize: 11 }}>
+                          {user.org_id ? user.org_id.slice(0, 8) + '…' : '—'}
+                        </td>
+                        <td style={{ padding: '8px 12px' }}>
+                          <Toggle
+                            checked={user.is_admin}
+                            disabled={isSelf}
+                            onChange={v => patch.mutate({ id: user.id, body: { is_admin: v } })}
+                          />
+                        </td>
+                        <td style={{ padding: '8px 12px' }}>
+                          <Toggle
+                            checked={user.is_active}
+                            disabled={isSelf}
+                            onChange={v => patch.mutate({ id: user.id, body: { is_active: v } })}
+                          />
+                        </td>
+                        <td style={{ padding: '8px 12px', color: 'var(--muted)', fontSize: 11, whiteSpace: 'nowrap' }}>
+                          {new Date(user.created_at).toLocaleDateString()}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/v3/test_user_management.py
+++ b/tests/v3/test_user_management.py
@@ -1,0 +1,50 @@
+"""Tests for admin user management endpoints (no Postgres required)."""
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers.v3.auth import get_current_user, require_admin
+
+
+def _admin():
+    return {"id": "admin-1", "is_admin": True, "is_active": True}
+
+
+def _non_admin():
+    return {"id": "user-1", "is_admin": False, "is_active": True}
+
+
+def test_list_users_requires_admin():
+    """Non-admin should get 403 when listing users."""
+    from fastapi import HTTPException
+
+    def raise_403():
+        raise HTTPException(status_code=403, detail="Admin required")
+
+    app.dependency_overrides[get_current_user] = _non_admin
+    app.dependency_overrides[require_admin] = raise_403
+    try:
+        client = TestClient(app)
+        resp = client.get("/v3/auth/users")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(require_admin, None)
+
+
+def test_cannot_self_demote():
+    """Admin cannot remove their own admin status."""
+    from unittest.mock import patch
+
+    app.dependency_overrides[get_current_user] = _admin
+    app.dependency_overrides[require_admin] = _admin
+    user_id = "admin-1"
+    url = "/v3/auth/users/" + user_id
+    try:
+        with patch("app.routers.v3.auth.fetch_one", return_value=None):
+            client = TestClient(app)
+            resp = client.patch(url, json={"is_admin": False})
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(require_admin, None)


### PR DESCRIPTION
Allows admins to view all users and toggle is_admin / is_active.

## Summary
- `GET /v3/auth/users` + `PATCH /v3/auth/users/{id}` — admin-only, self-demotion blocked with 400
- `AdminUsersPage.tsx` — table listing all users with inline toggles; own row is disabled
- `IconRail` — User Management nav item (◫) conditionally shown for admin users only
- `v3.ts` — `UserRecord` type + `listUsers` / `patchUser` API functions
- 2 tests using `dependency_overrides` (no Postgres required)

## Test plan
- [ ] `pytest tests/v3/test_user_management.py` — 2 passed
- [ ] As admin: navigate to /admin/users, verify table loads, toggle another user's is_admin
- [ ] Verify own row toggles are disabled
- [ ] As non-admin: verify nav item is not visible and direct URL returns 403