### PR TITLE
feat(brain): bridge IS-loop (Path B) to v3 UI + cleanup orphan runs

### DIFF
--- a/app/pipeline/runners/working_memory.py
+++ b/app/pipeline/runners/working_memory.py
@@ -890,6 +890,159 @@ class WorkingMemory(BaseModel):
             },
         }
 
+    def to_engine_v2_trail(
+        self,
+        status: str = "succeeded",
+        terminate_reason: str | None = None,
+    ) -> tuple[dict, list[dict]]:
+        """Build an engine_v2-shaped trail + per-finding enriched list.
+
+        Path B (IS-loop) didn't originally produce data the v2 UI could read
+        (PhaseDAGView, TacticianSwimLanes, CandidateComparison, ACHMatrix).
+        This adapter maps the brain-loop state onto engine_v2's trail shape so
+        /v3/runs/{id}/replay returns populated phases/cards/candidates.
+
+        Returns:
+          (trail_dict, findings_list) — trail_dict goes into research_trails.trail;
+          findings_list goes into research_trails.findings.
+
+        Mapping:
+          - WM.findings  → one branch each (phase_id from finding.turn → WM phase
+            at that turn, candidate_name from the hypothesis the finding supports)
+          - WM phase entries → phases_full (one per phase observed: explore,
+            test if any test-turn findings exist, synthesize if synthesis_summary set)
+          - WM.hypotheses (status=supported) → ranked_candidates sorted by confidence
+          - ach_matrix → None (Path B does not produce signed evidence weighting)
+        """
+        # Build hypothesis → support map for candidate_name lookup
+        finding_to_hypothesis: dict[str, str] = {}
+        for h in self.hypotheses:
+            for fid in h.supporting_finding_ids:
+                finding_to_hypothesis.setdefault(fid, h.statement)
+
+        # Determine which phase each finding belongs to. The WM tracks the
+        # *current* phase plus phase_entered_at_turn but doesn't store a
+        # per-finding phase. Heuristic: findings from turn 0 → explore;
+        # findings whose turn >= phase_entered_at_turn AND current phase ==
+        # test → test; later (after synthesize entered) → synthesize. We
+        # approximate by binning on turn count, mirroring how the loop
+        # transitions phases linearly.
+        # observed_phases: phase_id → list of finding indices
+        explore_findings: list[int] = []
+        test_findings: list[int] = []
+        synth_findings: list[int] = []
+        # synthesize-phase entry turn (if known): the last phase transition.
+        synth_entry_turn = self.phase_entered_at_turn if self.phase == "synthesize" else None
+        for i, f in enumerate(self.findings):
+            if synth_entry_turn is not None and f.turn >= synth_entry_turn:
+                synth_findings.append(i)
+            elif f.turn == 0 or len(self.hypotheses) == 0 or f.turn < 1:
+                explore_findings.append(i)
+            else:
+                test_findings.append(i)
+
+        # Build per-finding "branches" entries + per-finding enriched list
+        branches: list[dict] = []
+        findings_list: list[dict] = []
+        phase_assignments = [
+            ("explore", explore_findings),
+            ("test", test_findings),
+            ("synthesize", synth_findings),
+        ]
+        for phase_id, idxs in phase_assignments:
+            for i in idxs:
+                f = self.findings[i]
+                candidate = finding_to_hypothesis.get(f.id, "")
+                snippet = (f.content or f.title or "")[:240]
+                branches.append({
+                    "phase_id": phase_id,
+                    "slot_idx": 0,  # Path B uses one slot per phase
+                    "candidate_name": candidate,
+                    "evidence_snippet": snippet,
+                    "source_url": f.source_url,
+                    "source_class": f.source_class,
+                    "confidence": f.confidence,
+                    "technique_id": f.source_tool or "brain_turn",
+                })
+                findings_list.append({
+                    "title": f.title,
+                    "content": f.content,
+                    "source_url": f.source_url,
+                    "source_tool": f.source_tool,
+                    "source_class": f.source_class,
+                    "confidence": int(f.confidence * 100),
+                    "finding_type": "result",
+                    "deception_risk": f.deception_risk,
+                    "deception_flags": f.deception_flags,
+                    "phase_id": phase_id,
+                    "hypothesis_slot": 0,
+                    "technique_id": f.source_tool or "brain_turn",
+                    "evidence_snippet": snippet,
+                    "evidence_summary": snippet,
+                })
+
+        # phases_full: emit one entry per phase that produced findings, plus
+        # synthesize if the brain reached it. Each entry shapes the UI's
+        # PhaseDAGView (status + n_tacticians + distinct_candidate_names).
+        phases_full: list[dict] = []
+        for phase_id, idxs in phase_assignments:
+            if not idxs and phase_id != self.phase:
+                continue
+            candidate_names = sorted({
+                finding_to_hypothesis.get(self.findings[i].id, "")
+                for i in idxs
+                if finding_to_hypothesis.get(self.findings[i].id, "")
+            })
+            phase_status = "passed"
+            if phase_id == self.phase and status not in ("succeeded", "ask_user"):
+                phase_status = "failed" if status == "failed" else "running"
+            phases_full.append({
+                "phase_id": phase_id,
+                "status": phase_status,
+                "gate_status": "pass" if phase_status == "passed" else (
+                    "fail" if phase_status == "failed" else "ask_user"
+                ),
+                "distinct_candidate_names": candidate_names,
+                "metadata": {"num_tacticians": 1},
+                "gate_result": None,
+            })
+
+        # ranked_candidates from supported hypotheses (sorted high→low)
+        ranked_candidates: list[dict] = []
+        supported = sorted(
+            (h for h in self.hypotheses if h.status == "supported"),
+            key=lambda h: -h.confidence,
+        )
+        # Build a quick map for evidence backfill
+        finding_by_id = {f.id: f for f in self.findings}
+        for h in supported:
+            evidence = []
+            for fid in h.supporting_finding_ids[:8]:
+                f = finding_by_id.get(fid)
+                if f is None:
+                    continue
+                evidence.append({
+                    "snippet": (f.content or f.title or "")[:200],
+                    "source_url": f.source_url,
+                    "source_class": f.source_class,
+                })
+            ranked_candidates.append({
+                "name": h.statement,
+                "score": h.confidence,
+                "evidence": evidence,
+            })
+
+        trail = {
+            "branches": branches,
+            "phases": [p["phase_id"] for p in phases_full],
+            "phases_full": phases_full,
+            "status": status,
+            "terminate_reason": terminate_reason,
+            "ranked_candidates": ranked_candidates,
+            "ach_matrix": None,  # Path B does not currently produce ACH weighting
+        }
+        return trail, findings_list
+
     def _render_cross_run_priors(self) -> str:
         if not self.cross_run_priors:
             return "CROSS-RUN PRIORS: (no semantically-related prior research found)"

--- a/app/pipeline/tests/test_engine_v2_trail_adapter.py
+++ b/app/pipeline/tests/test_engine_v2_trail_adapter.py
@@ -1,0 +1,89 @@
+"""WorkingMemory.to_engine_v2_trail() — verify the IS-loop → v2-UI adapter.
+
+Built to close the v3-broke-v2-UI gap: the Path B brain loop produces a
+WorkingMemory whose natural shape doesn't fit the v2-UI's expectations
+(PhaseDAGView, CandidateComparison, ACHMatrix). The adapter projects
+WM state onto engine_v2's trail shape so /v3/runs/{id}/replay returns
+populated phases/cards/candidates.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.pipeline.runners.working_memory import (
+    Finding, Hypothesis, WorkingMemory,
+)
+
+
+def _wm_with(*, findings, hypotheses, phase="synthesize", phase_entered_at_turn=3) -> WorkingMemory:
+    return WorkingMemory(
+        run_id=uuid4(), question="q",
+        findings=findings,
+        hypotheses=hypotheses,
+        phase=phase,
+        phase_entered_at_turn=phase_entered_at_turn,
+        turn=phase_entered_at_turn,
+    )
+
+
+def test_empty_wm_produces_empty_branches_and_phases():
+    wm = _wm_with(findings=[], hypotheses=[], phase="explore", phase_entered_at_turn=0)
+    trail, findings = wm.to_engine_v2_trail()
+    assert trail["branches"] == []
+    assert findings == []
+    # Empty WM still emits the current phase entry so the UI shows the run
+    # in its starting state rather than as a completely blank DAG.
+    assert {p["phase_id"] for p in trail["phases_full"]} == {"explore"}
+    assert trail["ranked_candidates"] == []
+    assert trail["ach_matrix"] is None
+
+
+def test_findings_become_branches_with_phase_assignment():
+    h = Hypothesis(statement="Stripe was founded by the Collison brothers", status="supported", confidence=0.9)
+    f1 = Finding(title="founding", content="2010 by Patrick + John Collison", turn=0, source_class="primary_official", confidence=0.9)
+    f2 = Finding(title="company history", content="founded in Palo Alto", turn=2, source_class="news", confidence=0.7)
+    h.supporting_finding_ids = [f1.id, f2.id]
+    wm = _wm_with(findings=[f1, f2], hypotheses=[h])
+    trail, findings = wm.to_engine_v2_trail()
+
+    assert len(trail["branches"]) == 2
+    # Each branch carries phase_id, candidate_name (from hypothesis), source fields
+    phase_ids = {b["phase_id"] for b in trail["branches"]}
+    assert "explore" in phase_ids  # turn-0 finding → explore
+    cands = {b["candidate_name"] for b in trail["branches"]}
+    assert "Stripe was founded by the Collison brothers" in cands
+    # Findings list is parallel — has phase_id + technique_id + evidence_snippet
+    assert len(findings) == 2
+    assert all("phase_id" in f for f in findings)
+    assert all("evidence_snippet" in f for f in findings)
+
+
+def test_supported_hypotheses_become_ranked_candidates_sorted():
+    h_strong = Hypothesis(statement="Strong claim", status="supported", confidence=0.9)
+    h_weak   = Hypothesis(statement="Weak claim",   status="supported", confidence=0.4)
+    h_refuted = Hypothesis(statement="Refuted",     status="refuted",   confidence=0.1)
+    wm = _wm_with(findings=[], hypotheses=[h_weak, h_strong, h_refuted])
+    trail, _ = wm.to_engine_v2_trail()
+
+    names = [c["name"] for c in trail["ranked_candidates"]]
+    assert names == ["Strong claim", "Weak claim"]  # refuted excluded; sorted desc
+    assert trail["ranked_candidates"][0]["score"] == 0.9
+
+
+def test_phases_full_includes_n_tacticians_and_gate_status():
+    f = Finding(title="t", turn=0, confidence=0.5)
+    wm = _wm_with(findings=[f], hypotheses=[], phase="synthesize", phase_entered_at_turn=2)
+    trail, _ = wm.to_engine_v2_trail(status="succeeded", terminate_reason="synthesized")
+
+    for p in trail["phases_full"]:
+        assert p["metadata"]["num_tacticians"] == 1
+        assert p["gate_status"] in ("pass", "fail", "ask_user")
+
+
+def test_terminate_reason_threaded_through():
+    wm = _wm_with(findings=[], hypotheses=[])
+    trail, _ = wm.to_engine_v2_trail(status="ask_user", terminate_reason="max_turns_exceeded")
+    assert trail["status"] == "ask_user"
+    assert trail["terminate_reason"] == "max_turns_exceeded"

--- a/app/routers/v3/pipelines.py
+++ b/app/routers/v3/pipelines.py
@@ -284,6 +284,49 @@ def list_all_pipeline_runs(user: dict = Depends(get_current_user)):
     return [PipelineRunSummaryOut(**dict(r)) for r in rows]
 
 
+@router.delete("/runs/purge-trailless", status_code=200)
+def purge_trailless_runs(
+    dry_run: bool = True,
+    user: dict = Depends(get_current_user),
+):
+    """Admin-only: delete pipeline_runs that have no research_trails row.
+
+    Targets the Path B / IS-loop regression where post_process never wrote a
+    trail (fixed forward by adding the INSERT in post_process). These rows
+    pollute the user's run list with entries that always 404 in the UI.
+
+    Returns the list of affected ids. Pass ?dry_run=false to actually delete.
+    Cascades: pipeline_step_runs / run_share_links / webhook_deliveries via
+    ON DELETE CASCADE; budget_ledger_entries via ON DELETE SET NULL.
+    """
+    if not user.get("is_admin"):
+        raise HTTPException(status_code=403, detail="Admin only")
+
+    rows = fetch_all(
+        """SELECT pr.id, pr.status, pr.query, pr.started_at, pr.user_id
+             FROM pipeline_runs pr
+        LEFT JOIN research_trails rt ON rt.run_id = pr.id
+            WHERE rt.id IS NULL
+         ORDER BY pr.started_at DESC""",
+    )
+    ids = [str(r["id"]) for r in rows]
+
+    if dry_run or not ids:
+        return {"dry_run": dry_run, "count": len(ids), "ids": ids,
+                "samples": [dict(r) for r in rows[:5]]}
+
+    # Detach FK rows that don't cascade (research_skills has no ON DELETE rule)
+    execute(
+        "UPDATE research_skills SET run_id = NULL WHERE run_id = ANY(%s::uuid[])",
+        (ids,),
+    )
+    execute(
+        "DELETE FROM pipeline_runs WHERE id = ANY(%s::uuid[])",
+        (ids,),
+    )
+    return {"dry_run": False, "deleted": len(ids), "ids": ids}
+
+
 @router.post("/runs/{run_id}/cancel", status_code=204)
 async def cancel_pipeline_run(run_id: str, user: dict = Depends(get_current_user)):
     from temporalio.client import Client

--- a/app/temporal/activities/brain_turn.py
+++ b/app/temporal/activities/brain_turn.py
@@ -18,6 +18,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Awaitable, Callable
 from uuid import UUID
 
 from temporalio import activity
@@ -205,16 +206,53 @@ async def init_working_memory(inp: InitWorkingMemoryInput) -> str:
 # ── run_brain_turn ────────────────────────────────────────────────────────────
 @activity.defn(name="run_brain_turn")
 async def run_brain_turn(inp: BrainTurnInput) -> BrainTurnOutput:
-    """Run one brain turn: read WM, build prompt, spawn subprocess, parse delta, apply."""
+    """Run one brain turn: read WM, build prompt, spawn subprocess, parse delta, apply.
+
+    Emits the same `is.phase_*` / `is.tactician_*` / `is.tool_call` WS event
+    family engine_v2 produces, so the v3 UI's DAG / swimlanes / cards
+    populate live for IS-loop runs (not only via end-of-run replay).
+    """
     wm = WorkingMemory.model_validate_json(inp.working_memory_json)
+    prev_phase = wm.phase  # for phase-transition detection after apply()
     wm = wm.model_copy(update={"turn": wm.turn + 1})  # increment turn counter
 
+    # On the first turn into a phase, announce it. The workflow's prior brain
+    # turn is responsible for emitting the prior phase's *complete* event.
+    if wm.turn == 1:
+        await _push_event(inp.user_id, {
+            "type": "is.phase_start", "phase_id": wm.phase,
+            "job_id": inp.run_id, "run_id": inp.run_id,
+            "n_tacticians": 1,
+        })
+    await _push_event(inp.user_id, {
+        "type": "is.tactician_start", "phase_id": wm.phase, "slot_idx": 0,
+        "job_id": inp.run_id, "run_id": inp.run_id,
+        "tactic_id": "brain_turn", "forbidden_candidates": [],
+    })
+
     prompt = build_turn_prompt(wm, past_research=inp.past_research or [])
+
+    async def _on_tool_call(tool_name: str, input_dict: dict) -> None:
+        # Mirror is.tool_call shape from engine_v2 / agent.py:466.
+        await _push_event(inp.user_id, {
+            "type": "is.tool_call",
+            "job_id": inp.run_id, "run_id": inp.run_id,
+            "tool": tool_name,
+            "status": "calling",
+            "query_preview": str(
+                input_dict.get("query")
+                or input_dict.get("url")
+                or input_dict.get("name")
+                or input_dict.get("term")
+                or ""
+            )[:120],
+            "input": input_dict,
+        })
 
     heartbeat_task = asyncio.create_task(_heartbeat_loop())
     try:
         result_text, tool_call_count, err = await _spawn_brain_turn_subprocess(
-            prompt, phase=wm.phase,
+            prompt, phase=wm.phase, on_tool_call=_on_tool_call,
         )
         if err:
             return BrainTurnOutput(
@@ -258,6 +296,41 @@ async def run_brain_turn(inp: BrainTurnInput) -> BrainTurnOutput:
             tool_call_count=tool_call_count,
         )
 
+        # Live UI events: tactician_complete for the slot just finished, plus
+        # phase transition events if the brain advanced the phase.
+        new_finding_ids = {f.id for f in new_wm.findings if f.turn == new_wm.turn}
+        candidates_for_turn: set[str] = set()
+        for h in new_wm.hypotheses:
+            for fid in h.supporting_finding_ids:
+                if fid in new_finding_ids:
+                    candidates_for_turn.add(h.statement)
+        await _push_event(inp.user_id, {
+            "type": "is.tactician_complete",
+            "phase_id": prev_phase, "slot_idx": 0,
+            "job_id": inp.run_id, "run_id": inp.run_id,
+            "candidate_names": sorted(candidates_for_turn),
+            "findings_count": len(new_finding_ids),
+        })
+        if new_wm.phase != prev_phase:
+            # Phase advanced — close prior, open new.
+            phase_candidates = sorted({
+                h.statement for h in new_wm.hypotheses
+                if any(fid in {f.id for f in new_wm.findings} for fid in h.supporting_finding_ids)
+            })
+            await _push_event(inp.user_id, {
+                "type": "is.phase_complete",
+                "phase_id": prev_phase,
+                "job_id": inp.run_id, "run_id": inp.run_id,
+                "status": "passed", "gate_status": "pass",
+                "distinct_candidate_names": phase_candidates,
+            })
+            await _push_event(inp.user_id, {
+                "type": "is.phase_start",
+                "phase_id": new_wm.phase,
+                "job_id": inp.run_id, "run_id": inp.run_id,
+                "n_tacticians": 1,
+            })
+
         # Observability: log a compact line per turn so we can audit whether
         # the brain emitted hypothesis_updates (the load-bearing analytical
         # signal) and which IDs it used.
@@ -282,11 +355,21 @@ async def run_brain_turn(inp: BrainTurnInput) -> BrainTurnOutput:
         heartbeat_task.cancel()
 
 
+async def _push_event(user_id: str, payload: dict) -> None:
+    """Best-effort WS push from inside a Temporal activity. Never raises."""
+    try:
+        from app.routers.v3.stream import push_event
+        await push_event(user_id, payload)
+    except Exception as exc:
+        log.debug("push_event failed (non-fatal): %s", exc)
+
+
 # ── subprocess plumbing (minimal version of is_brain.run_research) ────────────
 async def _spawn_brain_turn_subprocess(
     prompt: str,
     *,
     phase: str = "explore",
+    on_tool_call: Callable[[str, dict], Awaitable[None]] | None = None,
 ) -> tuple[str, int, str | None]:
     """Spawn claude with the turn prompt + phase-gated tool allowlist.
 
@@ -346,6 +429,14 @@ async def _spawn_brain_turn_subprocess(
                     for content in event.get("message", {}).get("content", []):
                         if content.get("type") == "tool_use":
                             tool_calls += 1
+                            if on_tool_call is not None:
+                                tool_name = content.get("name", "")
+                                # Strip MCP prefix for UI consistency with engine_v2.
+                                clean = tool_name.split("__")[-1] if "__" in tool_name else tool_name
+                                try:
+                                    await on_tool_call(clean, content.get("input") or {})
+                                except Exception:
+                                    pass
                 if etype == "result":
                     result_line = line
         except asyncio.LimitOverrunError:

--- a/app/temporal/activities/post_process.py
+++ b/app/temporal/activities/post_process.py
@@ -1,6 +1,8 @@
 """Post-processing activity — scorecard, KG, session, webhook."""
 from __future__ import annotations
+import json
 import logging
+import uuid
 from dataclasses import dataclass, field
 from temporalio import activity
 
@@ -90,6 +92,44 @@ async def post_process(inp: PostProcessInput) -> None:
     except Exception as exc:
         log.warning("PIR coverage failed (non-fatal): %s", exc)
 
+    # Persist research_trails row. The workflow now builds an engine_v2-shaped
+    # trail via WorkingMemory.to_engine_v2_trail() and stashes it under
+    # _engine_v2_trail / _engine_v2_findings so /v3/runs/{id}/replay returns
+    # populated phases / cards / candidates for IS-loop runs. Falls back to
+    # the legacy `tree` shape if those keys are absent (e.g. ISRunWorkflow
+    # Path A, which doesn't yet build a v2 trail).
+    try:
+        execute("DELETE FROM research_trails WHERE run_id = %s", (inp.run_id,))
+        trail_id = str(uuid.uuid4())
+        v2_trail = result.get("_engine_v2_trail")
+        v2_findings = result.get("_engine_v2_findings")
+        if isinstance(v2_trail, dict) and isinstance(v2_findings, list):
+            trail_blob = v2_trail
+            findings_blob = v2_findings
+            tool_calls_count = len(v2_trail.get("branches") or [])
+        else:
+            trail_blob = result.get("tree") or {}
+            findings_blob = findings
+            tool_calls_count = (result.get("tree") or {}).get("total_branches", 0)
+        execute(
+            """INSERT INTO research_trails
+                (id, user_id, run_id, query, entity_type, trail, findings, tool_calls, suggested_pipeline)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+            (
+                trail_id,
+                inp.user_id,
+                inp.run_id,
+                result.get("query", ""),
+                result.get("entity_type", "unknown"),
+                json.dumps(trail_blob),
+                json.dumps(findings_blob),
+                tool_calls_count,
+                json.dumps(result.get("pipeline")) if result.get("pipeline") else None,
+            ),
+        )
+    except Exception as exc:
+        log.warning("research_trails persistence failed (non-fatal): %s", exc)
+
     # Mark succeeded
     execute(
         """UPDATE pipeline_runs
@@ -104,6 +144,19 @@ async def post_process(inp: PostProcessInput) -> None:
         "type": "job.completed", "job_id": inp.run_id, "run_id": inp.run_id,
         "status": "succeeded", "result": result,
     }))
+
+    # Push is.run_complete so the v3 UI's CandidateComparison + ACHMatrix
+    # populate live without waiting for the user to navigate away and back
+    # to trigger a replay-hydrate. Mirrors engine_v2.py's emission.
+    _v2 = result.get("_engine_v2_trail") or {}
+    if isinstance(_v2, dict):
+        asyncio.create_task(push_event(inp.user_id, {
+            "type": "is.run_complete",
+            "job_id": inp.run_id, "run_id": inp.run_id,
+            "status": _v2.get("status") or "succeeded",
+            "ranked_candidates": _v2.get("ranked_candidates") or [],
+            "ach_matrix": _v2.get("ach_matrix"),
+        }))
 
     # Session update
     if inp.session_id:

--- a/app/temporal/workflows/is_loop_run.py
+++ b/app/temporal/workflows/is_loop_run.py
@@ -261,6 +261,21 @@ class IsLoopRunWorkflow:
         legacy_result = final_wm.to_legacy_brain_result()
         legacy_result["_loop_meta"]["terminate_reason"] = terminate_reason
 
+        # Build the engine_v2-shaped trail alongside the legacy shape so that
+        # /v3/runs/{id}/replay returns populated phases/cards/candidates for
+        # IS-loop runs. post_process persists whichever shape is present
+        # (engine_v2 preferred when both exist).
+        _final_status = (
+            "cancelled" if terminate_reason == "cancelled_by_user"
+            else "failed" if terminate_reason.startswith("turn_error")
+            else "succeeded"
+        )
+        _v2_trail, _v2_findings = final_wm.to_engine_v2_trail(
+            status=_final_status, terminate_reason=terminate_reason,
+        )
+        legacy_result["_engine_v2_trail"] = _v2_trail
+        legacy_result["_engine_v2_findings"] = _v2_findings
+
         # Honesty: status column is binary (succeeded/failed/cancelled) and we
         # don't add a new "partial" status here. Instead, when the loop did NOT
         # reach synthesize, prepend a clear gap so the result surface reflects

--- a/docs/runbooks/purge-trailless-runs.sql
+++ b/docs/runbooks/purge-trailless-runs.sql
@@ -1,0 +1,77 @@
+-- Purge pipeline_runs that have no research_trails row.
+--
+-- Context: the Path B / IS-loop substrate (default since 6d02595) marked
+-- runs succeeded via post_process without writing a trail. The UI's Results
+-- panel calls /v3/runs/{id}/replay, which reads research_trails, so these
+-- runs always render empty.
+--
+-- The forward fix is in app/temporal/activities/post_process.py (adds the
+-- INSERT). This script removes the orphans created before that fix.
+--
+-- USAGE (preview first):
+--   psql $DATABASE_URL -f docs/runbooks/purge-trailless-runs.sql
+--
+-- The script wraps everything in a transaction and ends with ROLLBACK by
+-- default. Change the final ROLLBACK to COMMIT once you've reviewed the
+-- preview output.
+
+BEGIN;
+
+-- 1. Preview what will be deleted ------------------------------------------
+\echo '=== Runs without research_trails (purge candidates) ==='
+
+SELECT pr.id,
+       pr.status,
+       pr.user_id,
+       pr.started_at,
+       left(coalesce(pr.query, ''), 60) AS query_preview
+  FROM pipeline_runs pr
+  LEFT JOIN research_trails rt ON rt.run_id = pr.id
+ WHERE rt.id IS NULL
+ ORDER BY pr.started_at DESC;
+
+\echo ''
+\echo '=== Dependent rows that will cascade or be detached ==='
+
+SELECT 'pipeline_step_runs'     AS table, count(*) FROM pipeline_step_runs WHERE run_id IN (
+    SELECT pr.id FROM pipeline_runs pr LEFT JOIN research_trails rt ON rt.run_id = pr.id WHERE rt.id IS NULL
+) UNION ALL
+SELECT 'run_share_links',      count(*) FROM run_share_links WHERE run_id IN (
+    SELECT pr.id FROM pipeline_runs pr LEFT JOIN research_trails rt ON rt.run_id = pr.id WHERE rt.id IS NULL
+) UNION ALL
+SELECT 'webhook_deliveries',   count(*) FROM webhook_deliveries WHERE run_id IN (
+    SELECT pr.id FROM pipeline_runs pr LEFT JOIN research_trails rt ON rt.run_id = pr.id WHERE rt.id IS NULL
+) UNION ALL
+SELECT 'budget_ledger_entries (SET NULL)', count(*) FROM budget_ledger_entries WHERE run_id IN (
+    SELECT pr.id FROM pipeline_runs pr LEFT JOIN research_trails rt ON rt.run_id = pr.id WHERE rt.id IS NULL
+) UNION ALL
+SELECT 'research_skills (SET NULL manual)', count(*) FROM research_skills WHERE run_id IN (
+    SELECT pr.id FROM pipeline_runs pr LEFT JOIN research_trails rt ON rt.run_id = pr.id WHERE rt.id IS NULL
+);
+
+-- 2. Detach FK rows that don't have ON DELETE CASCADE / SET NULL -----------
+UPDATE research_skills
+   SET run_id = NULL
+ WHERE run_id IN (
+    SELECT pr.id FROM pipeline_runs pr
+    LEFT JOIN research_trails rt ON rt.run_id = pr.id
+    WHERE rt.id IS NULL
+);
+
+-- 3. Delete the trailless runs ---------------------------------------------
+WITH deleted AS (
+    DELETE FROM pipeline_runs pr
+    USING (
+        SELECT pr2.id
+          FROM pipeline_runs pr2
+     LEFT JOIN research_trails rt ON rt.run_id = pr2.id
+         WHERE rt.id IS NULL
+    ) t
+    WHERE pr.id = t.id
+    RETURNING pr.id
+)
+SELECT count(*) AS rows_deleted FROM deleted;
+
+-- 4. End: ROLLBACK by default; change to COMMIT to apply -------------------
+ROLLBACK;
+-- COMMIT;

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -71,7 +71,7 @@ export interface AgentSession {
   run_count: number
   accumulated_summary: string
   entity_type: string
-  conversation_thread?: Array<{ role: string; content: string; timestamp?: string }>
+  conversation_thread?: Array<{ role: string; content: string; timestamp?: string; ts?: string; run_id?: string | null }>
 }
 
 export interface AgentPipelineOut {

--- a/frontend/src/components/agent/AgentChat.tsx
+++ b/frontend/src/components/agent/AgentChat.tsx
@@ -211,12 +211,16 @@ export default function AgentChat() {
     setSearchParams(next, { replace: true })
   }, [searchParams, setSearchParams])
 
-  // Rehydrate chat from server on mount when local store is empty (e.g. fresh
-  // login, or a different device). Source of truth is agent_sessions; the
-  // local zustand persist cache is just a hot path. Without this, a user
-  // sees a blank Agent panel after logout/login even though their threads
-  // exist on the backend.
+  // Rehydrate chat from server when local store is empty (e.g. fresh login,
+  // 401 → refresh → retry, or a different device). Source of truth is
+  // agent_sessions; the local zustand persist cache is just a hot path.
+  // Re-runs when the access token changes so post-login / post-refresh races
+  // don't leave the panel blank. The chatMessages.length guard prevents an
+  // active session's in-memory messages from being clobbered by a stale
+  // rehydrate.
+  const accessToken = useSessionStore(s => s.accessToken)
   useEffect(() => {
+    if (!accessToken) return
     if (chatMessages.length > 0) return
     let cancelled = false
     async function rehydrate() {
@@ -237,6 +241,15 @@ export default function AgentChat() {
           timestamp?: string
           run_id?: string | null
         }>
+        // Also restore the Results panel to this session's last run so the
+        // DAG/cards re-render on cold app open — ResultsPanel auto-seeds
+        // runStreamStore from /v3/runs/{id}/replay when col1Content changes.
+        const lastRunId = [...thread].reverse().find(e => e.run_id)?.run_id
+        if (lastRunId) {
+          const s = useSessionStore.getState()
+          s.setActiveJobId(lastRunId)
+          s.setCol1Content({ type: 'pipeline_run', runId: lastRunId })
+        }
         if (thread.length === 0) {
           setSessionId(target.id)
           if (target.genesis_query) setGenesisQuery(target.genesis_query)
@@ -258,7 +271,7 @@ export default function AgentChat() {
     }
     void rehydrate()
     return () => { cancelled = true }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [accessToken]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // run_ids that have a brain.question in flight — skip "Researching…" for these
   const pendingQuestionsRef = useRef<Set<string>>(new Set())

--- a/frontend/src/components/live/LiveStream.tsx
+++ b/frontend/src/components/live/LiveStream.tsx
@@ -5,7 +5,6 @@ import { listAllPipelineRuns, type PipelineRunSummary } from '../../api/pipeline
 import { useWebSocket, type WsEvent } from '../../hooks/useWebSocket'
 import { useChatStore } from '../../stores/chatStore'
 import { useSessionStore } from '../../stores/sessionStore'
-import { replayRunIntoStore } from '../../hooks/useReplay'
 import JobItem from './JobItem'
 import PipelineRunItem from './PipelineRunItem'
 import { Skeleton } from '../ui/skeleton'
@@ -18,6 +17,8 @@ function SessionHistoryItem({ session }: { session: AgentSession }) {
   const setGenesisQuery = useChatStore(s => s.setGenesisQuery)
   const clearMessages = useChatStore(s => s.clearMessages)
   const setMessages = useChatStore(s => s.setMessages)
+  const setCol1Content = useSessionStore(s => s.setCol1Content)
+  const setActiveJobId = useSessionStore(s => s.setActiveJobId)
   const [resumingId, setResumingId] = useState<string | null>(null)
 
   const resume = async () => {
@@ -43,6 +44,14 @@ function SessionHistoryItem({ session }: { session: AgentSession }) {
       }
       setSessionId(session.id)
       setGenesisQuery(session.genesis_query)
+      // Restore the Results panel to the session's most recent run so the
+      // user sees the DAG/cards/candidates they had open before. ResultsPanel
+      // auto-seeds runStreamStore via replay when col1Content changes.
+      const lastRunId = [...thread].reverse().find(e => e.run_id)?.run_id
+      if (lastRunId) {
+        setActiveJobId(lastRunId)
+        setCol1Content({ type: 'pipeline_run', runId: lastRunId })
+      }
     } catch {
       clearMessages()
       setSessionId(session.id)

--- a/frontend/src/components/results/ResultsPanel.tsx
+++ b/frontend/src/components/results/ResultsPanel.tsx
@@ -16,6 +16,7 @@ import { Sparkles, ArrowDownToLine, Save, RefreshCw, RotateCcw, Layers, Loader2,
 import { RunResultsView } from './RunResultsView'
 import { RunningTabBadge } from './RunningTabBadge'
 import { useRunStreamStore } from '../../stores/runStreamStore'
+import { replayRunIntoStore } from '../../hooks/useReplay'
 
 // Tab is either the static 'Pipeline' tab, the static 'Results' tab, or a dynamic run tab identified by run ID
 type Tab = 'Pipeline' | 'Results' | `run:${string}`
@@ -1851,8 +1852,33 @@ export default function ResultsPanel() {
   // Also un-dismiss the tab if it was previously closed.
   useEffect(() => {
     if (col1Content?.type === 'pipeline_run') {
-      setDismissedTabs(prev => { const n = new Set(prev); n.delete(col1Content.runId); return n })
-      setActiveTab(`run:${col1Content.runId}`)
+      const runId = col1Content.runId
+      setDismissedTabs(prev => { const n = new Set(prev); n.delete(runId); return n })
+      setActiveTab(`run:${runId}`)
+      // Seed runStreamStore for past runs so DAG / cards / candidates / ACH
+      // render on click-into-history. Live runs are already populated by WS
+      // events — skip those to avoid clobbering in-flight state.
+      const existing = useRunStreamStore.getState().runsById[runId]
+      const isLiveOrSeeded =
+        !!existing && (existing.status === 'running' || (existing.cardOrder?.length ?? 0) > 0)
+      if (!isLiveOrSeeded) {
+        void replayRunIntoStore(runId).then((ok) => {
+          // If replay returns 404 / no data, seed a minimal hydrated entry so
+          // the empty state renders "No node results were recorded for this
+          // run" instead of the in-flight "No events yet" copy.
+          if (!ok) {
+            const stillMissing = !useRunStreamStore.getState().runsById[runId]?.hydratedFromServer
+            if (stillMissing) {
+              useRunStreamStore.getState().hydrateFromServer(runId, {
+                kind: 'is',
+                status: 'succeeded',
+                cards: {},
+                cardOrder: [],
+              })
+            }
+          }
+        })
+      }
     } else if (col1Content?.type === 'job') {
       setDismissedTabs(prev => { const n = new Set(prev); n.delete(col1Content.jobId); return n })
       setActiveTab(`run:${col1Content.jobId}`)

--- a/frontend/src/components/results/StreamingCardList.tsx
+++ b/frontend/src/components/results/StreamingCardList.tsx
@@ -129,7 +129,11 @@ export function StreamingCardList({ runId, filterByTactician }: StreamingCardLis
 
       {cardOrder.length === 0 && (
         <p className="text-sm text-muted-foreground italic text-center mt-8">
-          No node events received yet.
+          {run.status === 'running'
+            ? 'No node events received yet.'
+            : run.hydratedFromServer
+            ? 'No node results were recorded for this run.'
+            : 'No data available for this run yet — open a live run or wait for replay to load.'}
         </p>
       )}
 

--- a/frontend/src/lib/clearClientSession.ts
+++ b/frontend/src/lib/clearClientSession.ts
@@ -11,6 +11,7 @@ const USER_SCOPED_KEYS = [
   'ib-chat',
   'info-broker.mode',
   'locked_pipelines',
+  'ib-session-view',
 ]
 
 /**

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -53,15 +53,40 @@ function safeGetItem(key: string): string | null {
 const storedToken = safeGetItem('access_token')
 const initialClaims = claimsFromToken(storedToken)
 
+// Rehydrate the open Results tab across refreshes. clearClientSession() removes
+// this key on logout so it doesn't leak between users on a shared browser.
+const VIEW_KEY = 'ib-session-view'
+type PersistedView = {
+  activeJobId: string | null
+  col1Content: SessionState['col1Content']
+}
+function loadPersistedView(): PersistedView {
+  try {
+    const raw = safeGetItem(VIEW_KEY)
+    if (!raw) return { activeJobId: null, col1Content: null }
+    const parsed = JSON.parse(raw) as Partial<PersistedView>
+    return {
+      activeJobId: parsed.activeJobId ?? null,
+      col1Content: parsed.col1Content ?? null,
+    }
+  } catch {
+    return { activeJobId: null, col1Content: null }
+  }
+}
+function savePersistedView(view: PersistedView): void {
+  try { localStorage.setItem(VIEW_KEY, JSON.stringify(view)) } catch { /* storage unavailable */ }
+}
+const initialView = loadPersistedView()
+
 export const useSessionStore = create<SessionState>((set) => ({
   accessToken: storedToken,
   username: null,
   userId:   initialClaims.userId,
   isAdmin:  initialClaims.isAdmin,
   role:     initialClaims.role,
-  activeJobId: null,
+  activeJobId: initialView.activeJobId,
   agentInput: '',
-  col1Content: null,
+  col1Content: initialView.col1Content,
 
   setTokens: (access, refresh) => {
     localStorage.setItem('access_token', access)
@@ -78,11 +103,17 @@ export const useSessionStore = create<SessionState>((set) => ({
 
   setIsAdmin: (isAdmin) => set({ isAdmin }),
 
-  setActiveJobId: (id) => set({ activeJobId: id }),
+  setActiveJobId: (id) => {
+    set({ activeJobId: id })
+    savePersistedView({ activeJobId: id, col1Content: useSessionStore.getState().col1Content })
+  },
 
   setAgentInput: (text) => set({ agentInput: text }),
 
-  setCol1Content: (content) => set({ col1Content: content }),
+  setCol1Content: (content) => {
+    set({ col1Content: content })
+    savePersistedView({ activeJobId: useSessionStore.getState().activeJobId, col1Content: content })
+  },
 
   logout: () => {
     clearClientSession()

--- a/tests/temporal/test_post_process_trail.py
+++ b/tests/temporal/test_post_process_trail.py
@@ -1,0 +1,150 @@
+"""post_process must persist a research_trails row so /v3/runs/id/replay can
+hydrate IS-loop runs. Regression guard: Path B previously marked
+pipeline_runs succeeded but skipped the trail write, leaving the UI panel
+empty for completed runs.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_post_process_inserts_research_trail():
+    from app.temporal.activities.post_process import post_process, PostProcessInput
+
+    brain_result = {
+        "query": "founders of SpaceX",
+        "entity_type": "company",
+        "summary": "Musk founded SpaceX in 2002.",
+        "findings": [
+            {"title": "founding", "content": "2002", "source_class": "primary_official"},
+        ],
+        "tree": {"total_branches": 3},
+        "pipeline": None,
+    }
+
+    captured: list[tuple[str, tuple]] = []
+
+    def fake_execute(sql, params=()):
+        captured.append((sql, params))
+
+    fake_fetch_one = MagicMock(return_value={"status": "running"})
+
+    with patch("app.routers.v3.db.execute", side_effect=fake_execute), \
+         patch("app.routers.v3.db.fetch_one", fake_fetch_one), \
+         patch("app.routers.v3.stream.push_event", AsyncMock(return_value=None)), \
+         patch("app.memory.writer.index_research_findings", AsyncMock(return_value=0)):
+        await post_process(PostProcessInput(
+            run_id="11111111-1111-1111-1111-111111111111",
+            user_id="22222222-2222-2222-2222-222222222222",
+            session_id=None,
+            brain_result=brain_result,
+        ))
+
+    inserts = [(s, p) for s, p in captured if "INSERT INTO research_trails" in s]
+    assert len(inserts) == 1, f"expected exactly one trail INSERT, captured: {[s[:60] for s,_ in captured]}"
+
+    _, params = inserts[0]
+    # id, user_id, run_id, query, entity_type, trail, findings, tool_calls, pipeline
+    assert params[1] == "22222222-2222-2222-2222-222222222222"
+    assert params[2] == "11111111-1111-1111-1111-111111111111"
+    assert params[3] == "founders of SpaceX"
+    assert params[4] == "company"
+    trail = json.loads(params[5])
+    assert trail.get("total_branches") == 3
+    findings = json.loads(params[6])
+    assert findings[0]["title"] == "founding"
+    assert params[7] == 3   # tool_calls = tree.total_branches
+    assert params[8] is None  # suggested_pipeline
+
+
+@pytest.mark.asyncio
+async def test_post_process_uses_engine_v2_trail_when_present():
+    """When the workflow attaches _engine_v2_trail / _engine_v2_findings, the
+    trail JSONB column gets the engine_v2 shape (with branches / phases_full
+    / ranked_candidates) so /v3/runs/{id}/replay returns populated data
+    for the v3 UI."""
+    from app.temporal.activities.post_process import post_process, PostProcessInput
+
+    v2_trail = {
+        "branches": [
+            {"phase_id": "explore", "slot_idx": 0, "candidate_name": "c1",
+             "evidence_snippet": "snip", "source_class": "primary_official",
+             "confidence": 0.9, "technique_id": "brain_turn"},
+        ],
+        "phases_full": [
+            {"phase_id": "explore", "status": "passed", "gate_status": "pass",
+             "distinct_candidate_names": ["c1"],
+             "metadata": {"num_tacticians": 1}, "gate_result": None},
+        ],
+        "ranked_candidates": [{"name": "c1", "score": 0.9, "evidence": []}],
+        "ach_matrix": None,
+        "status": "succeeded",
+        "terminate_reason": "synthesized",
+    }
+    v2_findings = [
+        {"title": "f", "phase_id": "explore", "hypothesis_slot": 0,
+         "technique_id": "brain_turn", "evidence_snippet": "snip"},
+    ]
+
+    captured: list[tuple[str, tuple]] = []
+
+    def fake_execute(sql, params=()):
+        captured.append((sql, params))
+
+    fake_fetch_one = MagicMock(return_value={"status": "running"})
+
+    with patch("app.routers.v3.db.execute", side_effect=fake_execute), \
+         patch("app.routers.v3.db.fetch_one", fake_fetch_one), \
+         patch("app.routers.v3.stream.push_event", AsyncMock(return_value=None)), \
+         patch("app.memory.writer.index_research_findings", AsyncMock(return_value=0)):
+        await post_process(PostProcessInput(
+            run_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            user_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            session_id=None,
+            brain_result={
+                "query": "q", "findings": [],
+                "_engine_v2_trail": v2_trail,
+                "_engine_v2_findings": v2_findings,
+            },
+        ))
+
+    inserts = [(s, p) for s, p in captured if "INSERT INTO research_trails" in s]
+    assert len(inserts) == 1
+    _, params = inserts[0]
+    trail_blob = json.loads(params[5])
+    findings_blob = json.loads(params[6])
+    # The engine_v2 shape should have flowed through, NOT the legacy `tree` shape
+    assert "branches" in trail_blob
+    assert "phases_full" in trail_blob
+    assert trail_blob["ranked_candidates"][0]["name"] == "c1"
+    assert findings_blob[0]["phase_id"] == "explore"
+    assert params[7] == 1  # tool_calls = len(branches)
+
+
+@pytest.mark.asyncio
+async def test_post_process_idempotent_when_already_succeeded():
+    """If pipeline_runs.status is already 'succeeded', skip everything."""
+    from app.temporal.activities.post_process import post_process, PostProcessInput
+
+    captured: list[tuple[str, tuple]] = []
+
+    def fake_execute(sql, params=()):
+        captured.append((sql, params))
+
+    fake_fetch_one = MagicMock(return_value={"status": "succeeded"})
+
+    with patch("app.routers.v3.db.execute", side_effect=fake_execute), \
+         patch("app.routers.v3.db.fetch_one", fake_fetch_one):
+        await post_process(PostProcessInput(
+            run_id="00000000-0000-0000-0000-000000000000",
+            user_id="00000000-0000-0000-0000-000000000000",
+            session_id=None,
+            brain_result={"query": "x", "findings": []},
+        ))
+
+    inserts = [s for s, _ in captured if "INSERT INTO research_trails" in s]
+    assert not inserts, "post_process must not write trail when run already succeeded"


### PR DESCRIPTION
## Summary

Path B (IS-loop, default since 6d02595) produced no data the v3 UI could
consume: brain_turn emitted no WS events, and post_process never wrote a
research_trails row. Every /v3/agent/message run rendered as an empty
Results panel.

This bridges Path B's WorkingMemory onto engine_v2's data shape, both live
(events) and persisted (trail), so PhaseDAGView / TacticianSwimLanes /
StreamingCardList / CandidateComparison / ACHMatrix all populate.

## Backend
- `WorkingMemory.to_engine_v2_trail()` — pure adapter producing the
  v2-shape trail dict (`branches`, `phases_full`, `ranked_candidates`)
  from a finished WM. ACH matrix is None (Path B has no signed ACH).
- `IsLoopRunWorkflow` builds the v2 trail before calling `post_process`.
- `post_process` writes the engine_v2-shape trail (falls back to legacy
  `tree` shape) and emits `is.run_complete` with `ranked_candidates +
  ach_matrix`.
- `brain_turn` emits `is.phase_start` (turn 1 + transitions),
  `is.tactician_start/complete` each turn, `is.tool_call` per `tool_use`
  event from the brain subprocess, `is.phase_complete` on transitions.

## Frontend
- ResultsPanel auto-seeds `runStreamStore` via `/v3/runs/{id}/replay`
  when col1Content switches to a past run (covers Live-panel click,
  History resume, refresh).
- `SessionHistoryItem.resume` restores both chat and Results panel.
- `sessionStore` persists `activeJobId + col1Content` to localStorage
  (`ib-session-view`); wiped on logout per #112's privacy stance.
- AgentChat rehydrate keys on `accessToken` for post-login races.
- StreamingCardList empty-state copy differentiates running / hydrated /
  cold.

## Cleanup of trailless legacy runs (7 on prod)
- `DELETE /v3/pipelines/runs/purge-trailless?dry_run=true` admin endpoint.
- `docs/runbooks/purge-trailless-runs.sql` runbook (ROLLBACK by default).

## Test plan
- [x] `pytest tests/temporal/test_post_process_trail.py app/pipeline/tests/test_engine_v2_trail_adapter.py app/pipeline/tests/test_engine_v2.py` — 22 passed, 2 skipped
- [x] `ruff check` — all checks passed on touched files
- [x] `tsc --noEmit` — clean
- [x] `npm run build` — built in 2.37s
- [x] vitest unit suites (AgentChat, LiveStream, ResultsPanel, clearClientSession) — 34/34 passing
- [ ] After deploy: run a new investigation via UI; confirm PhaseDAGView /
      swimlanes / cards / ranked_candidates populate live
- [ ] After deploy: apply `purge-trailless-runs.sql` against prod
      (preview-first; flip ROLLBACK → COMMIT)

## Deploy notes
- **Temporal worker restart required** — `brain_turn`, `post_process`,
  `IsLoopRunWorkflow` all changed.
- API server restart picks up the new admin endpoint.
- Cloudflare Pages will deploy the frontend automatically on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)