### PR TITLE
refactor: canonicalize broadening phase as `gather`, retire BROADEN

### DIFF
--- a/app/is_prompt.py
+++ b/app/is_prompt.py
@@ -87,12 +87,12 @@ If ANY temporal signal appears → `temporal_sensitivity = HIGH`
 
 **2. Gap analysis — assess which required signals are missing or ambiguous:**
 
-A query is EXPLICIT (proceed directly to BROADEN) only if ALL are true:
+A query is EXPLICIT (proceed directly to the gather phase) only if ALL are true:
   ✓ Entity is named, not described (proper noun / specific title / URL)
   ✓ Intent is retrieval ("find", "lookup", "get", "show"), not discovery ("what is", "who is", "identify")
   ✓ All context needed for the query type is present (platform, time period, format)
 
-  Example — explicit: "show golden gate bridge jpeg 160×160" → all present, skip to BROADEN
+  Example — explicit: "show golden gate bridge jpeg 160×160" → all present, skip to gather
   Example — not explicit: "new series with girl in spiderman" → entity described, platform missing, discovery intent
 
 If ANY condition fails → the query has a critical gap. Ask about it before researching.
@@ -121,13 +121,13 @@ TEMPORAL AMBIGUITY on live query:
 → ask_user("Is this about something current or recent?",
     options=["Very recent (2025–2026)", "A few years ago", "Historical", "Not sure"])
 
-MID-RESEARCH CONFIRMATION (during STEP 4, after BROADEN surfaces a strong hypothesis):
+MID-RESEARCH CONFIRMATION (during STEP 4, after the gather phase surfaces a strong hypothesis):
 → ask_user("Was this [specific hypothesis — one sentence]?", options=["Yes", "No", "Not sure"])
 → Binary confirmation only. One question. Use when genuinely uncertain between two strong candidates.
 
 **COHERENCE CHECK:**
 After gap-fill, ask: "Can ALL signals plausibly belong to a SINGLE entity, source, or work?"
-- ✅ YES → proceed to BROADEN
+- ✅ YES → proceed to gather
 - ❌ NO → add H_COMPOSITE as a mandatory first hypothesis AND ask the discovery question above if not yet asked
   (Example: "blue car in a cologne ad" + "woman cooking pasta" = conflicting contexts
    → likely from different items in a composite source like a YouTube playlist or reel compilation)
@@ -150,7 +150,7 @@ REQUIRED before naming any candidate:
 Distinguish by source class — VERIFIED prior research (user-graded A/A1/A2) vs. UNVERIFIED (brain-scored from a prior run).
 
 UNVERIFIED prior research is ONE source among many, not the overarching narrative. If it names a candidate:
-- That candidate is H_PRIOR — ONE hypothesis among the ≥3 required for BROADEN, not the answer.
+- That candidate is H_PRIOR — ONE hypothesis among the ≥3 required for the gather phase, not the answer.
 - You MUST still generate ≥2 DISTINCT alternative identity hypotheses (different person/entity, not different facets of the same person) before running confirmation tools.
 - "Distinct identity" means a different name. Branches that all confirm facets of H_PRIOR (e.g., "subject_background of X" + "physical_signal_match of X" + "brand_first of X") are NOT distinct hypotheses — they are one hypothesis with multiple sub-searches.
 - Each alternative hypothesis must be supported by at least one LIVE tool call (run_web_search, run_google_news, run_image_search, equivalent) — NOT solely by prior_research or training_knowledge.
@@ -166,13 +166,13 @@ VIOLATION PATTERN (do not do this):
 
 CORRECT PATTERN:
   → Decompose the query into PRIMARY / SUPPORTING / CONTEXT signals (see STEP 0 SIGNAL HIERARCHY)
-  → Run BROADEN using hypothesis-first search (one search per hypothesis declared in log_cycle)
+  → Run the gather phase using hypothesis-first search (one search per hypothesis declared in log_cycle)
   → Check results: does any LIVE source name a specific title where the LEAD matches PRIMARY?
   → ONLY THEN name a candidate — with the live source as citation
 
 ---
 
-### STEP 2 — BOOTSTRAP / BROADEN (live evidence first, no commitment)
+### STEP 2 — BOOTSTRAP / GATHER (live evidence first, no commitment)
 
 **MANDATORY CYCLE DECLARATION (call before any search):**
 At the start of every INVESTIGATE cycle — top-level and every child PIR — call:
@@ -186,15 +186,15 @@ You CANNOT run any search before calling log_cycle for the current cycle. This d
 - Every finding with confidence ≥ 70% must come from a live tool call.
 - Tag each finding's basis: `live_search` | `prior_research` | `training_generated`
 
-**BROADEN — minimum 3 live searches before any hypothesis ranking (hard gate):**
+**Gather phase — minimum 3 live searches before any hypothesis ranking (hard gate):**
 
 **When PRE-RETRIEVED EVIDENCE is present** (injected above the workflow):
 Do NOT re-search that corpus. Work from it directly.
 YOU MUST produce >= 1 candidate from each non-empty branch before ranking.
 State "no viable candidate" for any branch you cannot satisfy.
-EXCEPTION — identification queries: pre-retrieved evidence (prior_research / RAG) seeds H_PRIOR only. The hypothesis-first BROADEN gate below (≥3 DISTINCT identity hypotheses, ≥1 live search each) still applies in full. You may not skip live BROADEN because a prior run already named a candidate.
+EXCEPTION — identification queries: pre-retrieved evidence (prior_research / RAG) seeds H_PRIOR only. The hypothesis-first gather gate below (≥3 DISTINCT identity hypotheses, ≥1 live search each) still applies in full. You may not skip live gather because a prior run already named a candidate.
 
-**HYPOTHESIS-FIRST BROADEN — minimum searches = number of hypotheses declared in log_cycle (≥3):**
+**HYPOTHESIS-FIRST GATHER — minimum searches = number of hypotheses declared in log_cycle (≥3):**
 
 For each hypothesis declared in log_cycle, run ≥1 dedicated search derived from that hypothesis.
 The search query is hypothesis-specific — ask "what would I search to confirm or deny H_n?" not "what combination of signals do I search?".
@@ -208,7 +208,7 @@ Also call get_past_research(query) — prior research may have already found a v
 
 You CANNOT rank hypotheses before all hypothesis searches complete. This is the hard gate.
 
-**AFTER BROADEN — rank by fewest signal inconsistencies (penalty-based, not elimination):**
+**AFTER GATHER — rank by fewest signal inconsistencies (penalty-based, not elimination):**
 
 Score each hypothesis against the PIR criteria declared in log_cycle:
 - PRIMARY signal mismatch: heavy penalty (candidate scores low, still appears in results)
@@ -224,7 +224,7 @@ ANTI-PATTERN: ranking a candidate high because it matches CONTEXT + SUPPORTING w
 
 ### STEP 3 — PLAN
 
-From BROADEN results, build your research plan:
+From gather results, build your research plan:
 1. Determine ENTITY TYPE and TASK TYPE:
    - entity_type: person | company | product | event | concept | celebrity
    - task_type: named_lookup | celebrity_identification | brand_lookup | comparative | factual | market_research | competitor_analysis
@@ -300,7 +300,7 @@ For each branch, explore recursively as deep as the research requires (suggested
      Do NOT close the PIR immediately. Instead:
      1. Re-hypothesize: form a new interpretation of the same PIR from a different angle
         (different locale, name variant, source type, or medium-type assumption).
-     2. Run ≥1 new BROADEN search from the re-hypothesized angle.
+     2. Run ≥1 new gather search from the re-hypothesized angle.
      3. Only mark the PIR closed when BOTH the original AND re-hypothesized angles yield no signal,
         OR when all declared hypotheses in log_cycle have been exhausted.
      Log: "DEAD END: [what failed]. RE-HYPOTHESIZE: [new angle tried]. OUTCOME: [result]."
@@ -480,7 +480,7 @@ CRITICAL: Your ENTIRE response must be a single valid JSON object. No markdown, 
   ],
   "gaps": ["things that could not be found — use provisionally_absent or confirmed_absent, not just 'not found'"],
   "considered_alternatives": [
-    "candidate name considered but ranked lower — include any title/name explored during BROADEN that didn't become the top result"
+    "candidate name considered but ranked lower — include any title/name explored during the gather phase that didn't become the top result"
   ]
 }}
 
@@ -592,7 +592,7 @@ def render_past_research_blocks(past_research: list[dict] | None) -> list[str]:
             )
         blocks.append(
             "RELATED PRIOR RESEARCH (unverified — brain-scored only, NOT user-graded):\n"
-            "  Treat as ONE source among many, not the overarching narrative. Seeds H_PRIOR for BROADEN.\n"
+            "  Treat as ONE source among many, not the overarching narrative. Seeds H_PRIOR for the gather phase.\n"
             "  For identification queries: must still generate ≥2 DISTINCT alternative identity hypotheses with live searches before ranking. RAG confidence is prior, not posterior.\n"
             + "\n".join(summaries)
         )

--- a/app/pipeline/ach.py
+++ b/app/pipeline/ach.py
@@ -139,7 +139,7 @@ def _mark_medium(
     # Collect phase_id from phase_outputs metadata
     gather_finding_ids: set[str] = set()
     for po in phase_outputs:
-        if hasattr(po, "phase_id") and po.phase_id in ("gather", "broaden"):  # allowlist 2026-05-23: legacy phase id for historical research_trails rows
+        if hasattr(po, "phase_id") and po.phase_id == "gather":
             for f in po.aggregated_findings:
                 url = f.get("source_url") or ""
                 if url:
@@ -149,7 +149,7 @@ def _mark_medium(
         for f in candidate_findings:
             phase_id = f.get("phase_id", "")
             source_class = f.get("source_class", "")
-            if phase_id in ("gather", "broaden") and source_class in _LIVE_SOURCE_CLASSES:  # allowlist 2026-05-23: legacy phase id for historical research_trails rows
+            if phase_id == "gather" and source_class in _LIVE_SOURCE_CLASSES:
                 finding_id = f.get("source_url") or f.get("evidence_snippet", "")[:40] or None
                 return "consistent", finding_id
 

--- a/app/pipeline/engine_v2.py
+++ b/app/pipeline/engine_v2.py
@@ -420,7 +420,7 @@ async def run_engine_v2(
         try:
             from app.pipeline.strategist import _enrich_ranked_candidates
             from app.pipeline.ach import ACHSignal
-            gather_phase = next((p for p in result.phases if p.phase_id in ("gather", "broaden")), None)  # allowlist 2026-05-23: legacy phase id for historical research_trails rows
+            gather_phase = next((p for p in result.phases if p.phase_id == "gather"), None)
             raw_ranked: list[dict] = []
             if gather_phase and gather_phase.distinct_candidate_names:
                 raw_ranked = [

--- a/app/pipeline/strategies/media_identification.py
+++ b/app/pipeline/strategies/media_identification.py
@@ -6,7 +6,7 @@ STRATEGY = """
 === MEDIA IDENTIFICATION STRATEGY ===
 
 goal: Identify unknown show/movie/media clip/advertisement from partial descriptions.
-execution_model: log_cycle(PIR + hypotheses) → MULTI-HYPOTHESIS(≥4 before searching) → BROADEN(≥1 search/hypothesis) → RED_TEAM(mandatory disconfirm per H) → RANK → RECURSE → DELIVER
+execution_model: log_cycle(PIR + hypotheses) → MULTI-HYPOTHESIS(≥4 before searching) → gather(≥1 search/hypothesis) → RED_TEAM(mandatory disconfirm per H) → RANK → RECURSE → DELIVER
 
 --- PIR TEMPLATE ---
 
@@ -131,7 +131,7 @@ Before delivering final answer, verify:
 [ ] HYPOTHESIS_MATRIX has ≥4 entries (H1–H4)
 [ ] H1–H4 name DISTINCT identities (different person/entity, not facets of one). If PRIOR RESEARCH seeded a candidate, ≥3 of H1–H4 are NOT that candidate.
 [ ] PIR_CRITERIA block present with all 5 signal weights
-[ ] Each hypothesis has at least one LIVE search executed (BROADEN phase) — prior_research or training_knowledge alone does NOT satisfy this for any hypothesis
+[ ] Each hypothesis has at least one LIVE search executed (gather phase) — prior_research or training_knowledge alone does NOT satisfy this for any hypothesis
 [ ] Each hypothesis has a [DISCONFIRM:H_n] entry (RED TEAM gate)
 [ ] ACH SCORING MATRIX filled with ✓/✗/? marks
 [ ] SPECIFIC_DETAIL_VERIFICATION completed for all PRIMARY and SUPPORTING signals

--- a/app/pipeline/strategies/place.py
+++ b/app/pipeline/strategies/place.py
@@ -6,7 +6,7 @@ STRATEGY = """
 === PLACE / ROUTE / NAVIGATION STRATEGY ===
 
 goal: Provide accurate, actionable route guidance including LOCAL shortcuts invisible to official mapping apps.
-execution_model: log_cycle(PIR + hypotheses) → BROADEN(≥1 search/hypothesis) → RANK → RECURSE → DELIVER
+execution_model: log_cycle(PIR + hypotheses) → gather(≥1 search/hypothesis) → RANK → RECURSE → DELIVER
 
 --- PIR TEMPLATE ---
 

--- a/app/pipeline/strategist.py
+++ b/app/pipeline/strategist.py
@@ -1220,7 +1220,7 @@ class Strategist:
         # from the aggregated_findings across all phases.
         if not raw_ranked:
             for p in completed_phases:
-                if p.phase_id in ("gather", "broaden") and p.distinct_candidate_names:  # allowlist 2026-05-23: legacy phase id for historical research_trails rows
+                if p.phase_id == "gather" and p.distinct_candidate_names:
                     raw_ranked = [
                         {"name": name, "confidence": 0.5}
                         for name in p.distinct_candidate_names

--- a/app/pipeline/tests/test_ach_strategies.py
+++ b/app/pipeline/tests/test_ach_strategies.py
@@ -1,8 +1,8 @@
 """Shared invariants for ACH-shaped strategy modules.
 
 The ACH backbone (signal_extraction → broaden → red_team → rank_verify) is
-the hand-written, non-skeleton strategy shape. All three ACH-shaped strategies
-have now been migrated to the unified taxonomy (extract → gather → disconfirm →
+the legacy strategy shape. All three ACH-shaped strategies have now been
+migrated to the unified taxonomy (extract → gather → disconfirm →
 synthesize) — person (Task 9), due_diligence (Task 10), media_identification
 (Task 11).
 
@@ -31,7 +31,7 @@ MODES_DIR = (
 
 # Strategies still on the legacy ACH backbone (signal_extraction → broaden →
 # red_team → rank_verify). Remove entries here as they are migrated to the
-# unified taxonomy (extract → gather → disconfirm → synthesize).
+# current unified taxonomy (extract → gather → disconfirm → synthesize).
 # person migrated 2026-05-23 (Task 9) — see TestPersonUnifiedTaxonomy below.
 # due_diligence migrated 2026-05-23 (Task 10) — see TestDueDiligenceUnifiedTaxonomy below.
 # media_identification migrated 2026-05-23 (Task 11) — see TestMediaIdentificationUnifiedTaxonomy below.

--- a/app/pipeline/tests/test_strategy_gate_audit.py
+++ b/app/pipeline/tests/test_strategy_gate_audit.py
@@ -139,7 +139,7 @@ class TestRealCatalog:
 # ---------------------------------------------------------------------------
 
 
-def _make_strategy_dict(id: str, broaden_checks: list) -> dict:
+def _make_strategy_dict(id: str, gather_checks: list) -> dict:
     """Minimal valid Strategy dict for the audit (Pydantic-validated)."""
     return {
         "id": id,
@@ -153,7 +153,7 @@ def _make_strategy_dict(id: str, broaden_checks: list) -> dict:
                 "depends_on": [],
                 "unit_of_work_contract": {"inputs": [], "briefing": "test"},
                 "hypothesis_count_policy": "fixed:1",
-                "gate": {"checks": broaden_checks, "on_fail": "ask_user"},
+                "gate": {"checks": gather_checks, "on_fail": "ask_user"},
             },
         ],
     }

--- a/app/routers/v3/agent.py
+++ b/app/routers/v3/agent.py
@@ -598,7 +598,7 @@ async def _run_is_research(
                 preflight_section = (
                     f"[PREFLIGHT: VALIDATED]\n"
                     f"Query interpreted as: {preflight_result.slots.raw_interpretation}\n"
-                    f"Proceed directly to BROADEN — skip STEP 0 decomposition (already done)."
+                    f"Proceed directly to gather — skip STEP 0 decomposition (already done)."
                 )
             session_context = (
                 preflight_section + "\n\n" + session_context

--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -133,7 +133,7 @@ def build_session_context(session: dict | None, current_message: str) -> str:
     # Keep this block GENERIC — no entity-specific examples, no special phases.
     # The IS brain's existing STEP 0 through STEP 7 methodology already handles
     # rejections correctly: STEP 0 re-decomposes with the rejection as a
-    # constraint, STEP 1 asks discriminating questions, STEP 2 BROADENs from
+    # constraint, STEP 1 asks discriminating questions, STEP 2 gathers from
     # retained signals, STEP 5 runs the adversarial check against rejected
     # evidence. Do not duplicate or pre-empt those phases here.
     rejection_section = ""
@@ -159,12 +159,12 @@ re-run the standard methodology from STEP 0 with this rejection as a constraint.
 Rejected findings (do not re-propose; treat as disconfirming evidence in ACH):
 {rejected_block}
 
-Retained signals (still valid; use as BROADEN seeds):
+Retained signals (still valid; use as gather seeds):
 {retained_block}
 
 Re-enter the methodology at STEP 0. Decompose the genesis query against the
 retained signals, run STEP 1's clarification gate if a critical gap remains,
-BROADEN from the retained signals (not from the rejected entity's family),
+gather from the retained signals (not from the rejected entity's family),
 and apply the STEP 5 adversarial check against the rejected evidence before
 delivering. H_COMPOSITE remains available as a hypothesis. Confidence on any
 new candidate is bounded by H_COMPOSITE and ACH consistency with the rejection.

--- a/docs/superpowers/specs/2026-05-24-phase-naming-canonicalize-gather-design.md
+++ b/docs/superpowers/specs/2026-05-24-phase-naming-canonicalize-gather-design.md
@@ -1,0 +1,91 @@
+# Design: Canonicalize the broadening phase as `gather` (retire `BROADEN`)
+
+> Date: 2026-05-24
+> Status: approved (brainstorm) → pending spec review
+> Related: #89 (brain BROADEN), #117 (unified taxonomy), `docs/TICKET-TRACKING.md`
+
+## Problem
+
+The pipeline has one phase that, depending on layer, is called two different things:
+
+- **Structural layer** (catalog, strategist, engine, gates, telemetry, tests): `gather` — the
+  domain-agnostic "collect evidence" phase in the unified taxonomy
+  `extract → gather → disconfirm → synthesize` (`LEGAL_PHASE_IDS`, shipped in #117).
+- **Brain-prompt layer** (`is_prompt.py`, `agent.py`, `session_service.py`): `BROADEN` — the
+  ACH-heritage behavioral instruction ("≥3 live searches before ranking; one search per
+  hypothesis"), which is exactly the anti-tunneling behavior #89 cares about.
+
+This split is a coherence problem: the orchestrator/logs say `gather`; the brain is told
+`BROADEN`. A reader (human or machine) cannot tell they are the same phase.
+
+## Decision
+
+**One vocabulary everywhere: `gather`.** `BROADEN` is retired as a label.
+
+`gather` wins because it is already the structural id across all domains, it generalizes
+(real_estate/company/lead "gather" all read naturally, "broaden a listings fetch" does not),
+and `broaden` is a *legacy* phase id the `test_no_legacy_phase_ids` CI lint already forbids.
+Renaming to `broaden` would revert #117 and fight the lint.
+
+**Intent is preserved, only the label changes.** The broadening *behavior* (≥3 distinct
+hypotheses, ≥1 live search each, hypothesis-first, no ranking until satisfied) remains stated
+explicitly — now as requirements *of the gather phase* rather than under a separate noun.
+This must read at least as forcefully as the current `BROADEN` framing (verified against #89).
+
+Beta context: pre-#117 run data is **not** worth preserving, so backward-compat handling of
+historical `"broaden"` phase rows is **removed** (simpler code) rather than kept.
+
+## Scope — four buckets
+
+### Bucket A — rename forward-looking prompt vocabulary → `gather`
+`is_prompt.py` (~15 refs: lines 90, 95, 124, 130, 153, 169, 175, 189, 195, 197, 211, 227,
+303, 483, 595), `routers/v3/agent.py:601`, `services/session_service.py:136,162,167`.
+Replace `BROADEN` with "the gather phase" / "gather" while keeping every behavioral rule.
+The step heading `STEP 2 — BOOTSTRAP / BROADEN` becomes `STEP 2 — BOOTSTRAP / GATHER`.
+
+### Bucket B — update stale docstrings/comments describing current flow → `gather`
+`person.py:10`, `media_identification.py:14`, `strategies/media_identification.py:9,134`,
+`strategies/place.py:9`, `test_ach_strategies.py:3,32`, `test_strategist.py:1395`.
+Where a docstring describes the *current* pipeline, say `gather`. Historical migration notes
+that explain "was X, now Y" may keep the old word in the "was" clause for context.
+
+### Bucket C — simplify backward-compat dual-checks → `gather` only
+`ach.py:142,152`, `engine_v2.py:423`, `strategist.py:1223`: change
+`phase_id in ("gather", "broaden")` → `phase_id == "gather"` and drop the now-unneeded
+`# allowlist 2026-05-23` comments. Accept that pre-#117 run rows lose special phase handling.
+
+### Bucket D — KEEP (the guardrail; it must name the forbidden word)
+`test_no_legacy_phase_ids.py` `_LEGACY_IDS = [..., "broaden", ...]`, plus the helpful
+legacy-id hints in `constants.py:9`, `schemas.py:97`, `audit.py:51`, and the
+`test_startup_audit.py` fixtures that assert the audit *rejects* `"broaden"`. These exist to
+*prevent* `broaden` from returning; they legitimately contain the word and stay (allowlisted).
+
+### Leave as-is — genuine English, not the phase
+`adverse_media.py:29` ("broaden query coverage"), `patent_prior_art.py:85` ("broadens
+search"), `strategist.py:187` ("Try broadening location or budget" — a user-facing
+real-estate hint). Unrelated to the phase; the lint only matches quoted `"broaden"`.
+Test variable `broaden_checks` (`test_strategy_gate_audit.py:142,156`) → `gather_checks`
+for token-consistency.
+
+## Verification
+
+1. **Lint**: `test_no_legacy_phase_ids` still passes (Bucket D intact; Buckets A–C no longer
+   emit quoted `"broaden"`).
+2. **Grep gate**: after the change, the only `broaden` tokens remaining in `app/` are Bucket D
+   (allowlisted) and the three English-verb uses; no `BROADEN` remains as a phase label.
+3. **Prompt-intent check**: re-read the rewritten `is_prompt.py` gather section and confirm the
+   ≥3-hypotheses / ≥1-live-source rules are stated at least as forcefully as before.
+4. **Backend tests**: `test_strategist.py`, `test_ach_strategies.py`, `test_startup_audit.py`,
+   `test_no_legacy_phase_ids.py`, `test_catalogs.py` pass on the host venv.
+5. **Live smoke**: one identification run still reaches gather with ≥3 hypotheses (dovetails
+   with the #89 verification — if #89 is exercised in the same window, reuse its run).
+
+## Out of scope
+- The #89 behavioral fix itself (tactician slot-0, ACH floor) — separate, decided by the #89
+  reproduction. This spec only changes *naming/vocabulary* + the prompt-intent wording.
+- Frontend phase-label strings (none reference `broaden` per the lint's frontend scan).
+
+## Risk
+Low. No structural phase id changes (it was already `gather`). Main risk is *weakening the
+prompt's anti-tunneling force* during the BROADEN→gather rewrite — mitigated by verification
+step 3 and by keeping all behavioral rules verbatim, changing only the label.


### PR DESCRIPTION
## Summary
Unifies the phase vocabulary on **`gather`** and retires the `BROADEN` label, so the orchestrator/telemetry/gates and the brain prompt no longer use two names for the same phase. Implements the approved spec `docs/superpowers/specs/2026-05-24-phase-naming-canonicalize-gather-design.md`.

- **Prompt vocabulary** (`is_prompt.py`, `agent.py`, `session_service.py`): `BROADEN` → "gather phase". **All behavioral rules kept verbatim** (≥3 distinct hypotheses, ≥1 live search each, hypothesis-first, no ranking until satisfied) — only the label changed.
- **Stale docstrings** describing current flow → `gather`.
- **Backward-compat dual-checks** (`ach.py`, `engine_v2.py`, `strategist.py`): `phase_id in ("gather","broaden")` → `== "gather"` (beta: pre-#117 run data not preserved).
- **Preserved**: the `test_no_legacy_phase_ids` lint definition + audit/schema hints (they must name `broaden` to forbid it), and genuine English-verb uses.

## Verification
- `test_no_legacy_phase_ids`, `test_startup_audit`, `test_strategy_gate_audit`: **38 passed**.
- Broader strategist/catalog/ach suite: 195 passed (4 pre-existing `test_engine_v2_emits_expected_events` failures unrelated to this change).
- `ruff check app`: 10 errors = pre-existing baseline, **no new**.
- No `BROADEN` phase label remains; remaining `broaden` tokens are the lint guardrail + 3 English-verb uses.

Relates to #89 (vocabulary groundwork; behavioral fix tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)