### PR TITLE
fix(mcp): web_crawl + whois node-execute bugs (#110, #111)

### DIFF
--- a/app/pipeline/nodes/web_crawl.py
+++ b/app/pipeline/nodes/web_crawl.py
@@ -83,7 +83,64 @@ class WebCrawlNode:
     async def execute(
         self, config: dict, inputs: list[dict], context: RunContext
     ) -> list[dict]:
-        return []
+        """Crawl the target URL(s) and return parsed page content.
+
+        Target URLs come from ``config['urls']`` / ``config['url']`` (ad-hoc and
+        MCP callers) and/or from upstream items' ``url`` / ``urls`` fields
+        (pipeline usage). Previously this returned ``[]`` unconditionally, so
+        the MCP ``run_web_crawl`` tool — which routes through this endpoint —
+        always reported success with zero results (see issue #110).
+        """
+        allowed_domains = config.get("allowed_domains", [])
+        max_pages = int(config.get("max_pages", 10))
+        scrape_depth = int(config.get("scrape_depth", 1))
+        delay_seconds = float(config.get("delay_seconds", 1.0))
+        respect_robots = bool(config.get("respect_robots", True))
+        extract_mode = config.get("extract_mode", "text")
+
+        # Collect target URLs from config and upstream items, deduped in order.
+        targets: list[str] = []
+
+        def _add(value: object) -> None:
+            if isinstance(value, str) and value.strip():
+                targets.append(value.strip())
+            elif isinstance(value, list):
+                for v in value:
+                    if isinstance(v, str) and v.strip():
+                        targets.append(v.strip())
+
+        _add(config.get("urls"))
+        _add(config.get("url"))
+        for item in inputs:
+            _add(item.get("url"))
+            _add(item.get("urls"))
+
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for url in targets:
+            if url not in seen:
+                seen.add(url)
+                ordered.append(url)
+
+        if not ordered:
+            return []
+
+        loop = asyncio.get_running_loop()
+        results: list[dict] = []
+        for url in ordered:
+            crawled = await loop.run_in_executor(
+                None,
+                _crawl,
+                url,
+                allowed_domains,
+                max_pages,
+                scrape_depth,
+                delay_seconds,
+                respect_robots,
+                extract_mode,
+            )
+            results.extend(crawled)
+        return results
 
     # -- ToolCallable interface ------------------------------------------------
 

--- a/app/routers/v3/nodes_api.py
+++ b/app/routers/v3/nodes_api.py
@@ -17,6 +17,56 @@ from app.routers.v3.stream import push_event
 router = APIRouter(prefix="/v3/nodes", tags=["v3-nodes"])
 log = logging.getLogger(__name__)
 
+# Per-item target fields that ad-hoc / MCP callers pass at the top level of an
+# /execute payload instead of inside an explicit `inputs` list. When one of
+# these is present and no `inputs` were given, the payload is wrapped as a
+# single upstream item so nodes that read these fields per-item receive their
+# target. Pure config keys (research_goal, criteria, instructions, ...) are
+# intentionally absent so config-only nodes keep their empty-inputs behaviour.
+_INPUT_TARGET_FIELDS = frozenset(
+    {
+        "query",
+        "domain",
+        "url",
+        "urls",
+        "website",
+        "company_name",
+        "company",
+        "full_name",
+        "name",
+        "username",
+        "title",
+        "email",
+        "phone",
+    }
+)
+
+
+def _wrap_payload_as_input(inputs: list[dict], body: dict) -> list[dict]:
+    """Wrap an ad-hoc /execute payload as a single upstream item when needed.
+
+    Ad-hoc callers (the MCP server, manual API calls) pass the node's target as
+    top-level fields rather than an explicit ``inputs`` list — e.g.
+    ``{"query": ...}`` for search nodes, ``{"domain": ...}`` for whois,
+    ``{"urls": [...]}`` for web_crawl. Nodes read their target from each upstream
+    item (``item["query"]``, ``item["domain"]``, ``item["url"]``, ...), so when
+    no explicit inputs are given but the payload carries a recognised target
+    field, the payload is wrapped as a single upstream item. ``body`` is still
+    passed through as config; nodes read only the keys they need from each side.
+
+    Without this, enrich nodes such as whois_lookup iterate an empty inputs list
+    and return zero items while the endpoint still reports ``status: success``
+    (see issue #111).
+
+    The allowlist is deliberately limited to per-item target fields. Pure config
+    keys (``research_goal``, ``criteria``, ``instructions``, ...) are excluded so
+    config-only nodes that synthesise their own input when ``inputs`` is empty
+    (intelligent_search, ai_scoring, summarizer) keep working unchanged.
+    """
+    if not inputs and any(k in body for k in _INPUT_TARGET_FIELDS):
+        return [dict(body)]
+    return inputs
+
 
 def _get_node(node_type: str):
     NodeRegistry.auto_discover()
@@ -48,10 +98,7 @@ async def execute_node(
     # Allow caller to pass inputs alongside config in the same payload.
     inputs: list[dict] = body.pop("inputs", [])
 
-    # For source/search nodes that accept a bare `query`, wrap it as an input
-    # item so the node can iterate over it.
-    if not inputs and "query" in body:
-        inputs = [{"query": body["query"]}]
+    inputs = _wrap_payload_as_input(inputs, body)
 
     ctx = RunContext(
         user_id="mcp-system",

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 from mcp.server.fastmcp import FastMCP
 
@@ -87,14 +88,38 @@ async def run_web_crawl(
 ) -> str:
     """Crawl one or more web pages and return their parsed text content.
 
-    urls: JSON array of URL strings.
+    urls: a JSON array of URL strings (e.g. ``["https://a.com", "https://b.com"]``),
+    a single bare URL, or a comma/whitespace-separated list. All forms are
+    accepted — a bare URL no longer raises a JSON decode error (see issue #110).
     """
+    url_list = _parse_url_arg(urls)
     result = await api_call(
         "POST",
         "/v3/nodes/web_crawl/execute",
-        json={"urls": json.loads(urls), "max_pages": max_pages, "scrape_depth": scrape_depth},
+        json={"urls": url_list, "max_pages": max_pages, "scrape_depth": scrape_depth},
     )
     return json.dumps(result)
+
+
+def _parse_url_arg(urls: str) -> list[str]:
+    """Coerce the ``urls`` tool argument into a list of URL strings.
+
+    The brain sometimes passes a JSON array string, but often passes a single
+    bare URL or a comma/whitespace-separated list. ``json.loads`` raised
+    ``JSONDecodeError`` on the bare-URL form before any HTTP call (issue #110);
+    this tolerates all three.
+    """
+    try:
+        parsed = json.loads(urls)
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+
+    if isinstance(parsed, list):
+        return [str(u).strip() for u in parsed if str(u).strip()]
+    if isinstance(parsed, str) and parsed.strip():
+        return [parsed.strip()]
+    # Bare string, or comma/whitespace-separated list.
+    return [u.strip() for u in re.split(r"[,\s]+", urls) if u.strip()]
 
 
 @mcp.tool()

--- a/tests/pipeline/nodes/test_web_crawl.py
+++ b/tests/pipeline/nodes/test_web_crawl.py
@@ -366,6 +366,71 @@ def test_crawl_extract_mode_markdown(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# execute() — actually crawls (regression for issue #110)
+#
+# Before the fix, WebCrawlNode.execute() returned [] unconditionally, so the
+# MCP run_web_crawl tool (which routes through /v3/nodes/web_crawl/execute)
+# always reported success with zero results.
+# ---------------------------------------------------------------------------
+
+def _patch_crawl(monkeypatch):
+    """Replace _crawl with a stub that records calls and returns one item/url."""
+    calls: list[str] = []
+
+    def fake_crawl(url, *args, **kwargs):
+        calls.append(url)
+        return [{"url": url, "content": f"content of {url}", "source": "web_crawl"}]
+
+    monkeypatch.setattr("app.pipeline.nodes.web_crawl._crawl", fake_crawl)
+    return calls
+
+
+def test_execute_crawls_urls_from_config_list(monkeypatch):
+    calls = _patch_crawl(monkeypatch)
+    node = WebCrawlNode()
+    results = _arun(
+        node.execute(
+            {"urls": ["https://a.com", "https://b.com"]}, [], _ctx()
+        )
+    )
+    assert calls == ["https://a.com", "https://b.com"]
+    assert [r["url"] for r in results] == ["https://a.com", "https://b.com"]
+
+
+def test_execute_crawls_singular_url_from_config(monkeypatch):
+    calls = _patch_crawl(monkeypatch)
+    node = WebCrawlNode()
+    results = _arun(node.execute({"url": "https://a.com"}, [], _ctx()))
+    assert calls == ["https://a.com"]
+    assert len(results) == 1
+
+
+def test_execute_reads_urls_from_upstream_items(monkeypatch):
+    calls = _patch_crawl(monkeypatch)
+    node = WebCrawlNode()
+    results = _arun(
+        node.execute({}, [{"url": "https://a.com"}, {"url": "https://b.com"}], _ctx())
+    )
+    assert calls == ["https://a.com", "https://b.com"]
+    assert len(results) == 2
+
+
+def test_execute_dedupes_urls_across_config_and_inputs(monkeypatch):
+    calls = _patch_crawl(monkeypatch)
+    node = WebCrawlNode()
+    _arun(node.execute({"urls": ["https://a.com"]}, [{"url": "https://a.com"}], _ctx()))
+    assert calls == ["https://a.com"]  # crawled once, not twice
+
+
+def test_execute_no_targets_returns_empty(monkeypatch):
+    calls = _patch_crawl(monkeypatch)
+    node = WebCrawlNode()
+    results = _arun(node.execute({}, [], _ctx()))
+    assert results == []
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
 # Node metadata preserved
 # ---------------------------------------------------------------------------
 
@@ -373,4 +438,4 @@ def test_node_metadata():
     node = WebCrawlNode()
     assert node.node_type == "web_crawl"
     assert node.display_name == "Web Crawl"
-    assert node.category == "datastore"
+    assert node.category == "source"

--- a/tests/test_mcp_url_parsing.py
+++ b/tests/test_mcp_url_parsing.py
@@ -1,0 +1,50 @@
+"""Regression tests for the MCP run_web_crawl URL-argument parsing (issue #110).
+
+The brain often passes ``urls`` as a single bare URL or a comma/whitespace list
+rather than a JSON array string. ``json.loads`` raised JSONDecodeError on the
+bare-URL form *before any HTTP call*. _parse_url_arg tolerates all forms.
+"""
+from __future__ import annotations
+
+import pytest
+
+mcp_server = pytest.importorskip("mcp_server.server")
+_parse_url_arg = mcp_server._parse_url_arg
+
+
+def test_json_array_string():
+    assert _parse_url_arg('["https://a.com", "https://b.com"]') == [
+        "https://a.com",
+        "https://b.com",
+    ]
+
+
+def test_bare_url_no_longer_crashes():
+    # This input previously raised json.JSONDecodeError before any HTTP call.
+    assert _parse_url_arg("https://example.com") == ["https://example.com"]
+
+
+def test_json_quoted_single_url():
+    assert _parse_url_arg('"https://example.com"') == ["https://example.com"]
+
+
+def test_comma_separated():
+    assert _parse_url_arg("https://a.com, https://b.com") == [
+        "https://a.com",
+        "https://b.com",
+    ]
+
+
+def test_whitespace_separated():
+    assert _parse_url_arg("https://a.com  https://b.com") == [
+        "https://a.com",
+        "https://b.com",
+    ]
+
+
+def test_blank_entries_dropped():
+    assert _parse_url_arg('["https://a.com", "", "  "]') == ["https://a.com"]
+
+
+def test_empty_string_returns_empty_list():
+    assert _parse_url_arg("") == []

--- a/tests/v3/test_nodes_api_input_wrapping.py
+++ b/tests/v3/test_nodes_api_input_wrapping.py
@@ -1,0 +1,60 @@
+"""Regression tests for /v3/nodes/{node}/execute input wrapping (issue #111).
+
+Ad-hoc/MCP callers pass a node's target as top-level payload fields rather than
+an explicit ``inputs`` list. The endpoint must wrap recognised target fields
+(query/domain/url/...) as a single upstream item so enrich nodes receive their
+target — while leaving pure config-only payloads (research_goal, criteria, ...)
+untouched so config-only nodes keep synthesising their own input.
+"""
+from __future__ import annotations
+
+from app.routers.v3.nodes_api import _INPUT_TARGET_FIELDS, _wrap_payload_as_input
+
+
+def test_explicit_inputs_are_never_overwritten():
+    explicit = [{"query": "real input"}]
+    assert _wrap_payload_as_input(explicit, {"domain": "x.com"}) is explicit
+
+
+def test_domain_payload_is_wrapped():
+    # The whois bug: domain stayed in config, inputs was empty -> zero items.
+    assert _wrap_payload_as_input([], {"domain": "example.com"}) == [
+        {"domain": "example.com"}
+    ]
+
+
+def test_query_payload_is_wrapped():
+    assert _wrap_payload_as_input([], {"query": "openai", "max_results": 3}) == [
+        {"query": "openai", "max_results": 3}
+    ]
+
+
+def test_urls_payload_is_wrapped():
+    assert _wrap_payload_as_input([], {"urls": ["https://a.com"]}) == [
+        {"urls": ["https://a.com"]}
+    ]
+
+
+def test_config_only_payload_is_not_wrapped():
+    # research_goal is a config key, not a per-item target: must stay empty so
+    # intelligent_search/ai_scoring/summarizer keep their empty-inputs behaviour.
+    assert _wrap_payload_as_input([], {"research_goal": "find founders"}) == []
+    assert _wrap_payload_as_input([], {"criteria": "relevance", "threshold": 50}) == []
+
+
+def test_empty_body_is_not_wrapped():
+    assert _wrap_payload_as_input([], {}) == []
+
+
+def test_wrapped_item_is_a_copy_not_the_body():
+    body = {"domain": "example.com"}
+    wrapped = _wrap_payload_as_input([], body)
+    wrapped[0]["domain"] = "mutated"
+    assert body["domain"] == "example.com"  # config dict untouched
+
+
+def test_config_keys_excluded_from_target_allowlist():
+    # Guard against accidentally adding a config key that would regress the
+    # empty-inputs-branching nodes.
+    for forbidden in ("research_goal", "criteria", "instructions", "score_field"):
+        assert forbidden not in _INPUT_TARGET_FIELDS


### PR DESCRIPTION
## Summary

Two MCP node tools silently returned `status=success` with **zero items**, root-caused and fixed with live-stack verification.

Closes #110. Closes #111.

### #111 — `run_whois_lookup` returns success with zero items
`POST /v3/nodes/{node}/execute` only wrapped a bare `query` field into the `inputs` list. The MCP whois tool passes its target as `domain`, so it stayed in the config dict and the node iterated an **empty** `inputs` list → 0 items, but the endpoint still reported `status: success`.

**Fix:** generalise the wrap to an allowlist of per-item target fields (`query`, `domain`, `url`, `urls`, `website`, `company_name`, ...), extracted into `_wrap_payload_as_input`. Config-only keys (`research_goal`, `criteria`, `instructions`, ...) are **deliberately excluded** so the config-only nodes that synthesise their own input when `inputs` is empty (`intelligent_search`, `ai_scoring`, `summarizer`) keep working unchanged.

### #110 — `run_web_crawl` JSON decode error before any HTTP call
Two faults:
1. The MCP `run_web_crawl` wrapper did `json.loads(urls)`, raising `JSONDecodeError` on a bare-URL string **before any HTTP call**. Now `_parse_url_arg` tolerates a JSON array string, a single bare URL, and comma/whitespace-separated lists.
2. `WebCrawlNode.execute()` was a **stub returning `[]`** — the real crawl logic only lived in `tool_invoke`. So the `/execute` path (which the MCP tool uses) never crawled. `execute()` now gathers target URLs from config (`urls`/`url`) and upstream items (deduped, order-preserving) and crawls each via the existing `_crawl`.

## Verification (live local stack)
Reproduced both bugs (`count: 0, status: success`) on `main`, then after the fix:

| Call | Before | After |
|---|---|---|
| whois `{"domain":"example.com"}` | `count: 0` | `count: 1` (registrar + creation/expiration dates) |
| web_crawl `{"urls":["https://example.com"]}` | `count: 0` | `count: 1` (page content) |
| **regression** web_crawl `{"url":...}` (singular) | — | `count: 1` |
| **regression** intelligent_search `{"research_goal":...}` | `count: 1` | `count: 1` (synth query preserved, not a stringified dict) |

## Tests
- `tests/v3/test_nodes_api_input_wrapping.py` (new) — wrap target fields, leave config-only payloads untouched, copy-not-alias the body, guard the allowlist against config keys.
- `tests/test_mcp_url_parsing.py` (new) — JSON array / bare URL / quoted / comma / whitespace forms.
- `tests/pipeline/nodes/test_web_crawl.py` — added `execute()` coverage (config list, singular url, upstream items, dedup, empty). Also corrected a stale `category` assertion (`datastore` → `source`, matching the code).

`49 passed` locally; `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)