### PR TITLE
fix(lint): resolve 24 ruff S608 SQL-injection warnings after security review (#94)

### DIFF
--- a/app/knowledge/materializer.py
+++ b/app/knowledge/materializer.py
@@ -20,7 +20,7 @@ class GraphMaterializer:
     # ------------------------------------------------------------------
 
     def _get_checkpoint(self, key: str) -> Optional[datetime]:
-        row = fetch_one(f"SELECT {key} FROM graph_materializer_state WHERE id = 1")
+        row = fetch_one(f"SELECT {key} FROM graph_materializer_state WHERE id = 1")  # noqa: S608 - column name from hardcoded literal (last_*_obs_at); value parameterized
         if row and row.get(key):
             val = row[key]
             # psycopg2 returns aware datetime directly for TIMESTAMPTZ
@@ -29,7 +29,7 @@ class GraphMaterializer:
 
     def _update_checkpoint(self, key: str, ts: datetime) -> None:
         execute(
-            f"UPDATE graph_materializer_state SET {key} = %s WHERE id = 1",
+            f"UPDATE graph_materializer_state SET {key} = %s WHERE id = 1",  # noqa: S608 - column name from hardcoded literal (last_*_obs_at); value parameterized
             (ts,),
         )
 

--- a/app/memory/retriever.py
+++ b/app/memory/retriever.py
@@ -62,7 +62,7 @@ def _track_access(run_ids: list[str]) -> None:
             f"""UPDATE entity_observations
                 SET last_accessed_at = now()
                 WHERE source_run_id IN ({placeholders})
-                  AND (last_accessed_at IS NULL OR last_accessed_at < now() - interval '1 hour')""",
+                  AND (last_accessed_at IS NULL OR last_accessed_at < now() - interval '1 hour')""",  # noqa: S608 - IN(...) is %s placeholders sized to run_ids; values parameterized
             tuple(run_ids),
         )
     except Exception:

--- a/app/routers/v3/admin_api.py
+++ b/app/routers/v3/admin_api.py
@@ -37,7 +37,7 @@ def list_sessions(
                   context, started_at, finished_at
             FROM mcp_sessions
             WHERE status = %s {scope_sql}
-            ORDER BY started_at DESC LIMIT %s""",
+            ORDER BY started_at DESC LIMIT %s""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
             (status, *scope_params, limit),
         )
     else:
@@ -46,7 +46,7 @@ def list_sessions(
                   context, started_at, finished_at
             FROM mcp_sessions
             WHERE 1=1 {scope_sql}
-            ORDER BY started_at DESC LIMIT %s""",
+            ORDER BY started_at DESC LIMIT %s""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
             (*scope_params, limit),
         )
     return [dict(r) for r in rows]
@@ -59,7 +59,7 @@ def get_session(session_id: str, user: dict = Depends(get_current_user)):
         f"""SELECT id, caller_identity, session_type, status, tool_call_count,
               context, started_at, finished_at, user_id
         FROM mcp_sessions
-        WHERE id = %s {scope_sql}""",
+        WHERE id = %s {scope_sql}""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         (session_id, *scope_params),
     )
     if not session:
@@ -79,11 +79,11 @@ def get_session(session_id: str, user: dict = Depends(get_current_user)):
 def get_dashboard(user: dict = Depends(get_current_user)):
     scope_sql, scope_params = _user_scope(user)
     active = fetch_one(
-        f"SELECT COUNT(*) AS cnt FROM mcp_sessions WHERE status = 'active' {scope_sql}",
+        f"SELECT COUNT(*) AS cnt FROM mcp_sessions WHERE status = 'active' {scope_sql}",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         scope_params,
     )
     total_calls = fetch_one(
-        f"SELECT COUNT(*) AS cnt FROM mcp_tool_calls WHERE 1=1 {scope_sql}",
+        f"SELECT COUNT(*) AS cnt FROM mcp_tool_calls WHERE 1=1 {scope_sql}",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         scope_params,
     )
     error_rate = fetch_one(
@@ -91,21 +91,21 @@ def get_dashboard(user: dict = Depends(get_current_user)):
             COUNT(*) FILTER (WHERE status = 'failed') AS errors,
             COUNT(*) AS total
         FROM mcp_tool_calls
-        WHERE created_at > now() - interval '1 hour' {scope_sql}""",
+        WHERE created_at > now() - interval '1 hour' {scope_sql}""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         scope_params,
     )
     avg_duration = fetch_one(
         f"""SELECT AVG(duration_ms) AS avg_ms
         FROM mcp_tool_calls
         WHERE status = 'succeeded'
-          AND created_at > now() - interval '1 hour' {scope_sql}""",
+          AND created_at > now() - interval '1 hour' {scope_sql}""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         scope_params,
     )
     top_tools = fetch_all(
         f"""SELECT tool_name, COUNT(*) AS call_count, AVG(duration_ms) AS avg_ms
         FROM mcp_tool_calls
         WHERE created_at > now() - interval '24 hours' {scope_sql}
-        GROUP BY tool_name ORDER BY call_count DESC LIMIT 10""",
+        GROUP BY tool_name ORDER BY call_count DESC LIMIT 10""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         scope_params,
     )
     return {
@@ -132,7 +132,7 @@ def get_tool_stats(user: dict = Depends(get_current_user)):
             MAX(created_at) AS last_used
         FROM mcp_tool_calls
         WHERE 1=1 {scope_sql}
-        GROUP BY tool_name ORDER BY total_calls DESC""",
+        GROUP BY tool_name ORDER BY total_calls DESC""",  # noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized
         scope_params,
     )
     return [dict(r) for r in rows]

--- a/app/routers/v3/auth.py
+++ b/app/routers/v3/auth.py
@@ -172,7 +172,7 @@ def update_user(
     set_clause = ", ".join(f"{k} = %s" for k in allowed)
     values = list(allowed.values()) + [user_id]
     row = fetch_one(
-        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING id, username, is_admin, role, is_active",
+        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING id, username, is_admin, role, is_active",  # noqa: S608 - set_clause keys allowlisted to is_admin/is_active/role; values parameterized
         tuple(values),
     )
     if not row:

--- a/app/routers/v3/curation_api.py
+++ b/app/routers/v3/curation_api.py
@@ -64,7 +64,7 @@ def list_contradictions(
         {where_sql}
         ORDER BY created_at DESC
         LIMIT %s OFFSET %s
-        """,
+        """,  # noqa: S608 - WHERE clauses are constant literals; values parameterized
         params,
     )
     return [dict(r) for r in rows]
@@ -165,7 +165,7 @@ def list_stale_flags(
         {where_sql}
         ORDER BY created_at DESC
         LIMIT %s OFFSET %s
-        """,
+        """,  # noqa: S608 - WHERE clauses are constant literals; values parameterized
         params,
     )
     return [dict(r) for r in rows]
@@ -222,7 +222,7 @@ def list_suggestions(
         params.append(status)
     params.append(limit)
     return fetch_all(
-        f"SELECT * FROM kg_curation_suggestions WHERE {' AND '.join(clauses)} ORDER BY created_at DESC LIMIT %s",
+        f"SELECT * FROM kg_curation_suggestions WHERE {' AND '.join(clauses)} ORDER BY created_at DESC LIMIT %s",  # noqa: S608 - WHERE clauses are constant literals; values parameterized
         tuple(params),
     )
 

--- a/app/routers/v3/exports.py
+++ b/app/routers/v3/exports.py
@@ -46,7 +46,7 @@ def trigger_export(
     # Fetch research trail by run_id
     _clause, _cparams = org_scope_clause(user)
     row = fetch_one(
-        f"SELECT rt.query, rt.findings, rt.analysis "
+        f"SELECT rt.query, rt.findings, rt.analysis "  # noqa: S608 - clause is a constant org-scope fragment; values parameterized
         f"FROM research_trails rt "
         f"JOIN pipeline_runs pr ON pr.id = rt.run_id "
         f"WHERE rt.run_id = %s {_clause.replace('AND org_id', 'AND pr.org_id')}",

--- a/app/routers/v3/health.py
+++ b/app/routers/v3/health.py
@@ -51,7 +51,7 @@ async def workers_health(user: dict = Depends(get_current_user)) -> dict[str, An
               EXTRACT(EPOCH FROM (now() - MIN(started_at) FILTER (WHERE status = 'queued')))  AS oldest_queued_age_seconds,
               EXTRACT(EPOCH FROM (now() - MIN(started_at) FILTER (WHERE status = 'running'))) AS oldest_running_age_seconds
             FROM pipeline_runs
-            WHERE status IN ('queued', 'running') {user_filter}""",
+            WHERE status IN ('queued', 'running') {user_filter}""",  # noqa: S608 - user_filter is a constant fragment; value parameterized
         params,
     ) or {}
 

--- a/app/routers/v3/knowledge_api.py
+++ b/app/routers/v3/knowledge_api.py
@@ -251,7 +251,7 @@ def get_timeline(
         {where}
         ORDER BY observed_at DESC
         LIMIT %s
-        """,
+        """,  # noqa: S608 - conditions are constant literals; values parameterized
         tuple(params),
     )
 

--- a/app/routers/v3/pipelines.py
+++ b/app/routers/v3/pipelines.py
@@ -366,7 +366,7 @@ def get_run(run_id: str, user: dict = Depends(get_current_user)):
     if run["trigger_type"] == "agent_is":
         _clause, _cparams = org_scope_clause(user)
         _trail_sql = (
-            "SELECT rt.query, rt.entity_type, rt.findings, rt.trail, "
+            "SELECT rt.query, rt.entity_type, rt.findings, rt.trail, "  # noqa: S608 - clause is a constant org-scope fragment; values parameterized
             "rt.tool_calls, rt.suggested_pipeline, rt.analysis "
             "FROM research_trails rt "
             "JOIN pipeline_runs pr ON pr.id = rt.run_id "
@@ -411,7 +411,7 @@ def list_pipelines(user: dict = Depends(get_current_user)):
         WHERE (user_id = %s OR is_system = TRUE)
           AND (TRUE {clause})
         ORDER BY is_system DESC, created_at DESC
-        """,
+        """,  # noqa: S608 - clause is a constant org-scope fragment; values parameterized
         tuple([str(user["id"]), *params]),
     )
     return [PipelineOut(**dict(r)) for r in rows]

--- a/app/routers/v3/research_api.py
+++ b/app/routers/v3/research_api.py
@@ -117,7 +117,7 @@ def get_scorecard(run_id: str, user: dict = Depends(get_current_user)):
     row = fetch_one(
         f"""SELECT rt.scorecard FROM research_trails rt
             JOIN pipeline_runs pr ON pr.id = rt.run_id
-            WHERE rt.run_id = %s {clause.replace("AND org_id", "AND pr.org_id")}""",
+            WHERE rt.run_id = %s {clause.replace("AND org_id", "AND pr.org_id")}""",  # noqa: S608 - clause is a constant org-scope fragment; values parameterized
         tuple([run_id, *params]),
     )
     if not row or not row.get("scorecard"):
@@ -144,7 +144,7 @@ def submit_scorecard_grade(run_id: str, body: dict, user: dict = Depends(get_cur
     row = fetch_one(
         f"""SELECT rt.scorecard FROM research_trails rt
             JOIN pipeline_runs pr ON pr.id = rt.run_id
-            WHERE rt.run_id = %s {clause.replace("AND org_id", "AND pr.org_id")}""",
+            WHERE rt.run_id = %s {clause.replace("AND org_id", "AND pr.org_id")}""",  # noqa: S608 - clause is a constant org-scope fragment; values parameterized
         tuple([run_id, *params]),
     )
     if not row or not row.get("scorecard"):

--- a/app/routers/v3/users.py
+++ b/app/routers/v3/users.py
@@ -43,7 +43,7 @@ def update_me(body: UserProfileIn, user: dict = Depends(get_current_user)):
         updates["avatar_url"] = updates["avatar_url"].strip()[:512]
     set_clause = ", ".join(f"{k} = %s" for k in updates)
     row = fetch_one(
-        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING *",
+        f"UPDATE ui_users SET {set_clause} WHERE id = %s RETURNING *",  # noqa: S608 - set_clause keys from hardcoded allowlist; values parameterized
         tuple(list(updates.values()) + [str(user["id"])]),
     )
     return _user_to_out(dict(row))


### PR DESCRIPTION
## Summary

Resolves the ruff **S608** (`hardcoded-sql-expression`) warnings. The count had grown from 14 (at issue-filing) to **24**. S608 is the project's load-bearing SQL-injection rule — `pyproject.toml` states it must *never* be silenced without a security review — so each site was individually reviewed before adding a directive.

Closes #94.

## Security review — all 24 are false positives

Every flagged f-string interpolates **only trusted SQL text**; no user-supplied value is ever concatenated into a query. Actual values are always passed as `%s` parameters to psycopg2.

| Category | Sites | Why safe |
|---|---|---|
| Constant org/user scope fragment | `admin_api.py` ×9, `exports.py`, `pipelines.py` ×2, `research_api.py` ×2, `health.py` | `org_scope_clause()` / `_user_scope()` return either `""` or `"AND <col> = %s"` — a constant string; the org/user id is a bound parameter. `health.py`'s `user_filter` is likewise `""` or `"AND user_id = %s"`. |
| Allowlisted column names | `auth.py`, `users.py` | `set_clause` is built from dict keys filtered against a **hardcoded allowlist** (`auth`: `is_admin/is_active/role`; `users`: `display_name/avatar_url/timezone/locale`). Values are parameterized. |
| Hardcoded literal column name | `materializer.py` ×2 | `_get_checkpoint`/`_update_checkpoint` are only ever called with string literals (`"last_entity_obs_at"`, `"last_rel_obs_at"`). |
| Constant clause literals + placeholders | `curation_api.py` ×3, `knowledge_api.py`, `retriever.py` | Every `WHERE`/`IN` fragment appended is a constant literal (`"status = %s"`, `"entity_ref = %s"`, ...) or a `%s`-placeholder string sized to a list; values are parameterized. |

## What changed
- Added a per-line `# noqa: S608` (placed via `ruff check --select S608 --add-noqa`, which puts the directive on the correct line for multi-line f-strings) to each of the 24 sites.
- Annotated each directive with its safety rationale, e.g.
  `# noqa: S608 - scope_sql is a constant fragment from _user_scope(); value parameterized`.
- **No SQL was modified.** The rule stays globally enabled, so genuinely unsafe future interpolations will still fail CI.

## Verification
- `ruff check --select S608 app` → **All checks passed!**
- `python -m py_compile` on all 11 changed files → OK (confirms no directive landed inside a string literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)