### PR TITLE
feat: default search mode selection (global + per-org)

### DIFF
--- a/app/modes/loader.py
+++ b/app/modes/loader.py
@@ -60,3 +60,32 @@ def get_mode(mode_id: str | None) -> Mode:
 def _load_file(path: Path) -> Mode:
     raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     return Mode.model_validate(raw)
+
+
+def get_default_mode_id(org_id: str | None) -> str:
+    """Resolve the default mode id for an org. Order: org → global → 'general'.
+
+    Invalid stored ids (mode no longer bundled) silently fall through to the
+    next tier and ultimately to 'general' so the picker never preselects
+    nothing.
+    """
+    from app.routers.v3.db import fetch_one  # local import avoids circulars
+
+    valid_ids = {m.id for m in list_modes()}
+
+    if org_id:
+        row = fetch_one(
+            "SELECT value FROM org_settings WHERE org_id = %s AND key = 'default_mode_id'",
+            (org_id,),
+        )
+        if row and row.get("value") and row["value"] in valid_ids:
+            return row["value"]
+
+    row = fetch_one(
+        "SELECT value FROM core_settings WHERE key = 'default_mode_id'",
+        (),
+    )
+    if row and row.get("value") and row["value"] in valid_ids:
+        return row["value"]
+
+    return _DEFAULT_MODE_ID

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -62,6 +62,14 @@ CREATE TABLE IF NOT EXISTS core_settings (
     updated_at TIMESTAMPTZ DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS org_settings (
+    org_id     UUID NOT NULL,
+    key        VARCHAR(128) NOT NULL,
+    value      TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, key)
+);
+
 CREATE TABLE IF NOT EXISTS v3_jobs (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id      UUID REFERENCES ui_users(id) ON DELETE CASCADE,

--- a/app/routers/v3/models.py
+++ b/app/routers/v3/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 from pydantic import BaseModel, Field, field_validator
 
@@ -362,3 +362,17 @@ class PluginRequestOut(BaseModel):
 
 class PluginRequestStatusIn(BaseModel):
     status: str  # "approved" | "rejected" | "implemented"
+
+
+class DefaultModeOut(BaseModel):
+    """Resolved default mode plus its provenance, for the calling user's org."""
+    resolved: str
+    source: Literal["org", "global", "fallback"]
+    org_value: str | None
+    global_value: str | None
+
+
+class DefaultModeIn(BaseModel):
+    """Write-side payload for PUT [REDACTED:high-entropy-base64:25ch:hash=d1ee1236]."""
+    value: str | None  # null clears the override at this scope
+    scope: Literal["global", "org"]

--- a/app/routers/v3/settings.py
+++ b/app/routers/v3/settings.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from app.crypto import decrypt_value, encrypt_value
-from app.modes.loader import get_default_mode_id
+from app.modes.loader import get_default_mode_id, list_modes
 from app.routers.v3.auth import get_current_user, require_admin
 from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.models import CoreSettingIn, CoreSettingsOut, DefaultModeIn, DefaultModeOut
@@ -88,3 +88,57 @@ def get_default_mode(user: dict = Depends(get_current_user)) -> DefaultModeOut:
         org_value=org_value,
         global_value=global_value,
     )
+
+
+@router.put("/default_mode", response_model=DefaultModeOut)
+def put_default_mode(
+    body: DefaultModeIn,
+    user: dict = Depends(get_current_user),
+) -> DefaultModeOut:
+    # Authz
+    if body.scope == "global":
+        if not user.get("is_admin"):
+            raise HTTPException(status_code=403, detail="Global default requires admin")
+    else:  # "org"
+        if user.get("role") != "admin":
+            raise HTTPException(status_code=403, detail="Org default requires org admin role")
+        if not user.get("org_id"):
+            raise HTTPException(status_code=400, detail="User has no org")
+
+    # Validate value (None means clear)
+    if body.value is not None:
+        valid = {m.id for m in list_modes()}
+        if body.value not in valid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown mode id; must be one of {sorted(valid)}",
+            )
+
+    if body.scope == "global":
+        if body.value is None:
+            execute("DELETE FROM core_settings WHERE key = 'default_mode_id'", ())
+        else:
+            execute(
+                """INSERT INTO core_settings (key, value, is_secret)
+                   VALUES ('default_mode_id', %s, false)
+                   ON CONFLICT (key) DO UPDATE
+                   SET value = EXCLUDED.value, updated_at = now()""",
+                (body.value,),
+            )
+    else:
+        org_id = str(user["org_id"])
+        if body.value is None:
+            execute(
+                "DELETE FROM org_settings WHERE org_id = %s AND key = 'default_mode_id'",
+                (org_id,),
+            )
+        else:
+            execute(
+                """INSERT INTO org_settings (org_id, key, value)
+                   VALUES (%s, 'default_mode_id', %s)
+                   ON CONFLICT (org_id, key) DO UPDATE
+                   SET value = EXCLUDED.value, updated_at = now()""",
+                (org_id, body.value),
+            )
+
+    return get_default_mode(user=user)

--- a/app/routers/v3/settings.py
+++ b/app/routers/v3/settings.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from app.crypto import decrypt_value, encrypt_value
+from app.modes.loader import get_default_mode_id
 from app.routers.v3.auth import get_current_user, require_admin
 from app.routers.v3.db import execute, fetch_all, fetch_one
-from app.routers.v3.models import CoreSettingIn, CoreSettingsOut
+from app.routers.v3.models import CoreSettingIn, CoreSettingsOut, DefaultModeIn, DefaultModeOut
 
 router = APIRouter(prefix="/v3/settings", tags=["v3-settings"])
 
@@ -51,4 +52,39 @@ def set_plugin_enabled(plugin_id: str, body: dict, user: dict = Depends(require_
         "INSERT INTO core_settings (key, value, is_secret) VALUES (%s, %s, false) "
         "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()",
         (key, "true" if body.get("enabled", True) else "false"),
+    )
+
+
+@router.get("/default_mode", response_model=DefaultModeOut)
+def get_default_mode(user: dict = Depends(get_current_user)) -> DefaultModeOut:
+    org_id = str(user["org_id"]) if user.get("org_id") else None
+
+    org_row = (
+        fetch_one(
+            "SELECT value FROM org_settings WHERE org_id = %s AND key = 'default_mode_id'",
+            (org_id,),
+        )
+        if org_id
+        else None
+    )
+    org_value = org_row["value"] if org_row and org_row.get("value") else None
+
+    global_row = fetch_one(
+        "SELECT value FROM core_settings WHERE key = 'default_mode_id'", ()
+    )
+    global_value = global_row["value"] if global_row and global_row.get("value") else None
+
+    resolved = get_default_mode_id(org_id)
+    if org_value and resolved == org_value:
+        source: str = "org"
+    elif global_value and resolved == global_value:
+        source = "global"
+    else:
+        source = "fallback"
+
+    return DefaultModeOut(
+        resolved=resolved,
+        source=source,  # type: ignore[arg-type]
+        org_value=org_value,
+        global_value=global_value,
     )

--- a/docs/superpowers/specs/2026-05-21-default-mode-selection-design.md
+++ b/docs/superpowers/specs/2026-05-21-default-mode-selection-design.md
@@ -1,0 +1,152 @@
+# Default Mode Selection — Global + Per-Org
+
+**Date:** 2026-05-21
+**Status:** Draft, pending review
+
+## Goal
+
+Let admins choose which bundled mode (`general`, `lead_gen`, `kyc_edd`, `competitive_intel`) is preselected when a user starts a new search. Two tiers: a system-wide default (set by superadmin) and a per-org override (set by org admin). Users can still pick a different mode per search; this only changes the initial selection.
+
+## Non-goals
+
+- Per-user default. (Two-tier only — agreed during brainstorm.)
+- Editing mode YAML content.
+- Authoring custom modes from the UI.
+- Restricting which modes a user can pick. The picker still shows all 4 modes; only the preselection changes.
+
+## Resolution order
+
+`org_settings.default_mode_id` → `core_settings.default_mode_id` → hardcoded `'general'`.
+
+The hardcoded fallback already exists in `app/modes/loader.py:_DEFAULT_MODE_ID`. If a stored value points at an unknown mode id, `get_mode()` falls back to `general` with a warning — no special handling needed.
+
+## Storage
+
+### Global default
+Reuse the existing `core_settings` table. New key:
+
+- **Key:** `default_mode_id`
+- **Value:** one of `general | lead_gen | kyc_edd | competitive_intel`
+- **Editor:** superadmin via the existing Settings → Core Settings UI.
+
+No schema change for the global tier.
+
+### Per-org default
+New table `org_settings`, modeled on `core_settings`:
+
+```sql
+CREATE TABLE IF NOT EXISTS org_settings (
+  org_id     UUID NOT NULL,
+  key        TEXT NOT NULL,
+  value      TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (org_id, key)
+);
+```
+
+First key used: `default_mode_id`. The table is intentionally general so future per-org settings (theme, retention, default search limits) drop in without new tables.
+
+Migration runs in the same bootstrap path as `core_settings` (`app/routers/v3/db.py`).
+
+## Backend
+
+### `app/modes/loader.py`
+
+Add:
+
+```python
+def get_default_mode_id(org_id: str | None) -> str:
+    """Resolve default mode for an org. org → global → 'general'."""
+```
+
+Single source of truth used by both the API and any server-side default selection logic. Reads `org_settings` then `core_settings`, validates the result against `list_modes()` ids, falls back to `_DEFAULT_MODE_ID` on miss or invalid value.
+
+### Endpoints
+
+All under existing `/v3` prefix.
+
+**`GET /v3/modes`**
+Returns the bundled mode list for dropdowns and pickers:
+```json
+[{"id": "general", "label": "General", "description": "..."}, ...]
+```
+Replaces frontend hardcoding of the mode list. Read-only, any authenticated user.
+
+**`GET /v3/settings/default_mode`**
+Returns the resolved default plus its provenance, scoped to the calling user's org:
+```json
+{
+  "resolved": "lead_gen",
+  "source": "org",          // "org" | "global" | "fallback"
+  "org_value": "lead_gen",  // null if no org override
+  "global_value": "general" // null if not set
+}
+```
+Used by Preflight on mount and by Settings to show current state.
+
+**`PUT /v3/settings/default_mode`**
+Body:
+```json
+{"value": "lead_gen" | null, "scope": "global" | "org"}
+```
+- `value: null` clears the override at the given scope.
+- `scope: "global"` requires `is_superadmin`. Writes to `core_settings`.
+- `scope: "org"` requires `is_admin` of the calling user's org. Writes to `org_settings` for that org.
+- Validates `value` against `list_modes()` ids; rejects unknown ids with 400.
+
+## Frontend
+
+### `frontend/src/pages/Settings.tsx`
+
+New section **"Default mode"** beneath the existing account section.
+
+- **System default** (only visible to superadmin) — single `<select>` populated from `GET /v3/modes`. Saves on change to `PUT /v3/settings/default_mode` with `scope: "global"`.
+- **Org default** (only visible to org admins) — single `<select>` with one extra option `"Use system default"` at the top, which sends `value: null`. Below the select, a hint line: when the org value is `null`, show *"Inherited from system default: General"*; otherwise show *"Active for everyone in this org."*
+
+Both controls show toast confirmation on save and surface 4xx errors inline.
+
+### `frontend/src/components/preflight/PreflightPanel.tsx`
+
+Replace the hardcoded initial state on line 108:
+
+```tsx
+const [mode, setMode] = useState<string>('investigation')
+```
+
+with a value seeded from `GET /v3/settings/default_mode` (fetched once at mount via React Query or the existing `api` client). Until the request resolves, render the panel with `general` selected — switching the selection once the response lands is fine since the user hasn't interacted yet.
+
+If the existing `'investigation'` literal is a separate concept (not one of the 4 bundled modes), preserve its handling but still apply the resolved default on top.
+
+## Authorization
+
+- `is_superadmin` — already represented as `is_admin && (some superadmin flag or seeded user)`; reuse whatever check `core_settings` write currently uses (audit during implementation; do not invent a new check).
+- `is_admin` of the calling user's org — derived from `ui_users.role = 'admin' AND ui_users.org_id = caller.org_id`.
+
+## Verification
+
+### Unit
+`get_default_mode_id` resolution table:
+| org_settings | core_settings | expected |
+|---|---|---|
+| `lead_gen` | anything | `lead_gen` |
+| `null` / missing | `kyc_edd` | `kyc_edd` |
+| `null` / missing | `null` / missing | `general` |
+| `bogus_id` | `lead_gen` | `lead_gen` (org value rejected) |
+| `null` | `bogus_id` | `general` (global rejected) |
+
+### API
+- Non-admin → `PUT /v3/settings/default_mode` returns 403 for either scope.
+- Org admin attempting `scope: global` returns 403.
+- Unknown mode id returns 400 with the list of valid ids.
+- `value: null` clears the row (subsequent `GET` shows `org_value: null`).
+
+### E2E (Playwright)
+1. Superadmin signs in, sets system default to `lead_gen`. User A (different org, no org override) opens Preflight → `lead_gen` is preselected.
+2. Org admin of org X sets org default to `kyc_edd`. User B in org X opens Preflight → `kyc_edd` is preselected; system default is unchanged for user A.
+3. Org admin clears the override → User B's preflight falls back to `lead_gen` (the global default).
+
+## Out of scope
+
+- GitHub OAuth login wiring (separate active workstream).
+- Theme / retention / other future per-org settings — the `org_settings` table is built to host them, but no UI is added.
+- Per-user defaults.

--- a/frontend/e2e/default-mode.spec.ts
+++ b/frontend/e2e/default-mode.spec.ts
@@ -16,7 +16,7 @@ test('admin sets global default mode and Preflight preselects it', async ({ page
   const token = await adminToken(req)
 
   // Reset state
-  await req.put(`${API}/v3/settings/default-mode`, {
+  await req.put(`${API}/v3/settings/default_mode`, {
     headers: { Authorization: `Bearer ${token}` },
     data: { value: 'lead_gen', scope: 'global' },
   })
@@ -35,7 +35,7 @@ test('admin sets global default mode and Preflight preselects it', async ({ page
     .toBeVisible({ timeout: 10_000 })
 
   // Cleanup — clear the global default
-  await req.put(`${API}/v3/settings/default-mode`, {
+  await req.put(`${API}/v3/settings/default_mode`, {
     headers: { Authorization: `Bearer ${token}` },
     data: { value: null, scope: 'global' },
   })

--- a/frontend/e2e/default-mode.spec.ts
+++ b/frontend/e2e/default-mode.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect, request } from '@playwright/test'
+
+const API = process.env.E2E_API_BASE || 'http://localhost:8000'
+const APP = process.env.E2E_APP_BASE || 'http://localhost:5173'
+
+async function adminToken(req: Awaited<ReturnType<typeof request.newContext>>) {
+  const r = await req.post(`${API}/v3/auth/login`, {
+    data: { username: 'admin', password: process.env.ADMIN_PASSWORD || 'admin' },
+  })
+  expect(r.ok()).toBeTruthy()
+  return (await r.json()).access_token as string
+}
+
+test('admin sets global default mode and Preflight preselects it', async ({ page }) => {
+  const req = await request.newContext()
+  const token = await adminToken(req)
+
+  // Reset state
+  await req.put(`${API}/v3/settings/default-mode`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { value: 'lead_gen', scope: 'global' },
+  })
+
+  // Log in via the UI so the session store is populated.
+  // The login form uses placeholder text (no aria-label), so we target by name attribute.
+  await page.goto(`${APP}/login`)
+  await page.locator('input[name="username"]').fill('admin')
+  await page.locator('input[name="password"]').fill(process.env.ADMIN_PASSWORD || 'admin')
+  await page.getByRole('button', { name: /sign in/i }).click()
+
+  // PreflightPanel lives on the Dashboard (/) via AgentChat — there is no /search route.
+  await page.goto(`${APP}/`)
+  await page.waitForSelector('[data-mode-id]', { timeout: 10_000 })
+  await expect(page.locator('[data-mode-id="lead_gen"][aria-pressed="true"]'))
+    .toBeVisible({ timeout: 10_000 })
+
+  // Cleanup — clear the global default
+  await req.put(`${API}/v3/settings/default-mode`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { value: null, scope: 'global' },
+  })
+})

--- a/frontend/src/components/preflight/ModePicker.tsx
+++ b/frontend/src/components/preflight/ModePicker.tsx
@@ -38,6 +38,8 @@ export function ModePicker({ modes, selectedMode, onSelect }: ModePickerProps) {
           return (
             <button
               key={mode.id}
+              data-mode-id={mode.id}
+              aria-pressed={active}
               title={mode.description}
               onClick={() => onSelect(mode)}
               style={{

--- a/frontend/src/components/preflight/PreflightPanel.tsx
+++ b/frontend/src/components/preflight/PreflightPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { api } from '../../api/client'
 import { usePreflight } from '../../hooks/usePreflight'
 import type { DialsIn, ModeEntry } from '../../hooks/usePreflight'
 import { ModePicker } from './ModePicker'
@@ -127,6 +128,24 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
       if (userDefaults.hypothesis_count) setHypothesisCount(userDefaults.hypothesis_count as DialsIn['hypothesis_count'])
     }
   }, [userDefaults]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [defaultMode, setDefaultMode] = useState<string | null>(null)
+  const [userTouchedMode, setUserTouchedMode] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    api.get('/settings/default-mode')
+      .then(r => { if (!cancelled) setDefaultMode((r.data as { resolved: string }).resolved) })
+      .catch(() => { /* fall back to current state */ })
+    return () => { cancelled = true }
+  }, [])
+
+  useEffect(() => {
+    if (defaultMode && !userTouchedMode) {
+      setMode(defaultMode)
+    }
+  }, [defaultMode, userTouchedMode])
+
   const [showSaveDialog, setShowSaveDialog] = useState(false)
   const [showSaveCta, setShowSaveCta] = useState(false)
 
@@ -162,6 +181,7 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
 
   // ---- mode selection -------------------------------------------------------
   function handleModeSelect(modeEntry: ModeEntry) {
+    setUserTouchedMode(true)
     const d = modeEntry.dial_defaults
     setMode(modeEntry.id)
     setSpeed(d.speed as DialsIn['speed'])

--- a/frontend/src/components/preflight/PreflightPanel.tsx
+++ b/frontend/src/components/preflight/PreflightPanel.tsx
@@ -134,7 +134,7 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
 
   useEffect(() => {
     let cancelled = false
-    api.get('/settings/default-mode')
+    api.get('[REDACTED:high-entropy-base64:25ch:hash=d1ee1236]')
       .then(r => { if (!cancelled) setDefaultMode((r.data as { resolved: string }).resolved) })
       .catch(() => { /* fall back to current state */ })
     return () => { cancelled = true }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form'
 import IconRail from '../components/layout/IconRail'
 import { useSessionStore } from '../stores/sessionStore'
 import AccountSection from '../components/settings/AccountSection'
+import { api } from '../api/client'
 
 const CORE_FIELDS = [
   // LLM Model Tiers
@@ -412,9 +413,117 @@ function NodeHealthSection() {
   )
 }
 
+type DefaultModeState = {
+  resolved: string
+  source: 'org' | 'global' | 'fallback'
+  org_value: string | null
+  global_value: string | null
+}
+
+type ModeEntry = { id: string; label: string; description?: string }
+
+function DefaultModeForm() {
+  const isAdmin = useSessionStore(s => s.isAdmin)
+  const role = useSessionStore(s => s.role)
+  const isOrgAdmin = role === 'admin'
+
+  const [modes, setModes] = useState<ModeEntry[]>([])
+  const [state, setState] = useState<DefaultModeState | null>(null)
+  const [saving, setSaving] = useState<'global' | 'org' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    Promise.all([
+      api.get('/v3/modes'),
+      api.get('/v3/settings/default-mode'),
+    ])
+      .then(([modesResp, defResp]) => {
+        setModes(modesResp.data as ModeEntry[])
+        setState(defResp.data as DefaultModeState)
+      })
+      .catch(e => setError(e?.response?.data?.detail || 'Failed to load'))
+  }, [])
+
+  async function save(scope: 'global' | 'org', value: string | null) {
+    setSaving(scope)
+    setError(null)
+    try {
+      const resp = await api.put('/v3/settings/default-mode', { value, scope })
+      setState(resp.data as DefaultModeState)
+    } catch (e: any) {
+      setError(e?.response?.data?.detail || 'Save failed')
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  if (error) return <div style={{ color: 'var(--danger)' }}>{error}</div>
+  if (!state) return <div style={{ color: 'var(--muted)' }}>Loading…</div>
+
+  const labelFor = (id: string) => modes.find(m => m.id === id)?.label || id
+
+  return (
+    <div className="space-y-6">
+      {isAdmin && (
+        <section>
+          <div className="text-xs font-semibold mb-2" style={{ color: 'var(--text)' }}>
+            System default
+          </div>
+          <select
+            disabled={saving === 'global'}
+            value={state.global_value ?? ''}
+            onChange={e => save('global', e.target.value || null)}
+            className="text-xs px-2 py-1 rounded"
+            style={{ background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
+          >
+            <option value="">— not set (uses fallback: general) —</option>
+            {modes.map(m => (
+              <option key={m.id} value={m.id}>{m.label}</option>
+            ))}
+          </select>
+          <div className="text-[11px] mt-1" style={{ color: 'var(--muted)' }}>
+            Applies to every org that has not set its own override.
+          </div>
+        </section>
+      )}
+
+      {isOrgAdmin && (
+        <section>
+          <div className="text-xs font-semibold mb-2" style={{ color: 'var(--text)' }}>
+            Org default
+          </div>
+          <select
+            disabled={saving === 'org'}
+            value={state.org_value ?? ''}
+            onChange={e => save('org', e.target.value || null)}
+            className="text-xs px-2 py-1 rounded"
+            style={{ background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
+          >
+            <option value="">Use system default ({labelFor(state.global_value || 'general')})</option>
+            {modes.map(m => (
+              <option key={m.id} value={m.id}>{m.label}</option>
+            ))}
+          </select>
+          <div className="text-[11px] mt-1" style={{ color: 'var(--muted)' }}>
+            {state.org_value
+              ? 'Active for everyone in this org.'
+              : `Inherited from system default: ${labelFor(state.global_value || 'general')}.`}
+          </div>
+        </section>
+      )}
+
+      <div className="text-[11px] pt-2" style={{ color: 'var(--muted)', borderTop: '1px solid var(--border)' }}>
+        Currently resolved for you: <b>{labelFor(state.resolved)}</b> (source: {state.source})
+      </div>
+    </div>
+  )
+}
+
 export default function Settings() {
   const isAdmin = useSessionStore(s => s.isAdmin)
-  const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health' | 'account'>(
+  const role = useSessionStore(s => s.role)
+  const canSeeDefaultMode = isAdmin || role === 'admin'
+  const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health' | 'account' | 'default-mode'>(
     isAdmin ? 'core' : 'account',
   )
 
@@ -434,6 +543,19 @@ export default function Settings() {
           >
             Account
           </button>
+          {canSeeDefaultMode && (
+            <button
+              onClick={() => setSection('default-mode')}
+              className="w-full text-left px-2 py-1 rounded text-xs mb-1"
+              style={{
+                background: section === 'default-mode' ? 'var(--panel2)' : 'transparent',
+                color: section === 'default-mode' ? 'var(--accent)' : 'var(--text)',
+                border: 'none', cursor: 'pointer',
+              }}
+            >
+              Default Mode
+            </button>
+          )}
 
           {isAdmin && (
             <>
@@ -502,6 +624,7 @@ export default function Settings() {
               : section === 'core' ? 'Core Settings'
               : section === 'agent' ? 'Agent Settings'
               : section === 'node-health' ? 'Node Health'
+              : section === 'default-mode' ? 'Default Mode'
               : 'Plugin Settings'}
           </h2>
           {section === 'account' && <AccountSection />}
@@ -509,6 +632,7 @@ export default function Settings() {
           {isAdmin && section === 'plugins' && <PluginSettingsForm />}
           {section === 'agent' && <AgentSettingsForm />}
           {section === 'node-health' && <NodeHealthSection />}
+          {section === 'default-mode' && <DefaultModeForm />}
         </div>
       </div>
       <IconRail />

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -435,7 +435,7 @@ function DefaultModeForm() {
   useEffect(() => {
     Promise.all([
       api.get('/v3/modes'),
-      api.get('/v3/settings/default-mode'),
+      api.get('/v3/settings/default_mode'),
     ])
       .then(([modesResp, defResp]) => {
         setModes(modesResp.data as ModeEntry[])
@@ -448,7 +448,7 @@ function DefaultModeForm() {
     setSaving(scope)
     setError(null)
     try {
-      const resp = await api.put('/v3/settings/default-mode', { value, scope })
+      const resp = await api.put('/v3/settings/default_mode', { value, scope })
       setState(resp.data as DefaultModeState)
     } catch (e: any) {
       setError(e?.response?.data?.detail || 'Save failed')

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -65,3 +65,72 @@ def test_invalid_global_value_falls_through_to_general(clean_settings):
         (),
     )
     assert get_default_mode_id(None) == "general"
+
+
+from fastapi.testclient import TestClient
+
+
+def _client_with_user(is_admin: bool = False, role: str = "analyst", org_id: str | None = None):
+    """Build a TestClient + a Bearer token for a freshly created test user."""
+    from app.main import app
+    from app.routers.v3.auth import _make_access_token
+    from app.routers.v3.db import execute
+
+    user_id = str(uuid.uuid4())
+    org = org_id or str(uuid.uuid4())
+    execute(
+        """INSERT INTO ui_users (id, username, email, password_hash, is_active, is_admin, role, org_id)
+           VALUES (%s, %s, %s, '', true, %s, %s, %s)""",
+        (user_id, f"u-{user_id[:8]}", f"{user_id[:8]}@ex.com", is_admin, role, org),
+    )
+    token = _make_access_token(user_id)
+    client = TestClient(app)
+    return client, {"Authorization": f"Bearer {token}"}, user_id, org
+
+
+def test_get_default_mode_returns_fallback(clean_settings):
+    client, headers, _, _ = _client_with_user()
+    r = client.get("/v3/settings/default_mode", headers=headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "resolved": "general",
+        "source": "fallback",
+        "org_value": None,
+        "global_value": None,
+    }
+
+
+def test_get_default_mode_returns_global_when_set(clean_settings):
+    execute(
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'lead_gen', false)",
+        (),
+    )
+    client, headers, _, _ = _client_with_user()
+    r = client.get("/v3/settings/default_mode", headers=headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resolved"] == "lead_gen"
+    assert body["source"] == "global"
+    assert body["org_value"] is None
+    assert body["global_value"] == "lead_gen"
+
+
+def test_get_default_mode_returns_org_override(clean_settings):
+    client, headers, _, org_id = _client_with_user()
+    execute(
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'general', false)",
+        (),
+    )
+    execute(
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'kyc_edd')",
+        (org_id,),
+    )
+    r = client.get("/v3/settings/default_mode", headers=headers)
+    body = r.json()
+    assert body == {
+        "resolved": "kyc_edd",
+        "source": "org",
+        "org_value": "kyc_edd",
+        "global_value": "general",
+    }

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -1,0 +1,67 @@
+"""Tests for default mode resolution (org → global → fallback)."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.modes.loader import get_default_mode_id
+from app.routers.v3.db import execute, fetch_one
+
+
+@pytest.fixture
+def clean_settings():
+    """Wipe default_mode_id rows before and after each test."""
+    execute("DELETE FROM core_settings WHERE key = 'default_mode_id'", ())
+    execute("DELETE FROM org_settings WHERE key = 'default_mode_id'", ())
+    yield
+    execute("DELETE FROM core_settings WHERE key = 'default_mode_id'", ())
+    execute("DELETE FROM org_settings WHERE key = 'default_mode_id'", ())
+
+
+def test_resolution_falls_back_to_general(clean_settings):
+    assert get_default_mode_id(None) == "general"
+    assert get_default_mode_id(str(uuid.uuid4())) == "general"
+
+
+def test_resolution_uses_global(clean_settings):
+    execute(
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'kyc_edd', false)",
+        (),
+    )
+    assert get_default_mode_id(None) == "kyc_edd"
+    assert get_default_mode_id(str(uuid.uuid4())) == "kyc_edd"
+
+
+def test_org_overrides_global(clean_settings):
+    org_id = str(uuid.uuid4())
+    execute(
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'general', false)",
+        (),
+    )
+    execute(
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'lead_gen')",
+        (org_id,),
+    )
+    assert get_default_mode_id(org_id) == "lead_gen"
+
+
+def test_invalid_org_value_falls_through_to_global(clean_settings):
+    org_id = str(uuid.uuid4())
+    execute(
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'lead_gen', false)",
+        (),
+    )
+    execute(
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'bogus_id')",
+        (org_id,),
+    )
+    assert get_default_mode_id(org_id) == "lead_gen"
+
+
+def test_invalid_global_value_falls_through_to_general(clean_settings):
+    execute(
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'bogus_id', false)",
+        (),
+    )
+    assert get_default_mode_id(None) == "general"

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -134,3 +134,79 @@ def test_get_default_mode_returns_org_override(clean_settings):
         "org_value": "kyc_edd",
         "global_value": "general",
     }
+
+
+def test_put_global_requires_is_admin(clean_settings):
+    client, headers, _, _ = _client_with_user(is_admin=False, role="admin")
+    r = client.put(
+        "/v3/settings/default_mode",
+        headers=headers,
+        json={"value": "lead_gen", "scope": "global"},
+    )
+    assert r.status_code == 403
+
+
+def test_put_org_requires_org_admin_role(clean_settings):
+    client, headers, _, _ = _client_with_user(is_admin=False, role="analyst")
+    r = client.put(
+        "/v3/settings/default_mode",
+        headers=headers,
+        json={"value": "lead_gen", "scope": "org"},
+    )
+    assert r.status_code == 403
+
+
+def test_put_rejects_unknown_mode_id(clean_settings):
+    client, headers, _, _ = _client_with_user(is_admin=True)
+    r = client.put(
+        "/v3/settings/default_mode",
+        headers=headers,
+        json={"value": "totally_made_up", "scope": "global"},
+    )
+    assert r.status_code == 400
+
+
+def test_put_global_persists_value(clean_settings):
+    client, headers, _, _ = _client_with_user(is_admin=True)
+    r = client.put(
+        "/v3/settings/default_mode",
+        headers=headers,
+        json={"value": "kyc_edd", "scope": "global"},
+    )
+    assert r.status_code == 200
+    row = fetch_one("SELECT value FROM core_settings WHERE key = 'default_mode_id'", ())
+    assert row["value"] == "kyc_edd"
+
+
+def test_put_org_persists_value(clean_settings):
+    client, headers, _, org_id = _client_with_user(is_admin=False, role="admin")
+    r = client.put(
+        "/v3/settings/default_mode",
+        headers=headers,
+        json={"value": "lead_gen", "scope": "org"},
+    )
+    assert r.status_code == 200
+    row = fetch_one(
+        "SELECT value FROM org_settings WHERE org_id = %s AND key = 'default_mode_id'",
+        (org_id,),
+    )
+    assert row["value"] == "lead_gen"
+
+
+def test_put_org_null_clears_override(clean_settings):
+    client, headers, _, org_id = _client_with_user(is_admin=False, role="admin")
+    execute(
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'lead_gen')",
+        (org_id,),
+    )
+    r = client.put(
+        "/v3/settings/default_mode",
+        headers=headers,
+        json={"value": None, "scope": "org"},
+    )
+    assert r.status_code == 200
+    row = fetch_one(
+        "SELECT value FROM org_settings WHERE org_id = %s AND key = 'default_mode_id'",
+        (org_id,),
+    )
+    assert row is None


### PR DESCRIPTION
## Summary
- Adds two-tier default search mode selection: system-wide default in `core_settings` (set by `is_admin`), per-org override in new `org_settings` table (set by users with `role='admin'`).
- Resolution order: `org_settings.default_mode_id` → `core_settings.default_mode_id` → `'general'`. Invalid stored ids silently fall through.
- New endpoints: `GET` and `PUT [REDACTED:high-entropy-base64:25ch:hash=d1ee1236]`. Existing `/v3/modes` reused for the picker list.
- New Settings UI section "Default Mode" (visible to system admins and org admins). PreflightPanel seeds its initial mode from the resolved default; user manual picks still win, and `estimate.suggested_mode` continues to override on query change.

## Spec / plan
- Spec: `[REDACTED:high-entropy-base64:63ch:hash=f86e5c7a].md`
- Plan: `[REDACTED:high-entropy-base64:61ch:hash=8ed6857c].md`

## Test plan
- [x] 14 new pytest cases in `tests/test_default_mode.py` (5 unit + 3 GET + 6 PUT) — all passing.
- [x] `pnpm tsc --noEmit` clean (matches CI).
- [x] `pnpm build` succeeds (matches CI).
- [ ] Playwright E2E `frontend/e2e/default-mode.spec.ts` — code in place, not run in this branch (requires dev stack). Run with `cd frontend && npx playwright test default-mode.spec.ts` once `localhost:8000` + `localhost:5173` are up.
- [ ] Manual smoke: log in as `admin` → Settings → Default Mode → set to `kyc_edd` → hard refresh → Preflight preselects `kyc_edd`.

## Notes
- The pre-existing failure in `tests/pipeline/fusion/test_dashboard.py::test_build_dashboard_with_data` also fails on `main` and is out of scope.
- Codebase has no "superadmin" role; spec's superadmin maps to `ui_users.is_admin=true`, org admin maps to `role='admin'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)