### PR TITLE
feat(rbac): org membership roles — analyst/viewer + route enforcement

### DIFF
--- a/app/routers/v3/agent.py
+++ b/app/routers/v3/agent.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from app.routers.v3.auth import get_current_user
 from app.routers.v3.db import execute, fetch_all, fetch_one
-from app.routers.v3.tenancy import user_org_id
+from app.routers.v3.tenancy import user_org_id, require_analyst_user
 from app.routers.v3.models import AgentMessageIn, AgentMessageOut, AgentPipelineOut
 from app.services.session_service import (
     classify_turn,
@@ -141,7 +141,7 @@ class AgentPipelineIn(BaseModel):
 
 
 @router.put("/pipeline", response_model=AgentPipelineOut)
-def set_agent_pipeline(body: AgentPipelineIn, user: dict = Depends(get_current_user)):
+def set_agent_pipeline(body: AgentPipelineIn, user: dict = Depends(require_analyst_user)):
     from app.pipeline.nodes import NodeRegistry
     NodeRegistry.auto_discover()
 
@@ -275,7 +275,7 @@ async def get_brain_status(user: dict = Depends(get_current_user)):
 @router.post("/research/sync")
 async def run_research_sync(
     body: dict,
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_analyst_user),
 ):
     """Run the IS brain synchronously and return the full result.
 
@@ -982,7 +982,7 @@ async def _run_is_research(
 @router.post("/message", response_model=AgentMessageOut, status_code=202)
 async def send_message(
     body: AgentMessageIn,
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_analyst_user),
 ):
     from app.pipeline.workflow import NodeSpec, EdgeSpec
     from app.pipeline.runner import launch_pipeline_run

--- a/app/routers/v3/auth.py
+++ b/app/routers/v3/auth.py
@@ -91,7 +91,7 @@ def refresh(body: RefreshRequest):
 def list_users(current_user: dict = Depends(get_current_user)) -> list[dict]:
     """List all users. Admin only."""
     rows = fetch_all(
-        """SELECT id, username, email, is_admin, is_active, org_id, created_at
+        """SELECT id, username, email, is_admin, role, is_active, org_id, created_at
            FROM ui_users
            ORDER BY created_at DESC""",
         (),
@@ -105,18 +105,21 @@ def update_user(
     body: dict,
     current_user: dict = Depends(get_current_user),
 ) -> dict:
-    """Update user is_admin or is_active. Admin only."""
+    """Update user is_admin, role, or is_active. Admin only."""
     if str(user_id) == str(current_user["id"]) and body.get("is_admin") is False:
         raise HTTPException(status_code=400, detail="Cannot remove your own admin status")
 
-    allowed = {k: v for k, v in body.items() if k in ("is_admin", "is_active")}
+    if "role" in body and body["role"] not in ("admin", "analyst", "viewer"):
+        raise HTTPException(status_code=422, detail="role must be admin, analyst, or viewer")
+
+    allowed = {k: v for k, v in body.items() if k in ("is_admin", "is_active", "role")}
     if not allowed:
-        raise HTTPException(status_code=422, detail="Only is_admin and is_active are patchable")
+        raise HTTPException(status_code=422, detail="Only is_admin, role, and is_active are patchable")
 
     set_clause = ", ".join(f"{k} = %s" for k in allowed)
     values = list(allowed.values()) + [user_id]
     row = fetch_one(
-        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING id, username, is_admin, is_active",
+        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING id, username, is_admin, role, is_active",
         tuple(values),
     )
     if not row:

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -509,9 +509,14 @@ ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_status    VARCHAR(32);
 ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_exhausted_at TIMESTAMPTZ;
 ALTER TABLE pipeline_runs ADD COLUMN IF NOT EXISTS budget_stop_reason  TEXT;
 
--- RBAC: admin flag on ui_users
+-- RBAC: admin flag + org role on ui_users
 ALTER TABLE ui_users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT false;
 UPDATE ui_users SET is_admin = true WHERE username = 'admin';
+
+-- Org membership role: admin | analyst | viewer
+ALTER TABLE ui_users ADD COLUMN IF NOT EXISTS role VARCHAR(32) NOT NULL DEFAULT 'analyst';
+UPDATE ui_users SET role = 'admin' WHERE is_admin = true OR username = 'admin';
+
 
 -- Session multi-turn hypothesis memory
 ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS investigated_hypotheses JSONB DEFAULT '[]'::jsonb;

--- a/app/routers/v3/sources_api.py
+++ b/app/routers/v3/sources_api.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 
 from app.deps import require_api_key
 from app.routers.v3.auth import get_current_user
+from app.routers.v3.tenancy import require_analyst_user
 from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.tenancy import user_org_id
 
@@ -96,7 +97,7 @@ async def _process_source(source_id: str, user_id: str, file_path: str, filename
 async def upload_source(
     file: UploadFile = File(...),
     run_id: str = Form(None),
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_analyst_user),
 ) -> dict:
     """Upload a file, persist metadata, and kick off async parsing."""
     # Validate extension
@@ -318,7 +319,7 @@ async def query_source_data(
 
 
 @router.delete("/{source_id}")
-def delete_source(source_id: str, user: dict = Depends(get_current_user)) -> dict:
+def delete_source(source_id: str, user: dict = Depends(require_analyst_user)) -> dict:
     """Delete a source metadata row."""
     row = fetch_one(
         "SELECT id FROM research_sources WHERE id = %s AND user_id = %s",

--- a/app/routers/v3/tenancy.py
+++ b/app/routers/v3/tenancy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import HTTPException
+from fastapi import Depends, HTTPException
 
 from app.routers.v3.db import fetch_one
 
@@ -23,6 +23,37 @@ def require_system_user(user_id: str, org_id: str) -> dict:
     if not user:
         raise HTTPException(status_code=404, detail="User not found in organization")
     return user
+
+
+def _user_role(user: dict) -> str:
+    """Resolve effective role: explicit role column falls back to is_admin flag."""
+    if user.get("is_admin"):
+        return "admin"
+    return user.get("role") or "analyst"
+
+
+def require_analyst(user: dict) -> dict:
+    """Dependency: passes for admin and analyst; blocks viewers."""
+    if _user_role(user) not in ("admin", "analyst"):
+        raise HTTPException(status_code=403, detail="Analyst or admin role required")
+    return user
+
+
+def require_viewer(user: dict) -> dict:
+    """Dependency: passes for any authenticated user (admin / analyst / viewer)."""
+    return user
+
+
+def _make_analyst_dep():
+    from app.routers.v3.auth import get_current_user
+
+    def _dep(user: dict = Depends(get_current_user)) -> dict:
+        return require_analyst(user)
+
+    return _dep
+
+
+require_analyst_user = _make_analyst_dep()
 
 
 def require_user_run(run_id: str, user_id: str, org_id: str) -> dict:

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -425,11 +425,14 @@ export const getRunHistory = (limit = 50): Promise<RunHistoryItem[]> =>
 
 // --- Admin: User Management ---
 
+export type UserRole = 'admin' | 'analyst' | 'viewer'
+
 export interface UserRecord {
   id: string
   username: string
   email: string | null
   is_admin: boolean
+  role: UserRole
   is_active: boolean
   org_id: string
   created_at: string
@@ -440,6 +443,6 @@ export const listUsers = (): Promise<UserRecord[]> =>
 
 export const patchUser = (
   userId: string,
-  body: Partial<Pick<UserRecord, 'is_admin' | 'is_active'>>,
+  body: Partial<Pick<UserRecord, 'is_admin' | 'is_active' | 'role'>>,
 ): Promise<UserRecord> =>
   api.patch(`/v3/auth/users/${userId}`, body).then(r => r.data)

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listUsers, patchUser, UserRecord } from '../api/v3'
+import { listUsers, patchUser, UserRecord, UserRole } from '../api/v3'
 import IconRail from '../components/layout/IconRail'
 import { useSessionStore } from '../stores/sessionStore'
 
@@ -56,7 +56,7 @@ export default function AdminUsersPage() {
   })
 
   const patch = useMutation({
-    mutationFn: ({ id, body }: { id: string; body: Partial<Pick<UserRecord, 'is_admin' | 'is_active'>> }) =>
+    mutationFn: ({ id, body }: { id: string; body: Partial<Pick<UserRecord, 'is_admin' | 'is_active' | 'role'>> }) =>
       patchUser(id, body),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-users'] }),
   })
@@ -115,7 +115,7 @@ export default function AdminUsersPage() {
               >
                 <thead>
                   <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                    {['Username', 'Email', 'Org', 'Admin', 'Active', 'Created'].map(h => (
+                    {['Username', 'Email', 'Org', 'Role', 'Admin', 'Active', 'Created'].map(h => (
                       <th
                         key={h}
                         style={{
@@ -164,6 +164,27 @@ export default function AdminUsersPage() {
                         </td>
                         <td style={{ padding: '8px 12px', color: 'var(--subtext)', fontFamily: 'monospace', fontSize: 11 }}>
                           {user.org_id ? user.org_id.slice(0, 8) + '…' : '—'}
+                        </td>
+                        <td style={{ padding: '8px 12px' }}>
+                          <select
+                            value={user.role ?? 'analyst'}
+                            disabled={isSelf}
+                            onChange={e => patch.mutate({ id: user.id, body: { role: e.target.value as UserRole } })}
+                            style={{
+                              background: 'var(--panel)',
+                              color: 'var(--text)',
+                              border: '1px solid var(--border)',
+                              borderRadius: 4,
+                              fontSize: 11,
+                              padding: '2px 6px',
+                              cursor: isSelf ? 'not-allowed' : 'pointer',
+                              opacity: isSelf ? 0.5 : 1,
+                            }}
+                          >
+                            <option value="admin">admin</option>
+                            <option value="analyst">analyst</option>
+                            <option value="viewer">viewer</option>
+                          </select>
                         </td>
                         <td style={{ padding: '8px 12px' }}>
                           <Toggle


### PR DESCRIPTION
## Summary

- Adds `role VARCHAR(32)` column to `ui_users` (values: `admin`, `analyst`, `viewer`; default `analyst`)
- `require_analyst_user` FastAPI dependency — drop-in for `Depends(get_current_user)` on write routes
- **Gated routes (analyst+):** `POST /v3/agent/message`, `PUT /v3/agent/pipeline`, `POST /v3/agent/research/sync`, `POST /v3/sources/upload`, `DELETE /v3/sources/{id}`
- Viewers can access all read endpoints; they cannot run investigations or upload sources
- `GET /v3/auth/users` now returns `role` field; `PATCH /v3/auth/users/{id}` accepts `role` (validated enum)
- AdminUsersPage: role column with inline `<select>` per row

## Test plan
- [ ] Login as admin: all routes accessible
- [ ] Login as analyst: can start investigation, upload source; cannot access admin routes
- [ ] PATCH user to role=viewer; login as viewer: POST /v3/agent/message returns 403
- [ ] Admin user management page shows Role column with dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)