### PR TITLE
test(is_prompt): fix BROADEN->gather assertion regression from #122

### DIFF
--- a/tests/test_is_prompt.py
+++ b/tests/test_is_prompt.py
@@ -74,9 +74,10 @@ def test_log_cycle_declaration_required():
     assert "CANNOT run any search before calling log_cycle" in RESEARCH_PROMPT
 
 
-def test_hypothesis_first_broaden_gate():
+def test_hypothesis_first_gather_gate():
     """Minimum searches = number of hypotheses (hard gate)."""
-    assert "HYPOTHESIS-FIRST BROADEN" in RESEARCH_PROMPT
+    # Phase label canonicalised to "gather" in #122 (was "BROADEN").
+    assert "HYPOTHESIS-FIRST GATHER" in RESEARCH_PROMPT
 
 
 def test_dead_end_rehypothesization_required():


### PR DESCRIPTION
`test_hypothesis_first_broaden_gate` asserted the old `HYPOTHESIS-FIRST BROADEN` prompt label, which #122 renamed to `GATHER`. The test broke silently (not in #122's test selection — caught now via full-suite baseline). Updates the assertion + renames the test. Verified: `tests/test_is_prompt.py` passes.