### PR TITLE
docs: reconcile TICKET-TRACKING.md (#127-#129 + issues #130/#131)

### DIFF
--- a/docs/TICKET-TRACKING.md
+++ b/docs/TICKET-TRACKING.md
@@ -1,6 +1,6 @@
 # Ticket Tracking — issues ↔ code ↔ PRs ↔ branches
 
-> Last reconciled: **2026-05-24** (incl. PRs #118, #120, #121, #122, #123, #124 merged; #68 closed)
+> Last reconciled: **2026-05-24** (PRs #118, #120–#129 merged; #68 closed; issues #130, #131 filed)
 > Maintainer note: this is the **source of truth for "what is actually shipped vs. in-flight."**
 > The older `TODO.md` (root) describes a tier roadmap and **lags reality** — trust this file and the code, not `TODO.md`.
 
@@ -29,9 +29,10 @@ Before citing a ticket, starting a "new" feature, or trusting a branch:
 | # | Type | Title | Code-verified state | Owning work | Regression notes |
 |---|------|-------|---------------------|-------------|------------------|
 | **#89** | hardening (was bug) | IS brain "tunnels" to RAG candidate; no BROADEN | **Does NOT reproduce** (verified 2026-05-24 after #123): brain broadened (3 hypothesis slots, 6 branches, live-search attempts) — no tunneling. Anti-tunneling machinery from #117 is firing. **Remaining latent items (no active symptom):** `tactician.py` seeds slot-0 from `prior_research_seed`; `fusion/ach.py` scores a lone hypothesis `high`. | Downgraded to hardening | Verify-first paid off — no speculative fix. Re-verify on prod once search keys + prior-RAG condition exist. |
-| **NEW** | bug (infra) | Live search 429-blocked locally → research can't complete | Discovered during #89 verify: Brave/Google return HTTP 429 / bot-block to the local stack IP; no Serper/Brave/Tavily keys. Gather gate then fails for lack of live sources even though the brain works. | Unfiled — needs an issue | Blocks ALL local research testing; prod likely has search keys. |
+| **#131** | bug (infra) | Live search 429-blocked locally → research can't complete | Brave/Google return HTTP 429 / bot-block to the local stack IP; no Serper/Brave/Tavily keys. Gather gate then fails for lack of live sources even though the brain works. | Filed | Blocks ALL local research testing; prod likely has search keys. |
+| **#130** | bug (infra) | Login rate-limit (60/min) makes full pytest suite flaky | After #90's isolation fix, cumulative logins across the suite trip the 60/min limit → later tests' logins get 429. Files pass in isolation (`test_pipelines.py` 50/0) but flake in the full run. | Filed | Different mechanism than #90 (rate limiter, not fixtures). Bypass limiter under test, or share tokens. |
 
-**Recently closed:** #90 (pytest test isolation) → **CLOSED by #124** (unique UUID fixtures + `ON CONFLICT DO UPDATE` + `load_dotenv` env-bleed fix in conftest; full suite 1682 pass, 0 fail, order-independent). #110/#111 → #118. #94 → #119. #95, #91 → verified fixed.
+**Recently closed:** #90 → #124. #110/#111 → #118. #94 → #119. #95, #91 → verified fixed. **Brain 100%-broken auth bug → #123** (kept env OAuth token). **Today's UI/agent work:** #127 (legacy phase order in v2 live + DAG + lint), #128 (mid-run injection persist+steer), #129 (#122 is_prompt assertion regression).
 
 > Issue "files likely to involve" lists are **stale** (pre-#117 taxonomy). Corrected file maps live in each issue's latest comment.
 
@@ -75,6 +76,8 @@ Reconciled from merged PRs; grep-verified entry points. Prevents duplication.
 | Assets library page | frontend assets | #108 |
 | Modes & Templates visibility admin toggle | `app/routers/v3` visibility | #109 |
 | DownloadMenu inline run exports | `frontend/.../runs/DownloadMenu.tsx` | (restored) f10890f / #95 |
+| v2 live + DAG phase order = unified taxonomy (legacy names removed) | `PhaseProgress.tsx`, `dag/buildDagFromRun.ts`, `PhaseDAGView.tsx` | #127 |
+| Mid-run instruction injection (persist follow-up to conversation_thread + steer running brain via `user_directive`) | `app/pipeline/runners/injection_queue.py`, `routers/v3/brain.py`, `strategist.py`, `scoped_brain.py` | #128 |
 
 ## TODO.md (root) reconciliation — what's actually done
 
@@ -97,4 +100,6 @@ Reconciled from merged PRs; grep-verified entry points. Prevents duplication.
 - **Signed callbacks** — do not re-merge #68; v3 (#84) is canonical.
 - **Brain subprocess auth** — `scoped_brain` must keep `CLAUDE_CODE_OAUTH_TOKEN` in the spawn env when no `/root/.claude/.credentials.json` file exists; popping it unconditionally broke ALL research. (#123) Beta = subscription token, not API.
 - **`org_scope_clause` only on org-scoped tables** — the `pipelines` table has NO `org_id` column, so applying `org_scope_clause` there SQL-errors for non-admins. Scope pipelines by `user_id`. Don't blanket-apply org scoping. (#124)
-- **Phase label** — vocabulary is `gather` everywhere; `BROADEN` retired. Don't reintroduce it as a label (distinct from the legacy-id lint, which keeps the word to forbid it). (#122)
+- **Phase label** — vocabulary is `gather` everywhere; `BROADEN` retired. Don't reintroduce it as a label (distinct from the legacy-id lint, which keeps the word to forbid it). (#122) Also keep prompt-content tests in sync — #122 silently broke `test_is_prompt::test_hypothesis_first_broaden_gate` (fixed in #129).
+- **Verify merges against a full-suite baseline, not an agent's selection.** #122's prompt-test break was invisible to its own test selection; only a full-suite diff caught it. When merging, diff failures against current `main` — distinguish real regressions from pre-existing (#125 temporal tests) and environmental flakiness (#130 login rate-limit).
+- **Mid-run injection requires a session** — `inject_node` persistence only fires when the run has a `session_id` (agent-chat runs do; bare `/v3/preflight/confirm` runs don't). The in-memory queue is per-process — won't bridge to out-of-process temporal workers. (#128)


### PR DESCRIPTION
Reconciliation pass: today's merges (#127 v2-live/DAG legacy phases, #128 mid-run injection, #129 is_prompt regression), new infra issues #130 (login rate-limit flakiness) + #131 (search 429), and regression-watchlist lessons (full-suite-baseline verification, mid-run injection needs a session). Docs only.