### PR TITLE
test(frontend): exclude e2e from vitest + fix stale mocks/assertions

### DIFF
--- a/frontend/src/components/live/LiveStream.test.tsx
+++ b/frontend/src/components/live/LiveStream.test.tsx
@@ -4,7 +4,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 
 vi.mock('../../hooks/useWebSocket', () => ({ useWebSocket: vi.fn() }))
-vi.mock('../../api/v3', () => ({
+// Spread the real module so every export LiveStream calls (getCoreSettings,
+// listSessions, getSession, ...) stays defined; override only listJobs.
+vi.mock('../../api/v3', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../api/v3')>()),
   listJobs: vi.fn().mockResolvedValue([
     { id: 'job-1', status: 'completed', query: 'find CTOs', created_at: '2026-04-28T00:00:00Z', completed_at: null, result_count: 5 },
   ]),
@@ -12,13 +15,18 @@ vi.mock('../../api/v3', () => ({
 
 import LiveStream from './LiveStream'
 
+function makeClient() {
+  // retry:false so any non-overridden query fails fast instead of retrying.
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
 describe('LiveStream', () => {
   it('renders Live Stream header', () => {
     render(
-      <QueryClientProvider client={new QueryClient()}>
+      <QueryClientProvider client={makeClient()}>
         <MemoryRouter><LiveStream /></MemoryRouter>
       </QueryClientProvider>,
     )
-    expect(screen.getByText('Live')).toBeInTheDocument()
+    expect(screen.getByText(/^live$/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -8,7 +8,12 @@ vi.mock('@/components/layout/IconRail', () => ({
   default: () => null,
 }))
 
-vi.mock('@/api/v3', () => ({
+// Spread the real module so every export the Dashboard tree calls
+// (listInvestigationTemplates, getWorkerHealth, getCoreSettings, ...) stays
+// defined; override only the two endpoints these assertions depend on. Queries
+// run with retry:false (see renderPage) so any non-overridden call fails fast.
+vi.mock('@/api/v3', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/api/v3')>()),
   listRuns: vi.fn().mockResolvedValue([
     {
       id: 'r1', status: 'succeeded', query: 'investigate: ACME',

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -26,15 +26,15 @@ function renderLogin() {
 describe('Login', () => {
   it('renders username and password fields', () => {
     renderLogin()
-    expect(screen.getByPlaceholderText('username')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('password')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument()
   })
 
   it('calls login on submit', async () => {
     const { login } = await import('../api/auth')
     renderLogin()
-    fireEvent.change(screen.getByPlaceholderText('username'), { target: { value: 'admin' } })
-    fireEvent.change(screen.getByPlaceholderText('password'), { target: { value: 'secret' } })
+    fireEvent.change(screen.getByPlaceholderText(/username/i), { target: { value: 'admin' } })
+    fireEvent.change(screen.getByPlaceholderText(/password/i), { target: { value: 'secret' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
     await waitFor(() => expect(login).toHaveBeenCalledWith('admin', 'secret'))
   })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,5 +25,10 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
     globals: true,
+    // Only run unit/component tests under src/. Without this, vitest's default
+    // glob also collects the Playwright specs under e2e/ (which use the
+    // Playwright runner, not vitest) and reports them all as failures.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules', 'dist', 'e2e/**'],
   },
 })


### PR DESCRIPTION
## Summary

Fixes the two frontend test-suite problems surfaced while verifying #91 (the original localStorage failure was already resolved). Before this, `vitest run` reported **56 of 72 files failing**; after, the suite is **19 files / 124 tests green** and runs in **3.6s** (was ~1090s).

## Changes
- **`vite.config.ts`** — scope vitest to `src/` (`include: ['src/**/*.{test,spec}.{ts,tsx}']`) and `exclude: ['node_modules','dist','e2e/**']`. The default glob was collecting the Playwright `e2e/*.spec.ts` files (52 spurious file failures); those run under the Playwright runner, not vitest.
- **`Dashboard.test.tsx` / `LiveStream.test.tsx`** — the `@/api/v3` `vi.mock` factories omitted exports the component tree now calls (`getCoreSettings`, `listInvestigationTemplates`, ...). Switched to `vi.mock(..., async (importOriginal) => ({ ...(await importOriginal()), <overrides> }))` so the real exports stay defined and only the asserted endpoints are stubbed — resilient to future exports. Added `retry:false` to LiveStream's QueryClient so non-overridden queries fail fast offline.
- **`Login.test.tsx`** — real placeholders are `"Username"`/`"Password"`; matchers were case-sensitive lowercase → switched to case-insensitive regex.
- **`LiveStream.test.tsx`** — header renders literal `"LIVE"`; assertion expected `"Live"` → case-insensitive.

## Verification
```
npx vitest run
 Test Files  19 passed (19)
      Tests  124 passed (124)
   Duration  3.62s
```
`tsc --noEmit` clean on the changed files. No production code changed — config + test files only.

Relates to #91 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)