### PR TITLE
fix: default-mode targets preflight modes; restyle GitHub login button

### DIFF
--- a/app/modes/loader.py
+++ b/app/modes/loader.py
@@ -62,16 +62,21 @@ def _load_file(path: Path) -> Mode:
     return Mode.model_validate(raw)
 
 
-def get_default_mode_id(org_id: str | None) -> str:
-    """Resolve the default mode id for an org. Order: org → global → 'general'.
+_PREFLIGHT_DEFAULT_MODE_ID = "investigation"
 
-    Invalid stored ids (mode no longer bundled) silently fall through to the
-    next tier and ultimately to 'general' so the picker never preselects
-    nothing.
+
+def get_default_mode_id(org_id: str | None) -> str:
+    """Resolve the default preflight mode id for an org. Order: org → global → 'investigation'.
+
+    Validated against the preflight mode catalog (the one the picker renders),
+    NOT against the bundled YAML loop modes — they are separate concepts.
+    Invalid stored ids fall through to the next tier and ultimately to
+    'investigation' so the picker never preselects nothing.
     """
     from app.routers.v3.db import fetch_one  # local import avoids circulars
+    from app.routers.v3.preflight import valid_preflight_mode_ids
 
-    valid_ids = {m.id for m in list_modes()}
+    valid_ids = valid_preflight_mode_ids()
 
     if org_id:
         row = fetch_one(
@@ -88,4 +93,4 @@ def get_default_mode_id(org_id: str | None) -> str:
     if row and row.get("value") and row["value"] in valid_ids:
         return row["value"]
 
-    return _DEFAULT_MODE_ID
+    return _PREFLIGHT_DEFAULT_MODE_ID

--- a/app/routers/v3/preflight.py
+++ b/app/routers/v3/preflight.py
@@ -284,6 +284,15 @@ def _get_wallet_snapshot(user_id: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def valid_preflight_mode_ids() -> set[str]:
+    """Set of mode ids served by GET [REDACTED:high-entropy-base64:23ch:hash=a944149d].
+
+    Used by settings/default_mode to validate user-chosen defaults against the
+    same mode catalog the picker actually renders.
+    """
+    return set(_MODE_META.keys())
+
+
 @router.get("/modes", response_model=list[ModeOut])
 def list_modes(_user: dict = Depends(get_current_user)):
     """Return all 6 optimization modes with their id, label, description, and dial defaults."""

--- a/app/routers/v3/settings.py
+++ b/app/routers/v3/settings.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.crypto import decrypt_value, encrypt_value
-from app.modes.loader import get_default_mode_id, list_modes
+from app.modes.loader import get_default_mode_id
 from app.routers.v3.auth import get_current_user, require_admin
 from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.models import CoreSettingIn, CoreSettingsOut, DefaultModeIn, DefaultModeOut
+from app.routers.v3.preflight import valid_preflight_mode_ids
 
 router = APIRouter(prefix="/v3/settings", tags=["v3-settings"])
 
@@ -105,9 +106,10 @@ def put_default_mode(
         if not user.get("org_id"):
             raise HTTPException(status_code=400, detail="User has no org")
 
-    # Validate value (None means clear)
+    # Validate value (None means clear). Validate against the preflight mode
+    # catalog — these are the ids the picker actually renders.
     if body.value is not None:
-        valid = {m.id for m in list_modes()}
+        valid = valid_preflight_mode_ids()
         if body.value not in valid:
             raise HTTPException(
                 status_code=400,

--- a/frontend/e2e/default-mode.spec.ts
+++ b/frontend/e2e/default-mode.spec.ts
@@ -18,20 +18,31 @@ test('admin sets global default mode and Preflight preselects it', async ({ page
   // Reset state
   await req.put(`${API}/v3/settings/default_mode`, {
     headers: { Authorization: `Bearer ${token}` },
-    data: { value: 'lead_gen', scope: 'global' },
+    data: { value: 'leads_generation', scope: 'global' },
   })
 
-  // Log in via the UI so the session store is populated.
-  // The login form uses placeholder text (no aria-label), so we target by name attribute.
+  // Skip the UI login — inject the access token into localStorage so the session
+  // store reads it on mount. (UI login is exercised elsewhere; not under test here.)
+  const loginResp = await req.post(`${API}/v3/auth/login`, {
+    data: { username: 'admin', password: process.env.ADMIN_PASSWORD || 'admin' },
+  })
+  const tokens = await loginResp.json()
   await page.goto(`${APP}/login`)
-  await page.locator('input[name="username"]').fill('admin')
-  await page.locator('input[name="password"]').fill(process.env.ADMIN_PASSWORD || 'admin')
-  await page.getByRole('button', { name: /sign in/i }).click()
+  await page.evaluate((t) => {
+    localStorage.setItem('access_token', t.access_token)
+    localStorage.setItem('refresh_token', t.refresh_token)
+  }, tokens)
 
-  // PreflightPanel lives on the Dashboard (/) via AgentChat — there is no /search route.
-  await page.goto(`${APP}/`)
+  // PreflightPanel lives inside AgentChat on the Research page, after a query is submitted.
+  await page.goto(`${APP}/research`)
+  const queryBox = page.getByPlaceholder(/Ask info-broker/i)
+  await queryBox.waitFor({ timeout: 10_000 })
+  await queryBox.fill('verify default mode')
+  await queryBox.press('Enter')
+
+  // Once Preflight renders, the mode picker chips should be present and leads_generation preselected.
   await page.waitForSelector('[data-mode-id]', { timeout: 10_000 })
-  await expect(page.locator('[data-mode-id="lead_gen"][aria-pressed="true"]'))
+  await expect(page.locator('[data-mode-id="leads_generation"][aria-pressed="true"]'))
     .toBeVisible({ timeout: 10_000 })
 
   // Cleanup — clear the global default

--- a/frontend/src/components/preflight/PreflightPanel.tsx
+++ b/frontend/src/components/preflight/PreflightPanel.tsx
@@ -134,7 +134,7 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
 
   useEffect(() => {
     let cancelled = false
-    api.get('[REDACTED:high-entropy-base64:25ch:hash=d1ee1236]')
+    api.get('/v3/settings/default_mode')
       .then(r => { if (!cancelled) setDefaultMode((r.data as { resolved: string }).resolved) })
       .catch(() => { /* fall back to current state */ })
     return () => { cancelled = true }
@@ -169,10 +169,15 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
     runPreflightDebounced()
   }, [speed, capability, resource, hypothesisCount, depth]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Sync hypothesis_count if backend upgraded it (strategy floor enforcement)
+  // Sync hypothesis_count if backend upgraded it (strategy floor enforcement).
+  // The backend's suggested_mode is treated as a *recommendation* — the user's
+  // configured default (or manual pick) takes precedence. Suggested_mode only
+  // applies when the user has no default set and hasn't manually picked.
   useEffect(() => {
     if (estimate) {
-      setMode(estimate.suggested_mode)
+      if (!defaultMode && !userTouchedMode) {
+        setMode(estimate.suggested_mode)
+      }
       if (estimate.envelope.hypothesis_count !== hypothesisCount) {
         setHypothesisCount(estimate.envelope.hypothesis_count as DialsIn['hypothesis_count'])
       }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -184,18 +184,26 @@ export default function Login() {
                 Continue with Google
               </Button>
             )}
-            <Button
+            <button
               type="button"
-              variant="outline"
               onClick={() => startOAuth('github')}
-              className="w-full gap-2 text-sm"
-              style={{ borderColor: 'var(--border)', color: providers.github ? 'var(--text)' : 'var(--subtext)', background: 'transparent' }}
               disabled={!providers.github}
               title={providers.github ? 'Continue with your GitHub account' : 'GitHub login — not configured'}
+              className="w-full inline-flex items-center justify-center gap-2 text-sm font-semibold rounded-md px-4 py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: '#24292e',
+                color: '#ffffff',
+                border: '1px solid #24292e',
+                cursor: providers.github ? 'pointer' : 'not-allowed',
+              }}
+              onMouseEnter={e => { if (providers.github) e.currentTarget.style.background = '#1b1f23' }}
+              onMouseLeave={e => { if (providers.github) e.currentTarget.style.background = '#24292e' }}
             >
-              <GithubIcon />
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 .5C5.65.5.5 5.65.5 12.02c0 5.1 3.29 9.42 7.86 10.95.57.1.78-.25.78-.55v-1.93c-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.27-1.68-1.27-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.7 1.25 3.36.96.1-.74.4-1.25.73-1.54-2.55-.29-5.23-1.28-5.23-5.71 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.18 1.18a11.04 11.04 0 0 1 5.79 0c2.21-1.49 3.18-1.18 3.18-1.18.62 1.58.23 2.75.11 3.04.74.8 1.18 1.83 1.18 3.09 0 4.43-2.69 5.41-5.25 5.7.41.36.78 1.07.78 2.16v3.2c0 .31.21.66.79.55C20.21 21.43 23.5 17.12 23.5 12.02 23.5 5.65 18.35.5 12 .5Z"/>
+              </svg>
               Continue with GitHub
-            </Button>
+            </button>
           </div>
 
           <div className="flex items-center gap-3 mb-5">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -434,7 +434,7 @@ function DefaultModeForm() {
 
   useEffect(() => {
     Promise.all([
-      api.get('/v3/modes'),
+      api.get('/v3/preflight/modes'),
       api.get('/v3/settings/default_mode'),
     ])
       .then(([modesResp, defResp]) => {
@@ -476,7 +476,7 @@ function DefaultModeForm() {
             className="text-xs px-2 py-1 rounded"
             style={{ background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
           >
-            <option value="">— not set (uses fallback: general) —</option>
+            <option value="">— not set (uses fallback: investigation) —</option>
             {modes.map(m => (
               <option key={m.id} value={m.id}>{m.label}</option>
             ))}
@@ -499,7 +499,7 @@ function DefaultModeForm() {
             className="text-xs px-2 py-1 rounded"
             style={{ background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
           >
-            <option value="">Use system default ({labelFor(state.global_value || 'general')})</option>
+            <option value="">Use system default ({labelFor(state.global_value || 'investigation')})</option>
             {modes.map(m => (
               <option key={m.id} value={m.id}>{m.label}</option>
             ))}
@@ -507,7 +507,7 @@ function DefaultModeForm() {
           <div className="text-[11px] mt-1" style={{ color: 'var(--muted)' }}>
             {state.org_value
               ? 'Active for everyone in this org.'
-              : `Inherited from system default: ${labelFor(state.global_value || 'general')}.`}
+              : `Inherited from system default: ${labelFor(state.global_value || 'investigation')}.`}
           </div>
         </section>
       )}

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -20,43 +20,43 @@ def clean_settings():
 
 
 def test_resolution_falls_back_to_general(clean_settings):
-    assert get_default_mode_id(None) == "general"
-    assert get_default_mode_id(str(uuid.uuid4())) == "general"
+    assert get_default_mode_id(None) == "investigation"
+    assert get_default_mode_id(str(uuid.uuid4())) == "investigation"
 
 
 def test_resolution_uses_global(clean_settings):
     execute(
-        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'kyc_edd', false)",
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'quick_lookup', false)",
         (),
     )
-    assert get_default_mode_id(None) == "kyc_edd"
-    assert get_default_mode_id(str(uuid.uuid4())) == "kyc_edd"
+    assert get_default_mode_id(None) == "quick_lookup"
+    assert get_default_mode_id(str(uuid.uuid4())) == "quick_lookup"
 
 
 def test_org_overrides_global(clean_settings):
     org_id = str(uuid.uuid4())
     execute(
-        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'general', false)",
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'investigation', false)",
         (),
     )
     execute(
-        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'lead_gen')",
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'leads_generation')",
         (org_id,),
     )
-    assert get_default_mode_id(org_id) == "lead_gen"
+    assert get_default_mode_id(org_id) == "leads_generation"
 
 
 def test_invalid_org_value_falls_through_to_global(clean_settings):
     org_id = str(uuid.uuid4())
     execute(
-        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'lead_gen', false)",
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'leads_generation', false)",
         (),
     )
     execute(
         "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'bogus_id')",
         (org_id,),
     )
-    assert get_default_mode_id(org_id) == "lead_gen"
+    assert get_default_mode_id(org_id) == "leads_generation"
 
 
 def test_invalid_global_value_falls_through_to_general(clean_settings):
@@ -64,7 +64,7 @@ def test_invalid_global_value_falls_through_to_general(clean_settings):
         "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'bogus_id', false)",
         (),
     )
-    assert get_default_mode_id(None) == "general"
+    assert get_default_mode_id(None) == "investigation"
 
 
 from fastapi.testclient import TestClient
@@ -94,7 +94,7 @@ def test_get_default_mode_returns_fallback(clean_settings):
     assert r.status_code == 200
     body = r.json()
     assert body == {
-        "resolved": "general",
+        "resolved": "investigation",
         "source": "fallback",
         "org_value": None,
         "global_value": None,
@@ -103,36 +103,36 @@ def test_get_default_mode_returns_fallback(clean_settings):
 
 def test_get_default_mode_returns_global_when_set(clean_settings):
     execute(
-        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'lead_gen', false)",
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'leads_generation', false)",
         (),
     )
     client, headers, _, _ = _client_with_user()
     r = client.get("/v3/settings/default_mode", headers=headers)
     assert r.status_code == 200
     body = r.json()
-    assert body["resolved"] == "lead_gen"
+    assert body["resolved"] == "leads_generation"
     assert body["source"] == "global"
     assert body["org_value"] is None
-    assert body["global_value"] == "lead_gen"
+    assert body["global_value"] == "leads_generation"
 
 
 def test_get_default_mode_returns_org_override(clean_settings):
     client, headers, _, org_id = _client_with_user()
     execute(
-        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'general', false)",
+        "INSERT INTO core_settings (key, value, is_secret) VALUES ('default_mode_id', 'investigation', false)",
         (),
     )
     execute(
-        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'kyc_edd')",
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'quick_lookup')",
         (org_id,),
     )
     r = client.get("/v3/settings/default_mode", headers=headers)
     body = r.json()
     assert body == {
-        "resolved": "kyc_edd",
+        "resolved": "quick_lookup",
         "source": "org",
-        "org_value": "kyc_edd",
-        "global_value": "general",
+        "org_value": "quick_lookup",
+        "global_value": "investigation",
     }
 
 
@@ -141,7 +141,7 @@ def test_put_global_requires_is_admin(clean_settings):
     r = client.put(
         "/v3/settings/default_mode",
         headers=headers,
-        json={"value": "lead_gen", "scope": "global"},
+        json={"value": "leads_generation", "scope": "global"},
     )
     assert r.status_code == 403
 
@@ -151,7 +151,7 @@ def test_put_org_requires_org_admin_role(clean_settings):
     r = client.put(
         "/v3/settings/default_mode",
         headers=headers,
-        json={"value": "lead_gen", "scope": "org"},
+        json={"value": "leads_generation", "scope": "org"},
     )
     assert r.status_code == 403
 
@@ -171,11 +171,11 @@ def test_put_global_persists_value(clean_settings):
     r = client.put(
         "/v3/settings/default_mode",
         headers=headers,
-        json={"value": "kyc_edd", "scope": "global"},
+        json={"value": "quick_lookup", "scope": "global"},
     )
     assert r.status_code == 200
     row = fetch_one("SELECT value FROM core_settings WHERE key = 'default_mode_id'", ())
-    assert row["value"] == "kyc_edd"
+    assert row["value"] == "quick_lookup"
 
 
 def test_put_org_persists_value(clean_settings):
@@ -183,20 +183,20 @@ def test_put_org_persists_value(clean_settings):
     r = client.put(
         "/v3/settings/default_mode",
         headers=headers,
-        json={"value": "lead_gen", "scope": "org"},
+        json={"value": "leads_generation", "scope": "org"},
     )
     assert r.status_code == 200
     row = fetch_one(
         "SELECT value FROM org_settings WHERE org_id = %s AND key = 'default_mode_id'",
         (org_id,),
     )
-    assert row["value"] == "lead_gen"
+    assert row["value"] == "leads_generation"
 
 
 def test_put_org_null_clears_override(clean_settings):
     client, headers, _, org_id = _client_with_user(is_admin=False, role="admin")
     execute(
-        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'lead_gen')",
+        "INSERT INTO org_settings (org_id, key, value) VALUES (%s, 'default_mode_id', 'leads_generation')",
         (org_id,),
     )
     r = client.put(


### PR DESCRIPTION
## Summary

Two follow-up fixes after PR #98, both verified locally end-to-end.

### A. Default-mode feature targeted the wrong mode system

PR #98 wired the default-mode picker against the bundled YAML loop modes (4 ids: `general`, `lead_gen`, `kyc_edd`, `competitive_intel`) returned by `/v3/modes`. But the picker chips that actually render in PreflightPanel come from `/v3/preflight/modes` — a different catalog of 6 ids (`investigation`, `leads_generation`, `academic_research`, `data_retrieval`, `market_analysis`, `quick_lookup`). So no preselection ever matched.

Changes:
- Backend validation switched to `valid_preflight_mode_ids()` (new helper in `app/routers/v3/preflight.py`).
- `get_default_mode_id` fallback now `investigation`, not `general`.
- Settings UI fetches `/v3/preflight/modes` for the dropdown.
- `PreflightPanel` treats backend `suggested_mode` as a recommendation only — the user's configured default (or manual pick) now wins.
- Tests + e2e spec updated to use real preflight mode ids.

### B. GitHub login button restyled

Replaced the generic outlined button with the standard "Sign in with GitHub" treatment: `#24292e` dark background, white text, official octocat SVG.

## Verification (done locally before opening PR)

- 14/14 pytest cases in `tests/test_default_mode.py` pass against the running container.
- `pnpm tsc --noEmit` clean; `pnpm build` succeeds.
- `frontend/e2e/default-mode.spec.ts` passes end-to-end against the live dev stack.
- Manual screenshot of the login page confirms the GitHub button restyle.
- API smoke: `PUT [REDACTED:high-entropy-base64:25ch:hash=d1ee1236]` with a preflight id returns 200, with a YAML loop id returns 400.

## Test plan

- [x] Backend pytest (14 tests)
- [x] Playwright e2e default-mode preselection
- [x] tsc + build green
- [x] Manual login button visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)