### PR TITLE
feat(agent): persist + inject mid-run follow-up instructions into the running brain

### DIFF
--- a/app/pipeline/runners/injection_queue.py
+++ b/app/pipeline/runners/injection_queue.py
@@ -1,0 +1,43 @@
+"""injection_queue.py — in-memory per-run instruction injection queue.
+
+Thread-safe store that bridges POST /v3/runs/{run_id}/inject → the running
+Strategist phase loop.
+
+IMPORTANT LIMITATIONS:
+- In-memory, per-process only.  Entries are lost on API-process restart.
+- Bridges inject_node → engine exclusively because agent-triggered runs execute
+  in the SAME API process (asyncio.create_task in agent.py).  This does NOT
+  work for out-of-process Temporal workers; if the Temporal path is ever
+  activated, a durable queue (Redis, DB table) must replace this module.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Dict, List
+
+_lock: threading.Lock = threading.Lock()
+_QUEUES: Dict[str, List[str]] = {}
+
+
+def enqueue(run_id: str, instruction: str) -> None:
+    """Append *instruction* to the pending queue for *run_id*."""
+    with _lock:
+        if run_id not in _QUEUES:
+            _QUEUES[run_id] = []
+        _QUEUES[run_id].append(instruction)
+
+
+def drain(run_id: str) -> List[str]:
+    """Return and clear all pending instructions for *run_id*.
+
+    Returns an empty list if there are no pending instructions.
+    """
+    with _lock:
+        instructions = _QUEUES.pop(run_id, [])
+    return instructions
+
+
+def pending_count(run_id: str) -> int:
+    """Return the number of pending instructions for *run_id* (non-destructive)."""
+    with _lock:
+        return len(_QUEUES.get(run_id, []))

--- a/app/pipeline/runners/scoped_brain.py
+++ b/app/pipeline/runners/scoped_brain.py
@@ -246,6 +246,17 @@ def _build_scoped_prompt(
             "",
         ]
 
+    # Mid-run user directive: injected via POST /v3/runs/{run_id}/inject while
+    # the research was already running.  Rendered prominently so the brain sees it.
+    user_directive = unit_of_work.get("user_directive")
+    if user_directive:
+        lines += [
+            "=== USER DIRECTIVE (mid-run steering) ===",
+            "The user added this instruction while the research was running. Incorporate it now:",
+            user_directive,
+            "",
+        ]
+
     # The user query is the de-facto objective when strategy doesn't define one.
     query_str = unit_of_work.get("query") or unit_of_work.get("objective", "")
     objective = unit_of_work.get("objective") or query_str

--- a/app/pipeline/strategist.py
+++ b/app/pipeline/strategist.py
@@ -960,7 +960,21 @@ class Strategist:
                         unit_of_work["corrective_hint"] = current_unit_of_work["corrective_hint"]
                     if "_tactic_override" in current_unit_of_work:
                         unit_of_work["_tactic_override"] = current_unit_of_work["_tactic_override"]
+                    if "user_directive" in current_unit_of_work:
+                        unit_of_work["user_directive"] = current_unit_of_work["user_directive"]
                 current_unit_of_work = unit_of_work
+
+                # Drain any mid-run user instructions injected via POST /v3/runs/{run_id}/inject
+                # and merge them into user_directive so the brain prompt receives them.
+                from app.pipeline.runners import injection_queue as _injection_queue
+                _directives = _injection_queue.drain(self._run_id)
+                if _directives:
+                    existing = unit_of_work.get("user_directive", "")
+                    unit_of_work["user_directive"] = (
+                        existing + "\n" + "\n".join(_directives)
+                    ).strip()
+                    # Also update current_unit_of_work so the directive survives replan
+                    current_unit_of_work["user_directive"] = unit_of_work["user_directive"]
 
                 n_tacticians = self._resolve_n_tacticians(
                     phase, phase_outputs_by_id

--- a/app/routers/v3/brain.py
+++ b/app/routers/v3/brain.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
+import json
+import logging
 import uuid
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.routers.v3.auth import get_current_user
+from app.routers.v3.db import execute, fetch_one
+from app.pipeline.runners import injection_queue
+from app.routers.v3.stream import push_event
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v3/brain", tags=["brain"])
 runs_router = APIRouter(prefix="/v3/runs", tags=["runs"])
@@ -59,7 +68,63 @@ async def inject_node(
     req: InjectNodeRequest,
     current_user: dict = Depends(get_current_user),
 ):
-    # TODO: verify run_id belongs to current_user before mutating
-    # TODO: emit WS event to notify pipeline live-view of the injected node
+    """Inject a mid-run user instruction into the running research brain.
+
+    Ownership-checks the run, persists the message to the session's
+    conversation_thread, enqueues the instruction for the running Strategist,
+    and emits a WS event so the live view notes it.
+
+    NOTE: in-memory injection only works because agent-triggered runs execute
+    in the same API process (asyncio.create_task).  Out-of-process Temporal
+    workers are NOT bridged by this mechanism.
+    """
+    # 1. Fetch run — 404 if missing
+    run = fetch_one(
+        "SELECT user_id, session_id FROM pipeline_runs WHERE id = %s",
+        (run_id,),
+    )
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Ownership check
+    if str(run["user_id"]) != str(current_user["id"]):
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    # 3. Extract instruction (may be None if only node_spec provided — still enqueue)
+    instruction = req.instruction or ""
+
+    # 4. Enqueue for the running brain
+    if instruction:
+        injection_queue.enqueue(run_id, instruction)
+
+    # 5. Persist to session conversation_thread (skip if no session_id or no instruction)
+    session_id = run.get("session_id")
+    if session_id and instruction:
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            msg = json.dumps([{
+                "role": "user",
+                "content": instruction,
+                "type": "injection",
+                "ts": now,
+            }])
+            execute(
+                "UPDATE agent_sessions SET conversation_thread = conversation_thread || %s::jsonb WHERE id = %s",
+                (msg, str(session_id)),
+            )
+        except Exception as exc:
+            # Non-fatal: enqueue already succeeded; log and continue
+            log.warning("inject_node: failed to persist to conversation_thread: %s", exc)
+
+    # 6. Emit WS event so the live view notes the injection
+    try:
+        await push_event(str(current_user["id"]), {
+            "type": "is.node_injected",
+            "run_id": run_id,
+            "instruction": instruction,
+        })
+    except Exception as exc:
+        log.warning("inject_node: push_event failed (non-fatal): %s", exc)
+
     node_id = str(uuid.uuid4())
     return {"node_id": node_id, "status": "queued"}

--- a/tests/pipeline/test_injection_drain.py
+++ b/tests/pipeline/test_injection_drain.py
@@ -1,0 +1,311 @@
+"""Tests for mid-run injection integration: strategist drain + scoped_brain prompt.
+
+Covers:
+1. A pending injection in the queue lands in unit_of_work["user_directive"]
+   after Strategist.execute runs a phase.
+2. If multiple directives are enqueued, they are joined with newlines.
+3. user_directive survives replan (overlay block propagates it).
+4. _build_scoped_prompt includes USER DIRECTIVE section when user_directive is set.
+5. _build_scoped_prompt does NOT include USER DIRECTIVE section when absent.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.pipeline.catalogs.budget import BudgetEnvelope
+from app.pipeline.catalogs.schemas import CheckSpec, GateSpec, PhaseSpec, Strategy
+from app.pipeline.runners import injection_queue
+from app.pipeline.runners.scoped_brain import _build_scoped_prompt
+from app.pipeline.catalogs.schemas import Tactic, TaskSpec
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrored from test_engine_v2_emits_expected_events.py)
+# ---------------------------------------------------------------------------
+
+def _make_envelope() -> BudgetEnvelope:
+    return BudgetEnvelope(
+        speed="normal",
+        capability="general",
+        resource="medium",
+        depth="search",
+        hypothesis_count="single",
+    )
+
+
+def _make_phase(phase_id: str, on_fail: str = "terminate") -> PhaseSpec:
+    return PhaseSpec(
+        id=phase_id,
+        depends_on=[],
+        unit_of_work_contract={"query": ""},
+        hypothesis_count_policy="fixed:1",
+        gate=GateSpec(
+            checks=[CheckSpec(kind="min_primary_signals", params={"min": 1})],
+            on_fail=on_fail,  # type: ignore[arg-type]
+        ),
+    )
+
+
+def _make_strategy(phases: list[PhaseSpec]) -> Strategy:
+    return Strategy(
+        id="test_strategy",
+        applies_to={"task_type": "test"},
+        phases=phases,
+        default_mode="balanced",
+        budget_minimums={},
+    )
+
+
+def _passing_tactician_output(uow_capture: list | None = None):
+    async def _fn(phase_spec, unit_of_work, slot_idx):
+        if uow_capture is not None:
+            uow_capture.append(dict(unit_of_work))
+        return {
+            "slot_idx": slot_idx,
+            "findings": [
+                {
+                    "candidate_name": "Alice",
+                    "source_class": "live_search",
+                    "confidence": 0.9,
+                    "evidence_snippet": "found",
+                }
+            ],
+            "metadata": {
+                "hypotheses_explored": 1,
+                "primary_signals_count": 1,
+                "disconfirm_count": 0,
+                "surviving_hypothesis_count": 1,
+                "actual_ru": 1,
+            },
+            "candidate_names": ["Alice"],
+            "ranked_candidates": [{"name": "Alice", "confidence": 0.9}],
+        }
+    return _fn
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Test: drain merges into unit_of_work["user_directive"]
+# ---------------------------------------------------------------------------
+
+class TestStrategistDrain:
+    def _run_single_phase_capture_uow(self, run_id: str) -> list[dict]:
+        """Run one phase, capture unit_of_work dicts seen by tactician_fn."""
+        phase = _make_phase("gather")
+        strategy = _make_strategy([phase])
+        envelope = _make_envelope()
+
+        captured: list[dict] = []
+
+        async def _run_test():
+            with patch("app.pipeline.strategist.wallet") as mock_wallet:
+                mock_wallet.consume = MagicMock()
+                from app.pipeline.strategist import Strategist
+                strategist = Strategist(
+                    strategy=strategy,
+                    envelope=envelope,
+                    run_id=run_id,
+                    user_id="user-test",
+                    hold_id="hold-test",
+                )
+                await strategist.execute(
+                    query="test query",
+                    classifier_output={},
+                    tactician_fn=_passing_tactician_output(captured),
+                )
+            return captured
+
+        return _run(_run_test())
+
+    def test_pending_injection_lands_in_user_directive(self):
+        run_id = f"drain-test-{__import__('uuid').uuid4().hex[:8]}"
+        injection_queue.drain(run_id)  # clean
+
+        injection_queue.enqueue(run_id, "focus on LinkedIn profiles")
+
+        captured = self._run_single_phase_capture_uow(run_id)
+        assert captured, "tactician_fn was never called"
+        uow = captured[0]
+        assert "user_directive" in uow
+        assert "focus on LinkedIn profiles" in uow["user_directive"]
+
+    def test_multiple_injections_joined_in_directive(self):
+        run_id = f"drain-multi-{__import__('uuid').uuid4().hex[:8]}"
+        injection_queue.drain(run_id)
+
+        injection_queue.enqueue(run_id, "directive one")
+        injection_queue.enqueue(run_id, "directive two")
+
+        captured = self._run_single_phase_capture_uow(run_id)
+        assert captured
+        directive = captured[0].get("user_directive", "")
+        assert "directive one" in directive
+        assert "directive two" in directive
+
+    def test_no_injection_no_directive_key(self):
+        run_id = f"drain-empty-{__import__('uuid').uuid4().hex[:8]}"
+        injection_queue.drain(run_id)  # ensure empty
+
+        captured = self._run_single_phase_capture_uow(run_id)
+        assert captured
+        # user_directive should not be set (or empty) when nothing was injected
+        assert not captured[0].get("user_directive")
+
+    def test_drain_clears_after_phase(self):
+        """Injections are consumed once; second run should see nothing."""
+        run_id = f"drain-once-{__import__('uuid').uuid4().hex[:8]}"
+        injection_queue.drain(run_id)
+
+        injection_queue.enqueue(run_id, "consumed instruction")
+
+        self._run_single_phase_capture_uow(run_id)
+
+        # After the phase ran, the queue must be empty
+        assert injection_queue.pending_count(run_id) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: user_directive survives replan overlay
+# ---------------------------------------------------------------------------
+
+class TestUserDirectiveSurvivesReplan:
+    def test_user_directive_propagated_on_replan(self):
+        """If user_directive is set before a replan attempt, it must survive overlay."""
+        phase = _make_phase("gather", on_fail="replan")
+        strategy = _make_strategy([phase])
+        envelope = _make_envelope()
+
+        run_id = f"replan-directive-{__import__('uuid').uuid4().hex[:8]}"
+        injection_queue.drain(run_id)
+        injection_queue.enqueue(run_id, "survive replan")
+
+        captured: list[dict] = []
+        attempt = [0]
+
+        async def _mixed_fn(phase_spec, unit_of_work, slot_idx):
+            attempt[0] += 1
+            captured.append(dict(unit_of_work))
+            # First attempt fails gate (no signals), second passes
+            if attempt[0] == 1:
+                return {
+                    "slot_idx": slot_idx,
+                    "findings": [],
+                    "metadata": {
+                        "hypotheses_explored": 1,
+                        "primary_signals_count": 0,
+                        "disconfirm_count": 0,
+                        "surviving_hypothesis_count": 0,
+                        "actual_ru": 1,
+                    },
+                    "candidate_names": [],
+                    "ranked_candidates": [],
+                }
+            return {
+                "slot_idx": slot_idx,
+                "findings": [
+                    {
+                        "candidate_name": "Bob",
+                        "source_class": "live_search",
+                        "confidence": 0.8,
+                        "evidence_snippet": "found",
+                    }
+                ],
+                "metadata": {
+                    "hypotheses_explored": 1,
+                    "primary_signals_count": 1,
+                    "disconfirm_count": 0,
+                    "surviving_hypothesis_count": 1,
+                    "actual_ru": 1,
+                },
+                "candidate_names": ["Bob"],
+                "ranked_candidates": [{"name": "Bob", "confidence": 0.8}],
+            }
+
+        async def _run_test():
+            with patch("app.pipeline.strategist.wallet") as mock_wallet:
+                mock_wallet.consume = MagicMock()
+                from app.pipeline.strategist import Strategist
+                strategist = Strategist(
+                    strategy=strategy,
+                    envelope=envelope,
+                    run_id=run_id,
+                    user_id="user-test",
+                    hold_id="hold-test",
+                )
+                await strategist.execute(
+                    query="test",
+                    classifier_output={},
+                    tactician_fn=_mixed_fn,
+                )
+
+        _run(_run_test())
+
+        assert len(captured) >= 2, "Expected at least 2 attempts (fail + pass)"
+        # The directive from the first attempt must appear in the second attempt too
+        directive_second = captured[1].get("user_directive", "")
+        assert "survive replan" in directive_second, (
+            f"user_directive not propagated to second attempt; got: {directive_second!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: _build_scoped_prompt renders user_directive
+# ---------------------------------------------------------------------------
+
+class TestScopedBrainUserDirective:
+    def _minimal_tactic(self) -> Tactic:
+        return Tactic(
+            id="web_search",
+            phase_compatibility=["gather"],
+            accepts={"query": ""},
+            produces=[TaskSpec(technique_id="ddg_search")],
+            cost_class="cheap",
+        )
+
+    def test_user_directive_appears_in_prompt(self):
+        tactic = self._minimal_tactic()
+        unit_of_work = {
+            "query": "find Alice",
+            "user_directive": "also check Twitter profiles",
+        }
+        prompt = _build_scoped_prompt(tactic, unit_of_work, capability_tier="general")
+        assert "USER DIRECTIVE" in prompt
+        assert "also check Twitter profiles" in prompt
+        assert "mid-run steering" in prompt
+
+    def test_user_directive_absent_when_not_set(self):
+        tactic = self._minimal_tactic()
+        unit_of_work = {"query": "find Bob"}
+        prompt = _build_scoped_prompt(tactic, unit_of_work, capability_tier="general")
+        assert "USER DIRECTIVE" not in prompt
+
+    def test_user_directive_placement_after_corrective_hint(self):
+        """user_directive section must appear before the ## Unit of Work section."""
+        tactic = self._minimal_tactic()
+        unit_of_work = {
+            "query": "test",
+            "user_directive": "my directive",
+        }
+        prompt = _build_scoped_prompt(tactic, unit_of_work, capability_tier="general")
+        directive_pos = prompt.index("USER DIRECTIVE")
+        uow_pos = prompt.index("## Unit of Work")
+        assert directive_pos < uow_pos, "USER DIRECTIVE must appear before ## Unit of Work"
+
+    def test_corrective_hint_and_directive_both_present(self):
+        tactic = self._minimal_tactic()
+        unit_of_work = {
+            "query": "test",
+            "corrective_hint": "try harder",
+            "user_directive": "also check records",
+        }
+        prompt = _build_scoped_prompt(tactic, unit_of_work, capability_tier="general")
+        assert "CORRECTIVE HINT" in prompt
+        assert "USER DIRECTIVE" in prompt
+        assert "also check records" in prompt

--- a/tests/pipeline/test_injection_queue.py
+++ b/tests/pipeline/test_injection_queue.py
@@ -1,0 +1,137 @@
+"""Tests for app.pipeline.runners.injection_queue.
+
+Covers: enqueue, drain, pending_count, drain-clears, isolation between run_ids.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from app.pipeline.runners import injection_queue
+
+
+def _clean(run_id: str) -> None:
+    """Drain any leftover state for *run_id* from prior tests."""
+    injection_queue.drain(run_id)
+
+
+class TestEnqueueDrain:
+    def test_enqueue_then_drain_returns_instruction(self):
+        rid = "run-test-001"
+        _clean(rid)
+        injection_queue.enqueue(rid, "focus on LinkedIn profiles")
+        result = injection_queue.drain(rid)
+        assert result == ["focus on LinkedIn profiles"]
+
+    def test_drain_empty_returns_empty_list(self):
+        rid = "run-test-002"
+        _clean(rid)
+        assert injection_queue.drain(rid) == []
+
+    def test_drain_clears_queue(self):
+        rid = "run-test-003"
+        _clean(rid)
+        injection_queue.enqueue(rid, "instruction A")
+        injection_queue.drain(rid)
+        # Second drain must be empty
+        assert injection_queue.drain(rid) == []
+
+    def test_multiple_enqueues_drain_in_order(self):
+        rid = "run-test-004"
+        _clean(rid)
+        injection_queue.enqueue(rid, "first")
+        injection_queue.enqueue(rid, "second")
+        injection_queue.enqueue(rid, "third")
+        result = injection_queue.drain(rid)
+        assert result == ["first", "second", "third"]
+
+    def test_drain_clears_multiple(self):
+        rid = "run-test-005"
+        _clean(rid)
+        injection_queue.enqueue(rid, "a")
+        injection_queue.enqueue(rid, "b")
+        injection_queue.drain(rid)
+        assert injection_queue.drain(rid) == []
+
+
+class TestPendingCount:
+    def test_pending_count_zero_initially(self):
+        rid = "run-test-006"
+        _clean(rid)
+        assert injection_queue.pending_count(rid) == 0
+
+    def test_pending_count_increments(self):
+        rid = "run-test-007"
+        _clean(rid)
+        injection_queue.enqueue(rid, "x")
+        assert injection_queue.pending_count(rid) == 1
+        injection_queue.enqueue(rid, "y")
+        assert injection_queue.pending_count(rid) == 2
+
+    def test_pending_count_zero_after_drain(self):
+        rid = "run-test-008"
+        _clean(rid)
+        injection_queue.enqueue(rid, "z")
+        injection_queue.drain(rid)
+        assert injection_queue.pending_count(rid) == 0
+
+    def test_pending_count_non_destructive(self):
+        rid = "run-test-009"
+        _clean(rid)
+        injection_queue.enqueue(rid, "check")
+        count_before = injection_queue.pending_count(rid)
+        count_again = injection_queue.pending_count(rid)
+        assert count_before == count_again == 1
+        # Verify item is still there
+        result = injection_queue.drain(rid)
+        assert result == ["check"]
+
+
+class TestIsolation:
+    def test_queues_are_isolated_between_run_ids(self):
+        rid_a = "run-iso-a"
+        rid_b = "run-iso-b"
+        _clean(rid_a)
+        _clean(rid_b)
+
+        injection_queue.enqueue(rid_a, "for A")
+        injection_queue.enqueue(rid_b, "for B")
+
+        assert injection_queue.drain(rid_a) == ["for A"]
+        assert injection_queue.drain(rid_b) == ["for B"]
+
+    def test_drain_one_does_not_affect_other(self):
+        rid_a = "run-iso-c"
+        rid_b = "run-iso-d"
+        _clean(rid_a)
+        _clean(rid_b)
+
+        injection_queue.enqueue(rid_a, "a1")
+        injection_queue.enqueue(rid_b, "b1")
+
+        injection_queue.drain(rid_a)
+        # rid_b still has its item
+        assert injection_queue.pending_count(rid_b) == 1
+        assert injection_queue.drain(rid_b) == ["b1"]
+
+
+class TestThreadSafety:
+    def test_concurrent_enqueues(self):
+        """Multiple threads enqueueing concurrently should not lose items."""
+        rid = "run-thread-safe"
+        _clean(rid)
+        n = 50
+
+        def _enqueue_many():
+            for i in range(n):
+                injection_queue.enqueue(rid, f"item-{i}")
+
+        threads = [threading.Thread(target=_enqueue_many) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        result = injection_queue.drain(rid)
+        assert len(result) == n * 4

--- a/tests/v3/test_inject_node.py
+++ b/tests/v3/test_inject_node.py
@@ -1,0 +1,213 @@
+"""Tests for POST /v3/runs/{run_id}/inject (inject_node endpoint).
+
+Covers:
+- 403 when run belongs to a different user
+- 404 when run does not exist
+- Successful injection enqueues the instruction
+- Appends to conversation_thread when session_id is present
+- Works when session_id is NULL (no DB error)
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.v3.test_auth import _register_user
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("POSTGRES_HOST"),
+    reason="Requires Postgres",
+)
+
+client = TestClient(app)
+
+SYSTEM_PIPELINE_ID = "00000000-0000-4000-8000-000000000001"
+
+
+def _auth_headers(username: str) -> dict:
+    _register_user(username, "pass")
+    r = client.post("/v3/auth/login", json={"username": username, "password": "pass"})
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+def _get_user_id(username: str) -> str:
+    from app.routers.v3.db import fetch_one
+    row = fetch_one("SELECT id FROM ui_users WHERE username = %s", (username,))
+    assert row is not None
+    return str(row["id"])
+
+
+def _seed_run(user_id: str, session_id: str | None = None) -> str:
+    """Insert a pipeline_run row and return its id."""
+    from app.routers.v3.db import execute
+    run_id = str(uuid.uuid4())
+    execute(
+        """
+        INSERT INTO pipeline_runs
+            (id, pipeline_id, user_id, status, trigger_type, query)
+        VALUES (%s, %s, %s, 'running', 'agent_is', 'test query')
+        """,
+        (run_id, SYSTEM_PIPELINE_ID, user_id),
+    )
+    if session_id is not None:
+        from app.routers.v3.db import execute as _exec
+        _exec(
+            "UPDATE pipeline_runs SET session_id = %s WHERE id = %s",
+            (session_id, run_id),
+        )
+    return run_id
+
+
+def _seed_session(user_id: str) -> str:
+    """Insert an agent_sessions row and return its id."""
+    from app.routers.v3.db import fetch_one
+    session_id = str(uuid.uuid4())
+    fetch_one(
+        """
+        INSERT INTO agent_sessions (id, user_id, genesis_query, status)
+        VALUES (%s, %s, 'test', 'active')
+        RETURNING id
+        """,
+        (session_id, user_id),
+    )
+    return session_id
+
+
+def _get_session_thread(session_id: str) -> list:
+    from app.routers.v3.db import fetch_one
+    row = fetch_one("SELECT conversation_thread FROM agent_sessions WHERE id = %s", (session_id,))
+    if row is None:
+        return []
+    thread = row["conversation_thread"]
+    if isinstance(thread, str):
+        return json.loads(thread)
+    return list(thread or [])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestInjectNode404:
+    def test_nonexistent_run_returns_404(self):
+        uname = f"inject_404_{uuid.uuid4().hex[:8]}"
+        h = _auth_headers(uname)
+        fake_run_id = str(uuid.uuid4())
+        r = client.post(f"/v3/runs/{fake_run_id}/inject", json={"instruction": "hello"}, headers=h)
+        assert r.status_code == 404
+
+
+class TestInjectNode403:
+    def test_run_owned_by_other_user_returns_403(self):
+        owner_name = f"inject_owner_{uuid.uuid4().hex[:8]}"
+        intruder_name = f"inject_intruder_{uuid.uuid4().hex[:8]}"
+
+        h_owner = _auth_headers(owner_name)
+        h_intruder = _auth_headers(intruder_name)
+
+        owner_id = _get_user_id(owner_name)
+        run_id = _seed_run(owner_id)
+
+        r = client.post(f"/v3/runs/{run_id}/inject", json={"instruction": "hack"}, headers=h_intruder)
+        assert r.status_code == 403
+
+
+class TestInjectNodeEnqueues:
+    def test_successful_inject_enqueues_instruction(self):
+        from app.pipeline.runners import injection_queue
+
+        uname = f"inject_ok_{uuid.uuid4().hex[:8]}"
+        h = _auth_headers(uname)
+        user_id = _get_user_id(uname)
+        run_id = _seed_run(user_id)
+
+        # Drain any prior state
+        injection_queue.drain(run_id)
+
+        r = client.post(f"/v3/runs/{run_id}/inject", json={"instruction": "focus on executives"}, headers=h)
+        assert r.status_code == 200
+        data = r.json()
+        assert "node_id" in data
+        assert data["status"] == "queued"
+
+        # Verify instruction was enqueued
+        pending = injection_queue.drain(run_id)
+        assert pending == ["focus on executives"]
+
+    def test_successful_inject_returns_uuid_node_id(self):
+        uname = f"inject_uuid_{uuid.uuid4().hex[:8]}"
+        h = _auth_headers(uname)
+        user_id = _get_user_id(uname)
+        run_id = _seed_run(user_id)
+
+        r = client.post(f"/v3/runs/{run_id}/inject", json={"instruction": "test"}, headers=h)
+        assert r.status_code == 200
+        node_id = r.json()["node_id"]
+        # Should be a valid UUID
+        uuid.UUID(node_id)
+
+
+class TestInjectNodePersistsToSession:
+    def test_instruction_appended_to_conversation_thread(self):
+        uname = f"inject_persist_{uuid.uuid4().hex[:8]}"
+        h = _auth_headers(uname)
+        user_id = _get_user_id(uname)
+
+        session_id = _seed_session(user_id)
+        run_id = _seed_run(user_id, session_id=session_id)
+
+        r = client.post(
+            f"/v3/runs/{run_id}/inject",
+            json={"instruction": "also check Twitter"},
+            headers=h,
+        )
+        assert r.status_code == 200
+
+        thread = _get_session_thread(session_id)
+        assert len(thread) == 1
+        msg = thread[0]
+        assert msg["role"] == "user"
+        assert msg["content"] == "also check Twitter"
+        assert msg["type"] == "injection"
+        assert "ts" in msg
+
+    def test_multiple_injections_all_persisted(self):
+        uname = f"inject_multi_{uuid.uuid4().hex[:8]}"
+        h = _auth_headers(uname)
+        user_id = _get_user_id(uname)
+
+        session_id = _seed_session(user_id)
+        run_id = _seed_run(user_id, session_id=session_id)
+
+        client.post(f"/v3/runs/{run_id}/inject", json={"instruction": "first"}, headers=h)
+        client.post(f"/v3/runs/{run_id}/inject", json={"instruction": "second"}, headers=h)
+
+        thread = _get_session_thread(session_id)
+        assert len(thread) == 2
+        contents = [m["content"] for m in thread]
+        assert "first" in contents
+        assert "second" in contents
+
+
+class TestInjectNodeNullSession:
+    def test_inject_without_session_id_does_not_error(self):
+        """When run has no session_id, persist is skipped but enqueue still works."""
+        from app.pipeline.runners import injection_queue
+
+        uname = f"inject_nosess_{uuid.uuid4().hex[:8]}"
+        h = _auth_headers(uname)
+        user_id = _get_user_id(uname)
+        run_id = _seed_run(user_id, session_id=None)
+
+        injection_queue.drain(run_id)
+
+        r = client.post(f"/v3/runs/{run_id}/inject", json={"instruction": "no session"}, headers=h)
+        assert r.status_code == 200
+
+        pending = injection_queue.drain(run_id)
+        assert pending == ["no session"]


### PR DESCRIPTION
## Summary

- **injection_queue.py** (new): thread-safe in-memory per-run queue (`enqueue` / `drain` / `pending_count`) bridging `inject_node` → `Strategist`. Module docstring documents the in-process-only limitation (no Temporal cross-process bridging).
- **brain.py `inject_node`**: replaces the no-op stub — ownership check (403), `pipeline_runs` lookup (404), enqueue, jsonb-append persist to `agent_sessions.conversation_thread`, WS `is.node_injected` event.
- **strategist.py**: drains injection queue after `_build_unit_of_work` each phase-loop iteration; merges into `unit_of_work["user_directive"]`; propagates across replan via the `current_unit_of_work` overlay block.
- **scoped_brain.py `_build_scoped_prompt`**: renders `user_directive` as a prominent `=== USER DIRECTIVE (mid-run steering) ===` section before `## Unit of Work`.

## Strategist drain hunk

```python
                # Overlay corrective hint and tactic override from prior attempts
                if current_unit_of_work is not None:
                    if "corrective_hint" in current_unit_of_work:
                        unit_of_work["corrective_hint"] = current_unit_of_work["corrective_hint"]
                    if "_tactic_override" in current_unit_of_work:
                        unit_of_work["_tactic_override"] = current_unit_of_work["_tactic_override"]
                    if "user_directive" in current_unit_of_work:
                        unit_of_work["user_directive"] = current_unit_of_work["user_directive"]
                current_unit_of_work = unit_of_work

                # Drain any mid-run user instructions injected via POST /v3/runs/{run_id}/inject
                # and merge them into user_directive so the brain prompt receives them.
                from app.pipeline.runners import injection_queue as _injection_queue
                _directives = _injection_queue.drain(self._run_id)
                if _directives:
                    existing = unit_of_work.get("user_directive", "")
                    unit_of_work["user_directive"] = (
                        existing + "\n" + "\n".join(_directives)
                    ).strip()
                    # Also update current_unit_of_work so the directive survives replan
                    current_unit_of_work["user_directive"] = unit_of_work["user_directive"]
```

## Test results

- `tests/pipeline/test_injection_queue.py`: **12 passed** (enqueue/drain/pending_count/isolation/thread-safety)
- `tests/pipeline/test_injection_drain.py`: **9 passed** (strategist drain merge, replan propagation, scoped_brain prompt rendering)
- `tests/v3/test_inject_node.py`: **7 passed** (404, 403, enqueue, persist to conversation_thread, null session)
- Full suite: **1698 passed**, 15 failed (all pre-existing: 3 temporal, 1 is_prompt, 3 agent rate-limit, 8 pipeline rate-limit — same tests fail on main in the full-suite run due to rate limiting)
- `ruff check app`: **0 new errors** (baseline 10, still 10)

## Test plan

- [ ] Start a run from the Agents pane, send a follow-up message while status shows "running"
- [ ] Verify 200 response with `{node_id, status: "queued"}` from `POST /v3/runs/{run_id}/inject`
- [ ] Verify WS event `is.node_injected` received in the live view
- [ ] After run completes, reload the session — verify the injection message appears in History (conversation_thread persisted)
- [ ] Verify a second injection without a session_id does not 500
- [ ] Send injection from a different user account — verify 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)