### PR TITLE
fix(tests): bypass rate limiter + admission gate under test (#130)

### DIFF
--- a/app/lib/rate_limit.py
+++ b/app/lib/rate_limit.py
@@ -9,9 +9,17 @@ Override per-route in the route decorator.
 """
 from __future__ import annotations
 
+import os
+
 from fastapi import Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+
+# Disable limiting under test: the suite makes hundreds of requests from a
+# single client IP (one bucket), which trips the 60/minute default and causes
+# flaky `429`s unrelated to the code under test. conftest sets DISABLE_RATE_LIMIT=1
+# before importing the app. (Does not affect prod, where the env var is unset.)
+_RATE_LIMIT_ENABLED = os.getenv("DISABLE_RATE_LIMIT") != "1"
 
 
 def _key_func(request: Request) -> str:
@@ -31,4 +39,5 @@ limiter = Limiter(
     default_limits=["60/minute"],
     storage_uri="memory://",
     headers_enabled=True,
+    enabled=_RATE_LIMIT_ENABLED,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,13 @@ import psycopg2.extras  # noqa: F401
 import os as _os
 _os.environ.setdefault("TEMPORAL_HOST", "localhost")
 _os.environ.setdefault("IS_USE_TEMPORAL", "false")
+# Disable the slowapi rate limiter under test (#130): the suite makes hundreds
+# of requests from one client IP, tripping the 60/min default and causing flaky
+# 429s ("Rate limit exceeded: 60 per 1 minute") on login-heavy tests. Must be
+# set before app import so the Limiter is constructed with enabled=False.
+_os.environ.setdefault("DISABLE_RATE_LIMIT", "1")
+# Bypass the run admission gate under test (#130): GLOBAL_MAX_CONCURRENT is 2,
+# so any stuck/concurrent runs in the shared dev DB make `check_admission` 429
+# every /v3/agent/message in the suite. Tests shouldn't depend on global run
+# capacity. Read at admission_gate import time.
+_os.environ.setdefault("GATE_ENABLED", "false")


### PR DESCRIPTION
## Summary
Closes #130. The full pytest suite was flaky because two **production guards** tripped on shared test state:

1. **slowapi rate limiter** (`default_limits=["60/minute"]`, keyed by client IP) → `Rate limit exceeded: 60 per 1 minute` on login-heavy tests (all share localhost → one bucket).
2. **run admission gate** (`GLOBAL_MAX_CONCURRENT=2`) → `429 admission_rejected` on every `/v3/agent/message` when the shared dev DB has ≥2 active runs.

Both are now disabled **under test** via `conftest.py` env vars set before app import:
- `DISABLE_RATE_LIMIT=1` → `Limiter(enabled=False)`
- `GATE_ENABLED=false` → `check_admission()` returns admitted

No production impact (env vars unset in prod). No test asserts these guards are enforced.

## Verification
- Login-heavy subset (`test_pipelines` + `test_account_endpoints` + `test_agent` + …): **72 passed** (was flaky with "Rate limit exceeded").
- `test_agent.py`: **3 passed** (was 429 `admission_rejected`).
- **Full suite: 1710 passed, 3 failed** (the 3 are `temporal/test_post_process_trail` from #125 — need a temporal harness, unrelated to this).

## Investigation note (re: "is rate-limit truly the cause?")
The **brain is NOT rate-limited**: a single `claude -p` call works, and a full run produced **23 trail branches with 0 `BRAIN_FAILURE`**. The `rate_limit_event` in the brain stream is informational and never used to fail a run (`scoped_brain.py:132-166` keys only off the `result` event). Earlier empty runs were #123 (auth, fixed) + intermittent search-429 (#131). Also cleaned up 12 zombie `running` runs (orphaned by API restarts) that were saturating the live admission gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)