### PR TITLE
feat(temporal): Phase 1 — IS workflow activities + route handler

### DIFF
--- a/app/routers/v3/agent.py
+++ b/app/routers/v3/agent.py
@@ -1157,34 +1157,41 @@ async def send_message(
             )
 
         # Fire and forget — research runs async, pushes WS events when done.
-        # Phase 0: Feature flag scaffolding. Phase 1 will activate this branch.
-        # if IS_USE_TEMPORAL:
-        #     from app.temporal.workflows.is_run import ISRunWorkflow, ISRunInput
-        #     from temporalio.client import Client
-        #     _host = _os.getenv("TEMPORAL_HOST", "localhost")
-        #     _port = int(_os.getenv("TEMPORAL_PORT", "7233"))
-        #     _client = await Client.connect(f"{_host}:{_port}")
-        #     await _client.start_workflow(
-        #         ISRunWorkflow.run,
-        #         ISRunInput(
-        #             run_id=run_id, user_id=uid, org_id=org_id, query=body.message,
-        #             pipeline_id=pipeline_id, session_id=sid,
-        #         ),
-        #         id=f"is-run-{run_id}",
-        #         task_queue="is-run-tasks",
-        #     )
-        # else:
-        #     asyncio.create_task(_run_is_research(...))  # current path
-        task = asyncio.create_task(
-            _run_is_research(
-                run_id, uid, pipeline_id, body.message,
-                past_research=past_research,
-                session_id=sid,
-                session_context=session_context,
-                preflight_result=preflight_result,
+        if IS_USE_TEMPORAL:
+            from app.temporal.workflows.is_run import ISRunWorkflow, ISRunInput
+            from temporalio.client import Client
+            _host = _os.getenv("TEMPORAL_HOST", "localhost")
+            _port = int(_os.getenv("TEMPORAL_PORT", "7233"))
+            _t_client = await Client.connect(f"{_host}:{_port}")
+            await _t_client.start_workflow(
+                ISRunWorkflow.run,
+                ISRunInput(
+                    run_id=run_id,
+                    user_id=uid,
+                    org_id=user_org_id(user),
+                    query=body.message,
+                    pipeline_id=pipeline_id,
+                    session_id=sid,
+                    session_context=session_context,
+                    past_research=past_research or [],
+                    budget=_raw_budget,
+                    callback_url=getattr(body, "callback_url", None),
+                    preflight_prior_slots=dict(_SESSION_SLOTS.get(sid or "", {}) or {}),
+                ),
+                id=f"is-run-{run_id}",
+                task_queue="is-run-tasks",
             )
-        )  # current path (Phase 0)
-        task.add_done_callback(lambda t: log.error("IS research task failed: %s", t.exception()) if t.exception() else None)
+        else:
+            task = asyncio.create_task(
+                _run_is_research(
+                    run_id, uid, pipeline_id, body.message,
+                    past_research=past_research,
+                    session_id=sid,
+                    session_context=session_context,
+                    preflight_result=preflight_result,
+                )
+            )
+            task.add_done_callback(lambda t: log.error("IS research task failed: %s", t.exception()) if t.exception() else None)
 
         return AgentMessageOut(job_id=run_id, session_id=sid, status="pending", mode="investigation")
 

--- a/app/temporal/activities/__init__.py
+++ b/app/temporal/activities/__init__.py
@@ -1,0 +1,11 @@
+from app.temporal.activities.brain import run_is_brain, RunISBrainInput, BrainResult
+from app.temporal.activities.budget import reserve_budget, release_budget_and_mark_failed, ReserveBudgetInput, AbortInput, ReservationResult
+from app.temporal.activities.post_process import post_process, PostProcessInput
+from app.temporal.activities.preflight import preflight_validation, mark_awaiting_input, PreflightInput, PreflightResult, MarkAwaitingInput
+
+__all__ = [
+    "run_is_brain", "RunISBrainInput", "BrainResult",
+    "reserve_budget", "release_budget_and_mark_failed", "ReserveBudgetInput", "AbortInput", "ReservationResult",
+    "post_process", "PostProcessInput",
+    "preflight_validation", "mark_awaiting_input", "PreflightInput", "PreflightResult", "MarkAwaitingInput",
+]

--- a/app/temporal/activities/brain.py
+++ b/app/temporal/activities/brain.py
@@ -1,0 +1,89 @@
+"""IS brain activity — wraps run_research() with heartbeating."""
+from __future__ import annotations
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from temporalio import activity
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class RunISBrainInput:
+    run_id: str
+    user_id: str
+    query: str
+    session_id: str | None
+    session_context: str
+    past_research: list[dict] | None = field(default_factory=list)
+    preflight_tier: int = 1
+    preflight_disclaimer: str | None = None
+    preflight_question: str | None = None
+
+
+@dataclass
+class BrainResult:
+    findings: list[dict] = field(default_factory=list)
+    summary: str = ""
+    raw: dict = field(default_factory=dict)
+
+
+@activity.defn(name="run_is_brain")
+async def run_is_brain(inp: RunISBrainInput) -> BrainResult:
+    """Run the IS brain subprocess. Heartbeats every 30s."""
+    from app.is_brain import run_research
+    from app.routers.v3.db import execute, fetch_one
+    from app.routers.v3.stream import push_event
+
+    execute(
+        "UPDATE pipeline_runs SET status = 'running' WHERE id = %s",
+        (inp.run_id,),
+    )
+    await push_event(inp.user_id, {
+        "type": "job.update", "job_id": inp.run_id, "status": "running",
+        "run_id": inp.run_id, "message": inp.query,
+    })
+
+    # Heartbeat task — keeps Temporal informed every 30s
+    heartbeat_task = asyncio.create_task(_heartbeat_loop())
+
+    async def _on_event(ev: dict) -> None:
+        try:
+            await push_event(inp.user_id, {**ev, "job_id": inp.run_id, "run_id": inp.run_id})
+        except Exception:
+            pass
+
+    try:
+        # Fetch pipeline run info for depth/branch params
+        row = fetch_one(
+            "SELECT max_depth, max_branches FROM pipeline_runs WHERE id = %s",
+            (inp.run_id,),
+        ) or {}
+        result = await run_research(
+            query=inp.query,
+            user_id=inp.user_id,
+            past_research=inp.past_research or [],
+            max_depth=row.get("max_depth") or 3,
+            max_branches=row.get("max_branches") or 10,
+            on_event=_on_event,
+            session_context=inp.session_context,
+        )
+        return BrainResult(
+            findings=result.get("findings", []),
+            summary=result.get("summary", ""),
+            raw=result,
+        )
+    except Exception as exc:
+        log.error("run_is_brain failed: %s", exc)
+        raise
+    finally:
+        heartbeat_task.cancel()
+
+
+async def _heartbeat_loop() -> None:
+    while True:
+        await asyncio.sleep(30)
+        try:
+            activity.heartbeat("IS brain running")
+        except Exception:
+            break

--- a/app/temporal/activities/budget.py
+++ b/app/temporal/activities/budget.py
@@ -1,0 +1,82 @@
+"""Budget reservation/release activities."""
+from __future__ import annotations
+import logging
+from dataclasses import dataclass
+from temporalio import activity
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ReserveBudgetInput:
+    run_id: str
+    user_id: str
+    org_id: str
+    budget: dict  # raw RunBudgetIn payload
+
+
+@dataclass
+class ReservationResult:
+    ok: bool
+    reason: str = ""
+
+
+@dataclass
+class AbortInput:
+    run_id: str
+    user_id: str
+    org_id: str
+    reason: str
+    callback_url: str | None = None
+
+
+@activity.defn(name="reserve_budget")
+async def reserve_budget(inp: ReserveBudgetInput) -> ReservationResult:
+    """Reserve budget. Idempotent — short-circuits if already reserved."""
+    from app.routers.v3.db import fetch_one
+    # Idempotency check
+    row = fetch_one(
+        "SELECT budget_status FROM pipeline_runs WHERE id = %s",
+        (inp.run_id,),
+    )
+    if row and row.get("budget_status") == "reserved":
+        return ReservationResult(ok=True, reason="already_reserved")
+    try:
+        from app.pipeline.budget import RunBudgetIn, estimate_run_cost
+        from app.pipeline.budget import reserve_budget as _reserve
+        budget_in = RunBudgetIn(**inp.budget) if inp.budget else RunBudgetIn()
+        estimated = estimate_run_cost(budget_in)
+        ok = _reserve(inp.user_id, inp.org_id, estimated)
+        return ReservationResult(ok=ok, reason="" if ok else "insufficient_balance")
+    except Exception as exc:
+        log.warning("reserve_budget failed (non-fatal): %s", exc)
+        return ReservationResult(ok=True, reason="wallet_error_allow")
+
+
+@activity.defn(name="release_budget_and_mark_failed")
+async def release_budget_and_mark_failed(inp: AbortInput) -> None:
+    """Release budget reservation and mark run as failed. Idempotent."""
+    from app.routers.v3.db import execute, fetch_one
+    row = fetch_one("SELECT status FROM pipeline_runs WHERE id = %s", (inp.run_id,))
+    if row and row.get("status") in ("succeeded", "failed", "cancelled"):
+        return  # Already terminal
+    execute(
+        """UPDATE pipeline_runs SET status = 'failed', finished_at = now(),
+           error_message = %s, budget_status = 'released' WHERE id = %s""",
+        (inp.reason, inp.run_id),
+    )
+    try:
+        from app.pipeline.budget import release_budget as _release
+        _release(inp.user_id, inp.run_id, 0, 0)
+    except Exception:
+        pass
+    if inp.callback_url:
+        try:
+            from app.services.webhook import deliver_webhook
+            import asyncio
+            asyncio.create_task(deliver_webhook(
+                inp.run_id, {"run_id": inp.run_id, "status": "failed", "reason": inp.reason},
+                inp.callback_url,
+            ))
+        except Exception:
+            pass

--- a/app/temporal/activities/post_process.py
+++ b/app/temporal/activities/post_process.py
@@ -1,0 +1,86 @@
+"""Post-processing activity — scorecard, KG, session, webhook."""
+from __future__ import annotations
+import logging
+from dataclasses import dataclass, field
+from temporalio import activity
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PostProcessInput:
+    run_id: str
+    user_id: str
+    session_id: str | None
+    brain_result: dict
+    callback_url: str | None = None
+
+
+@activity.defn(name="post_process")
+async def post_process(inp: PostProcessInput) -> None:
+    """Run post-processing. Idempotent — skips if run already succeeded."""
+    from app.routers.v3.db import execute, fetch_one
+    from app.routers.v3.stream import push_event
+    import asyncio
+
+    # Idempotency check
+    row = fetch_one("SELECT status FROM pipeline_runs WHERE id = %s", (inp.run_id,))
+    if row and row.get("status") == "succeeded":
+        return
+
+    result = inp.brain_result
+    findings = result.get("findings", [])
+    summary = result.get("summary", "")
+
+    # Annotate findings
+    try:
+        from app.pipeline.fusion.pyramid_scoring import annotate_findings
+        from app.pipeline.fusion.topic_clustering import cluster_findings
+        findings = annotate_findings(findings)
+        cluster_findings(findings)  # returns cluster labels; findings are annotated in-place
+    except Exception as exc:
+        log.warning("Annotation failed (non-fatal): %s", exc)
+
+    # Mark succeeded
+    execute(
+        """UPDATE pipeline_runs
+           SET status = 'succeeded', finished_at = now(),
+               error_message = NULL
+           WHERE id = %s""",
+        (inp.run_id,),
+    )
+
+    # Push completion event
+    asyncio.create_task(push_event(inp.user_id, {
+        "type": "job.completed", "job_id": inp.run_id, "run_id": inp.run_id,
+        "status": "succeeded", "result": result,
+    }))
+
+    # Session update
+    if inp.session_id:
+        try:
+            from app.services.session_service import update_session_after_run
+            update_session_after_run(
+                session_id=inp.session_id,
+                user_message=result.get("query", ""),
+                agent_summary=summary,
+                run_id=inp.run_id,
+                findings=findings,
+                entity_type=result.get("entity_type", "unknown"),
+                is_investigation=True,
+                result=result,
+            )
+        except Exception as exc:
+            log.warning("Session update failed (non-fatal): %s", exc)
+
+    # Webhook delivery
+    if inp.callback_url:
+        try:
+            from app.services.webhook import deliver_webhook
+            asyncio.create_task(deliver_webhook(
+                inp.run_id,
+                {"run_id": inp.run_id, "status": "succeeded"},
+                inp.callback_url,
+            ))
+        except Exception:
+            pass

--- a/app/temporal/activities/preflight.py
+++ b/app/temporal/activities/preflight.py
@@ -1,0 +1,67 @@
+"""PreFlight validation activity."""
+from __future__ import annotations
+import logging
+from dataclasses import dataclass, field
+from temporalio import activity
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PreflightInput:
+    query: str
+    prior_slots: dict | None = None
+
+
+@dataclass
+class PreflightResult:
+    tier: int
+    blocking: bool
+    first_question: str | None
+    first_question_options: list[str] | None
+    disclaimer: str | None
+    raw_result: dict | None = field(default=None, repr=False)
+
+
+@dataclass
+class MarkAwaitingInput:
+    run_id: str
+    question: str
+    options: list[str] | None
+
+
+@activity.defn(name="preflight_validation")
+async def preflight_validation(inp: PreflightInput) -> PreflightResult:
+    """Run 3-layer PreFlight validation. Non-fatal — returns tier=3 on failure."""
+    try:
+        from app.pipeline.preflight import validate
+        result = validate(inp.query, prior_slots=inp.prior_slots)
+        return PreflightResult(
+            tier=result.tier if hasattr(result.tier, '__int__') else int(result.tier),
+            blocking=result.blocking,
+            first_question=result.first_question,
+            first_question_options=result.first_question_options,
+            disclaimer=getattr(result, "disclaimer", None),
+            raw_result=None,
+        )
+    except Exception as exc:
+        log.warning("PreFlight failed (non-fatal): %s", exc)
+        return PreflightResult(tier=3, blocking=False, first_question=None,
+                               first_question_options=None, disclaimer=None)
+
+
+@activity.defn(name="mark_awaiting_input")
+async def mark_awaiting_input(inp: MarkAwaitingInput) -> None:
+    """Mark run as awaiting_input and push WS event with question."""
+    from app.routers.v3.db import execute
+    from app.routers.v3.stream import push_event
+    import asyncio
+    execute(
+        "UPDATE pipeline_runs SET status = 'awaiting_input' WHERE id = %s",
+        (inp.run_id,),
+    )
+    asyncio.create_task(push_event(inp.run_id, {
+        "type": "brain.question", "run_id": inp.run_id, "job_id": inp.run_id,
+        "question": inp.question, "options": inp.options or [],
+        "preflight": True,
+    }))

--- a/app/temporal/worker.py
+++ b/app/temporal/worker.py
@@ -17,6 +17,10 @@ async def run_is_worker() -> None:
     from temporalio.client import Client
     from temporalio.worker import Worker
     from app.temporal.workflows.is_run import ISRunWorkflow
+    from app.temporal.activities.brain import run_is_brain
+    from app.temporal.activities.budget import reserve_budget, release_budget_and_mark_failed
+    from app.temporal.activities.post_process import post_process
+    from app.temporal.activities.preflight import preflight_validation, mark_awaiting_input
 
     host = os.getenv("TEMPORAL_HOST", "localhost")
     port = int(os.getenv("TEMPORAL_PORT", "7233"))
@@ -24,9 +28,16 @@ async def run_is_worker() -> None:
     client = await Client.connect(f"{host}:{port}")
     worker = Worker(
         client,
-        task_queue=IS_TASK_QUEUE,
+        IS_TASK_QUEUE,
         workflows=[ISRunWorkflow],
-        activities=[],  # Phase 1 will add activities
+        activities=[
+            run_is_brain,
+            reserve_budget,
+            release_budget_and_mark_failed,
+            post_process,
+            preflight_validation,
+            mark_awaiting_input,
+        ],
     )
     log.info("IS Temporal worker starting on queue %s", IS_TASK_QUEUE)
     await worker.run()

--- a/app/temporal/workflows/is_run.py
+++ b/app/temporal/workflows/is_run.py
@@ -1,7 +1,39 @@
-"""IS Run Temporal workflow — Phase 0 stub."""
+"""IS Run Temporal workflow — Phase 1."""
 from __future__ import annotations
+
+import logging
 from dataclasses import dataclass, field
+from datetime import timedelta
 from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from app.temporal.activities.preflight import (
+        PreflightInput,
+        PreflightResult,
+        MarkAwaitingInput,
+        preflight_validation,
+        mark_awaiting_input,
+    )
+    from app.temporal.activities.budget import (
+        ReserveBudgetInput,
+        ReservationResult,
+        AbortInput,
+        reserve_budget,
+        release_budget_and_mark_failed,
+    )
+    from app.temporal.activities.brain import RunISBrainInput, BrainResult, run_is_brain
+    from app.temporal.activities.post_process import PostProcessInput, post_process
+
+log = logging.getLogger(__name__)
+
+# Retry policies
+_STANDARD_RETRY = RetryPolicy(
+    maximum_attempts=3,
+    initial_interval=timedelta(seconds=2),
+    backoff_coefficient=2.0,
+)
+_NO_RETRY = RetryPolicy(maximum_attempts=1)
 
 
 @dataclass
@@ -12,6 +44,10 @@ class ISRunInput:
     query: str
     pipeline_id: str
     session_id: str | None = None
+    session_context: str = ""
+    past_research: list[dict] = field(default_factory=list)
+    budget: dict = field(default_factory=dict)
+    callback_url: str | None = None
     preflight_prior_slots: dict = field(default_factory=dict)
 
 
@@ -19,26 +55,159 @@ class ISRunInput:
 class ISRunWorkflow:
     """Intelligent Search run as a Temporal workflow.
 
-    Phase 0: stub — connects and registers, no activities executed yet.
     Phase 1: full IS brain execution with activities.
+    Signals: brain_answer (PreFlight clarification), cancel_run
+    Query: get_run_status
     """
 
-    @workflow.run
-    async def run(self, inp: ISRunInput) -> str:
-        # Phase 0 stub — will be replaced in Phase 1
-        workflow.logger.info("ISRunWorkflow Phase 0 stub — run_id=%s", inp.run_id)
-        return "stub"
+    def __init__(self) -> None:
+        self._brain_answer: str | None = None
+        self._cancelled: bool = False
+        self._phase: str = "init"
+        self._cycle_count: int = 0
 
     @workflow.signal
     async def brain_answer(self, answer: str) -> None:
         """Signal from user answering a PreFlight clarification question."""
-        pass  # Phase 1
+        self._brain_answer = answer
 
     @workflow.signal
     async def cancel_run(self) -> None:
         """Signal to cancel the IS run."""
-        pass  # Phase 1
+        self._cancelled = True
 
     @workflow.query
     def get_run_status(self) -> str:
-        return "stub"
+        return self._phase
+
+    @workflow.run
+    async def run(self, inp: ISRunInput) -> str:
+        workflow.logger.info("ISRunWorkflow starting run_id=%s", inp.run_id)
+        self._phase = "preflight"
+
+        # 1. PreFlight validation
+        preflight: PreflightResult = await workflow.execute_activity(
+            preflight_validation,
+            PreflightInput(query=inp.query, prior_slots=inp.preflight_prior_slots or None),
+            schedule_to_close_timeout=timedelta(seconds=60),
+            retry_policy=_STANDARD_RETRY,
+        )
+
+        # 2. If blocking, wait for user's answer before proceeding
+        if preflight.blocking:
+            self._phase = "awaiting_input"
+            await workflow.execute_activity(
+                mark_awaiting_input,
+                MarkAwaitingInput(
+                    run_id=inp.run_id,
+                    question=preflight.first_question or "",
+                    options=preflight.first_question_options,
+                ),
+                schedule_to_close_timeout=timedelta(seconds=30),
+                retry_policy=_STANDARD_RETRY,
+            )
+            # Wait up to 10 minutes for the user answer signal
+            await workflow.wait_condition(
+                lambda: self._brain_answer is not None or self._cancelled,
+                timeout=timedelta(minutes=10),
+            )
+            if self._cancelled:
+                await self._abort(inp, "cancelled_by_user")
+                return "cancelled"
+            # Enrich query with clarification answer
+            inp = ISRunInput(
+                run_id=inp.run_id,
+                user_id=inp.user_id,
+                org_id=inp.org_id,
+                query=f"{inp.query}\n\nClarification: {self._brain_answer}",
+                pipeline_id=inp.pipeline_id,
+                session_id=inp.session_id,
+                session_context=inp.session_context,
+                past_research=inp.past_research,
+                budget=inp.budget,
+                callback_url=inp.callback_url,
+                preflight_prior_slots=inp.preflight_prior_slots,
+            )
+
+        # 3. Reserve budget
+        self._phase = "budget"
+        reservation: ReservationResult = await workflow.execute_activity(
+            reserve_budget,
+            ReserveBudgetInput(
+                run_id=inp.run_id,
+                user_id=inp.user_id,
+                org_id=inp.org_id,
+                budget=inp.budget,
+            ),
+            schedule_to_close_timeout=timedelta(seconds=30),
+            retry_policy=_STANDARD_RETRY,
+        )
+        if not reservation.ok:
+            await self._abort(inp, f"insufficient_budget: {reservation.reason}")
+            return "failed"
+
+        if self._cancelled:
+            await self._abort(inp, "cancelled_by_user")
+            return "cancelled"
+
+        # 4. Run IS brain
+        self._phase = "running"
+        try:
+            brain_result: BrainResult = await workflow.execute_activity(
+                run_is_brain,
+                RunISBrainInput(
+                    run_id=inp.run_id,
+                    user_id=inp.user_id,
+                    query=inp.query,
+                    session_id=inp.session_id,
+                    session_context=inp.session_context,
+                    past_research=inp.past_research or [],
+                    preflight_tier=preflight.tier,
+                    preflight_disclaimer=preflight.disclaimer,
+                ),
+                schedule_to_close_timeout=timedelta(minutes=15),
+                heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=_NO_RETRY,
+            )
+        except Exception as exc:
+            workflow.logger.error("run_is_brain failed: %s", exc)
+            await self._abort(inp, f"brain_error: {exc}")
+            return "failed"
+
+        # 5. Post-process
+        self._phase = "post_process"
+        await workflow.execute_activity(
+            post_process,
+            PostProcessInput(
+                run_id=inp.run_id,
+                user_id=inp.user_id,
+                session_id=inp.session_id,
+                brain_result={**brain_result.raw, "query": inp.query},
+                callback_url=inp.callback_url,
+            ),
+            schedule_to_close_timeout=timedelta(minutes=2),
+            retry_policy=_STANDARD_RETRY,
+        )
+
+        self._phase = "succeeded"
+        workflow.logger.info("ISRunWorkflow completed run_id=%s", inp.run_id)
+        return "succeeded"
+
+    async def _abort(self, inp: ISRunInput, reason: str) -> None:
+        """Release budget and mark run failed."""
+        self._phase = "failed"
+        try:
+            await workflow.execute_activity(
+                release_budget_and_mark_failed,
+                AbortInput(
+                    run_id=inp.run_id,
+                    user_id=inp.user_id,
+                    org_id=inp.org_id,
+                    reason=reason,
+                    callback_url=inp.callback_url,
+                ),
+                schedule_to_close_timeout=timedelta(seconds=30),
+                retry_policy=_STANDARD_RETRY,
+            )
+        except Exception as exc:
+            workflow.logger.error("_abort activity failed: %s", exc)


### PR DESCRIPTION
## Summary

- Adds 4 Temporal activity modules under `app/temporal/activities/`: `preflight`, `budget`, `brain`, `post_process`
- Upgrades `ISRunWorkflow` from Phase 0 stub to full orchestration: preflight → budget reservation → IS brain (30s heartbeat) → post-process
- Registers all activities in `worker.py`
- Activates the `IS_USE_TEMPORAL` feature flag branch in `agent.py`; asyncio path retained as `else` fallback
- Flag defaults to `false` — zero behaviour change without `IS_USE_TEMPORAL=true`

## Activity design

| Activity | Idempotency | Retry |
|---|---|---|
| `preflight_validation` | non-fatal, always safe to re-run | 3× |
| `mark_awaiting_input` | UPDATE is idempotent | 3× |
| `reserve_budget` | short-circuits if `budget_status='reserved'` | 3× |
| `release_budget_and_mark_failed` | skips if run already terminal | 3× |
| `run_is_brain` | 30s heartbeat; `heartbeat_timeout=2m` | 1× (no retry) |
| `post_process` | skips if run already `succeeded` | 3× |

## Test plan

- [ ] Set `IS_USE_TEMPORAL=false` (default): run an IS investigation end-to-end — unchanged asyncio path
- [ ] Set `IS_USE_TEMPORAL=true` with Temporal running: verify workflow appears in Temporal UI, run completes
- [ ] Send `cancel_run` signal mid-run: verify run marked `failed/cancelled`, budget released
- [ ] Kill worker mid-brain: verify heartbeat timeout triggers retry circuit (brain is no-retry, workflow marks failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)