### PR TITLE
fix(brain): keep CLAUDE_CODE_OAUTH_TOKEN when no creds file present (research was 100% broken)

### DIFF
--- a/app/pipeline/runners/scoped_brain.py
+++ b/app/pipeline/runners/scoped_brain.py
@@ -513,8 +513,19 @@ async def scoped_brain_runner(
         spawn_env["ANTHROPIC_API_KEY"] = api_key
     else:
         spawn_env.pop("ANTHROPIC_API_KEY", None)
-        spawn_env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
-        spawn_env.pop("CLAUDE_CODE_OAUTH_REFRESH_TOKEN", None)
+        # Prefer the auto-refreshing credentials FILE when one is present: its
+        # token is kept fresh (by the host CLI via the ~/.claude bind-mount, or
+        # a refresh flow), so a stale env token must not shadow it.
+        # But when NO creds file is reachable — e.g. the bind-mount isn't
+        # effective (Docker Desktop on WSL), or only a long-lived
+        # `claude setup-token` env token is provisioned — KEEP
+        # CLAUDE_CODE_OAUTH_TOKEN: the headless CLI authenticates with it
+        # directly. Popping it unconditionally left the subprocess with no auth
+        # ("Not logged in · Please run /login") whenever the file was absent.
+        _creds_file = Path("/root/.claude/.credentials.json")
+        if _creds_file.exists() and _creds_file.stat().st_size > 0:
+            spawn_env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+            spawn_env.pop("CLAUDE_CODE_OAUTH_REFRESH_TOKEN", None)
 
     log.info(
         "scoped_brain: spawning subprocess tactic=%s slot=%d model=%s",


### PR DESCRIPTION
## Summary
**All research runs were failing** — locally and on production (`infobroker.tech`) — with `Brain upstream error (HTTP ?)`. Root cause: `scoped_brain.py` popped `CLAUDE_CODE_OAUTH_TOKEN` (and the refresh token) from the brain subprocess env **unconditionally**, then relied on a bind-mounted `/root/.claude/.credentials.json`. When that file isn't present — Docker Desktop on WSL doesn't deliver the host `~/.claude` bind-mount; prod likewise had no file — the subprocess had **no auth** and every brain call failed with `Not logged in · Please run /login`.

A valid long-lived `CLAUDE_CODE_OAUTH_TOKEN` was sitting in the env the whole time; the code just discarded it.

## Fix
Only pop the OAuth env tokens when a non-empty creds file actually exists (so an auto-refreshing file still wins over a stale env token); otherwise **keep `CLAUDE_CODE_OAUTH_TOKEN`** so the headless CLI authenticates with it directly. ~10 lines, one `else` branch.

## Verification (real local stack)
- **Before:** run fails in ~4s, logs show `BRAIN_FAILURE ... Not logged in · Please run /login` for every tactic.
- **After:** identical query runs ~2m41s through the full pipeline (extract → gather/hypothesis_first_search → disconfirm slots 1-6 → ach_rank), **zero auth failures**, terminal `ask_user` (legitimate). Direct `claude -p` auth test in-container returns `AUTHOK` with the env token.
- The env token persists across container rebuilds → no per-rebuild credential re-seeding.

## Prod impact
This is why the prod happy-path test failed earlier. After this deploys (and prod has a valid `CLAUDE_CODE_OAUTH_TOKEN` in its env), prod research should work. Beta uses the Claude **subscription** via `CLAUDE_CODE_OAUTH_TOKEN` — not the Anthropic API.

## Note
A `rate_limit_event` appeared on the final `ach_rank` step (subscription throttle) — separate from this auth fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)