### PR TITLE
fix(ui): replace legacy phase order with unified taxonomy in v2 live + DAG

### DIFF
--- a/app/pipeline/tests/test_no_legacy_phase_ids.py
+++ b/app/pipeline/tests/test_no_legacy_phase_ids.py
@@ -15,9 +15,9 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _LEGACY_IDS = ["signal_extraction", "broaden", "red_team", "rank_verify"]  # allowlist 2026-05-23
-# Match the string in source (with double quotes only — single-quoted strings
-# in frontend code are handled by a separate scan if needed).
-_PATTERN = re.compile(r'"(' + "|".join(_LEGACY_IDS) + r')"')
+# Match the string in source with either single or double quotes so that
+# single-quoted TS literals (e.g. 'signal_extraction') are also caught.  # allowlist 2026-05-23
+_PATTERN = re.compile(r'["\'](' + "|".join(_LEGACY_IDS) + r')["\']')
 
 
 def _scan_dir(path: Path, suffixes: tuple[str, ...]) -> list[tuple[Path, int, str]]:

--- a/frontend/src/components/results/PhaseDAGView.tsx
+++ b/frontend/src/components/results/PhaseDAGView.tsx
@@ -25,7 +25,7 @@ export type ViewMode = 'live' | 'compact' | 'dag'
 /** Storage key — replaces the old "v2_live_view_compact" boolean key. */
 export const VIEW_MODE_STORAGE_KEY = 'v2_live_view_mode'
 
-const DEFAULT_PHASE_ORDER = ['signal_extraction', 'broaden', 'red_team', 'rank_verify']
+const DEFAULT_PHASE_ORDER = ['extract', 'gather', 'disconfirm', 'synthesize']
 
 interface PhaseDAGViewProps {
   runId: string

--- a/frontend/src/components/results/PhaseProgress.tsx
+++ b/frontend/src/components/results/PhaseProgress.tsx
@@ -17,7 +17,7 @@ interface PhaseProgressProps {
 }
 
 // Default placeholder order shown before the first is.phase_start arrives.
-const DEFAULT_PHASE_ORDER = ['signal_extraction', 'broaden', 'red_team', 'rank_verify']
+const DEFAULT_PHASE_ORDER = ['extract', 'gather', 'disconfirm', 'synthesize']
 
 function statusColor(status: PhaseState['status']): string {
   switch (status) {

--- a/frontend/src/components/results/dag/buildDagFromRun.test.ts
+++ b/frontend/src/components/results/dag/buildDagFromRun.test.ts
@@ -43,7 +43,7 @@ describe('buildDagFromRun', () => {
   it('produces query + phase nodes + edge for a single phase with no tacticians', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'passed', n_tacticians: 0, distinct_candidate_names: [], gate_status: 'pass' },
+        extract: { status: 'passed', n_tacticians: 0, distinct_candidate_names: [], gate_status: 'pass' },
       },
     })
     const g = buildDagFromRun(run)
@@ -53,16 +53,16 @@ describe('buildDagFromRun', () => {
     expect(kinds).toContain('phase')
     expect(g.edges).toHaveLength(1)
     expect(g.edges[0].sourceId).toBe('node__query')
-    expect(g.edges[0].targetId).toBe('node__phase__signal_extraction')
+    expect(g.edges[0].targetId).toBe('node__phase__extract')
   })
 
   it('produces tactician nodes and phase→tactician edges', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'running', n_tacticians: 2, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'running', n_tacticians: 2, distinct_candidate_names: [], gate_status: null },
       },
       tacticians: {
-        signal_extraction: {
+        extract: {
           0: { tactic_id: 't1', forbidden_candidates: [], candidate_names: ['Alice'], findings_count: 0, specialist_calls: 0 },
           1: { tactic_id: 't2', forbidden_candidates: ['Bob'], candidate_names: [], findings_count: 0, specialist_calls: 0 },
         },
@@ -73,17 +73,17 @@ describe('buildDagFromRun', () => {
     const tacNodes = g.nodes.filter(n => n.data.kind === 'tactician')
     expect(tacNodes).toHaveLength(2)
 
-    const phaseEdges = g.edges.filter(e => e.sourceId === 'node__phase__signal_extraction')
+    const phaseEdges = g.edges.filter(e => e.sourceId === 'node__phase__extract')
     expect(phaseEdges).toHaveLength(2)
   })
 
   it('caps finding nodes at MAX_FINDINGS_PER_TACTICIAN', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
       },
       tacticians: {
-        signal_extraction: {
+        extract: {
           0: {
             tactic_id: 't1',
             forbidden_candidates: [],
@@ -103,10 +103,10 @@ describe('buildDagFromRun', () => {
   it('produces no finding nodes when findings_count is 0', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
       },
       tacticians: {
-        signal_extraction: {
+        extract: {
           0: { tactic_id: 't1', forbidden_candidates: [], candidate_names: [], findings_count: 0, specialist_calls: 0 },
         },
       },
@@ -119,7 +119,7 @@ describe('buildDagFromRun', () => {
   it('produces top-3 candidate nodes from rankedCandidates', () => {
     const run = makeRun({
       phases: {
-        rank_verify: { status: 'passed', n_tacticians: 0, distinct_candidate_names: [], gate_status: 'pass' },
+        synthesize: { status: 'passed', n_tacticians: 0, distinct_candidate_names: [], gate_status: 'pass' },
       },
       rankedCandidates: [
         { name: 'Alice', confidence: 0.87, signal_scores: {}, evidence: [], slot_idx: 0 },
@@ -143,15 +143,15 @@ describe('buildDagFromRun', () => {
   it('places all nodes at non-negative x and y coordinates', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'passed', n_tacticians: 2, distinct_candidate_names: [], gate_status: 'pass' },
-        broaden: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'passed', n_tacticians: 2, distinct_candidate_names: [], gate_status: 'pass' },
+        gather: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
       },
       tacticians: {
-        signal_extraction: {
+        extract: {
           0: { tactic_id: 't1', forbidden_candidates: [], candidate_names: ['A'], findings_count: 2, specialist_calls: 0 },
           1: { tactic_id: 't2', forbidden_candidates: [], candidate_names: ['B'], findings_count: 1, specialist_calls: 0 },
         },
-        broaden: {
+        gather: {
           0: { tactic_id: 't3', forbidden_candidates: [], candidate_names: [], findings_count: 0, specialist_calls: 0 },
         },
       },
@@ -167,12 +167,12 @@ describe('buildDagFromRun', () => {
   it('does not produce edges past phase 1 when only 1 phase exists', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'running', n_tacticians: 0, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'running', n_tacticians: 0, distinct_candidate_names: [], gate_status: null },
       },
     })
     const g = buildDagFromRun(run)
 
-    // Only edge should be query → signal_extraction
+    // Only edge should be query → extract
     const nonQueryEdges = g.edges.filter(e => e.sourceId !== 'node__query')
     expect(nonQueryEdges).toHaveLength(0)
   })
@@ -180,14 +180,14 @@ describe('buildDagFromRun', () => {
   it('chains phase → phase edges for multiple phases', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'passed', n_tacticians: 0, distinct_candidate_names: [], gate_status: 'pass' },
-        broaden: { status: 'running', n_tacticians: 0, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'passed', n_tacticians: 0, distinct_candidate_names: [], gate_status: 'pass' },
+        gather: { status: 'running', n_tacticians: 0, distinct_candidate_names: [], gate_status: null },
       },
     })
     const g = buildDagFromRun(run)
 
     const p1ToP2 = g.edges.find(
-      e => e.sourceId === 'node__phase__signal_extraction' && e.targetId === 'node__phase__broaden'
+      e => e.sourceId === 'node__phase__extract' && e.targetId === 'node__phase__gather'
     )
     expect(p1ToP2).toBeDefined()
   })
@@ -195,10 +195,10 @@ describe('buildDagFromRun', () => {
   it('assigns consistent source_class round-robin for synthetic finding nodes', () => {
     const run = makeRun({
       phases: {
-        signal_extraction: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
+        extract: { status: 'running', n_tacticians: 1, distinct_candidate_names: [], gate_status: null },
       },
       tacticians: {
-        signal_extraction: {
+        extract: {
           0: { tactic_id: 't1', forbidden_candidates: [], candidate_names: [], findings_count: 3, specialist_calls: 0 },
         },
       },

--- a/frontend/src/components/results/dag/buildDagFromRun.ts
+++ b/frontend/src/components/results/dag/buildDagFromRun.ts
@@ -124,7 +124,7 @@ const ROW_GAP = 32   // vertical gap between rows
 const COL_GAP = 16   // horizontal gap between siblings
 
 // Default phase order (mirrors PhaseDAGView)
-const DEFAULT_PHASE_ORDER = ['signal_extraction', 'broaden', 'red_team', 'rank_verify']
+const DEFAULT_PHASE_ORDER = ['extract', 'gather', 'disconfirm', 'synthesize']
 
 // ─── Source class inference ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Replaces all hardcoded legacy ACH phase ids (`signal_extraction`, `broaden`, `red_team`, `rank_verify`) with the unified taxonomy (`extract`, `gather`, `disconfirm`, `synthesize`) in `PhaseProgress.tsx`, `PhaseDAGView.tsx`, `buildDagFromRun.ts`, and the DAG test fixtures
- Updates `buildDagFromRun.test.ts` fixture keys and node-id expectations to use unified phase names so tests assert the new taxonomy
- Tightens `test_no_legacy_phase_ids.py` regex from `"(...)"` to `["\'](...)["\']` so single-quoted TS literals are caught by the CI lint (which is what allowed these to slip through originally)

Closes the legacy-phase display issue from run 3010bbe3 analysis.

## Test plan

- [x] `npx vitest run src/components/results/dag/buildDagFromRun.test.ts` — 11/11 pass
- [x] `npx vitest run` (full suite) — 19 files / 124 tests pass (no regressions vs baseline)
- [x] `pytest app/pipeline/tests/test_no_legacy_phase_ids.py -q` — both `test_no_legacy_phase_ids_in_app` and `test_no_legacy_phase_ids_in_frontend_src` pass
- [x] `tsc --noEmit` — clean
- [x] `grep -rn "signal_extraction|broaden|red_team|rank_verify" frontend/src` — zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)