### PR TITLE
feat(strategy): real-estate leads-generation — listings + contact + owner-background enrichment

### DIFF
--- a/app/pipeline/catalogs/registries/strategies/real_estate_leads.py
+++ b/app/pipeline/catalogs/registries/strategies/real_estate_leads.py
@@ -1,0 +1,82 @@
+"""Strategy catalog entry: real_estate_leads.
+
+Real-estate leads generation — find matching listings THEN enrich each listing
+with listing-agent / property-owner contact info (email, phone, brokerage) AND
+owner background (LLC registration, other holdings, WHOIS domain registration).
+
+Default mode: leads_generation.
+Routed from: (intent="real_estate", mode="leads_generation") via composite
+             routing in app/routers/v3/preflight.py _resolve_strategy.
+"""
+from __future__ import annotations
+
+from app.pipeline.catalogs.builders.research_skeleton import build_research_strategy
+
+STRATEGY = build_research_strategy(
+    id="real_estate_leads",
+    default_mode="leads_generation",
+    hypothesis_count="single",
+    applies_to={
+        "signals": [
+            "properties_in", "for_rent", "for_sale", "mls_listings",
+            "find_leads", "prospect_list", "contact_list", "outreach",
+            "rental_leads", "real_estate_leads",
+        ],
+        "entity_types": ["property", "listing", "person"],
+    },
+    extract={
+        "briefing": (
+            "Parse the real-estate leads-generation brief. Extract: "
+            "location (city/neighborhood/zip), price band (min/max in USD), "
+            "listing type (rent vs sale), property type (house/condo/apartment), "
+            "bed/bath count, and any explicit must-haves. "
+            "Also note the desired output: the caller wants a contactable leads "
+            "list — property + listing agent/owner email + phone + background. "
+            "Emit a typed signal dict the gather phase can query against. "
+            "No tool calls — pure analysis of the query text."
+        ),
+    },
+    gather={
+        "preferred_tactic_id": "leads_enrich_gather",
+        "briefing": (
+            "Execute a two-stage enrichment pipeline:\n\n"
+            "STAGE 1 — Listings: Query Zillow/MLS sources via apify_listings_search "
+            "for properties matching the extracted criteria. For each listing capture: "
+            "URL, address, price, beds/baths, sqft, listing type, and listing agent "
+            "name/brokerage if shown.\n\n"
+            "STAGE 2 — Contact enrichment (per listing):\n"
+            "  a. Agent/owner discovery: run web_search for 'listing agent OR owner "
+            "     contact <address>' to surface name, brokerage, and any contact info.\n"
+            "  b. Email: if a brokerage domain is known, use hunter_email_search on "
+            "     that domain; also try apollo_contact with the agent name + brokerage.\n"
+            "  c. Phone: validate/enrich any phone found via phone_osint; use "
+            "     pipl_people for a full contact-aggregation search on the agent/owner.\n"
+            "  d. Owner background: if the listing shows an owner LLC or company, "
+            "     use opencorporates_owner to find its officers and registration status; "
+            "     if the owner has a web domain, use whois_owner for registrant info.\n\n"
+            "Run stage 2 in parallel across listings where budget allows. Skip enrichment "
+            "steps that clearly won't yield data (e.g. whois_owner without a domain). "
+            "Budget note: apify_listings_search costs 10 RU; enrichment tools cost 1-3 RU each."
+        ),
+        "gate_checks": [
+            {"kind": "min_listings_returned", "params": {"min": 1}},
+        ],
+    },
+    synthesize={
+        "briefing": (
+            "Produce a contactable leads table, one row per listing, with columns:\n"
+            "  - Property: address, price, beds/baths, listing URL\n"
+            "  - Listing agent: name, brokerage, email, phone, LinkedIn (if found)\n"
+            "  - Owner: name or LLC, email, phone (if different from agent)\n"
+            "  - Owner background: LLC registration state + status, other holdings count, "
+            "    WHOIS registrant (if applicable), OpenCorporates officers\n"
+            "  - Source URLs for every contact/background claim\n"
+            "  - Confidence: HIGH (directly confirmed) / MEDIUM (cross-referenced) / "
+            "    LOW (single source, unverified)\n\n"
+            "Dedupe by address. Mark rows where contact enrichment found nothing as "
+            "'no contact found' rather than dropping them. Sort by price ascending. "
+            "Append a 'data gaps' section listing listings that could not be enriched "
+            "and why (no brokerage domain, private listing, etc.)."
+        ),
+    },
+)

--- a/app/pipeline/catalogs/registries/tactics/leads_enrich_gather.py
+++ b/app/pipeline/catalogs/registries/tactics/leads_enrich_gather.py
@@ -1,0 +1,129 @@
+"""Gather tactic for real-estate leads generation.
+
+Pulls property listings via Apify Zillow FIRST, then enriches each listing
+with agent/owner contact info (email, phone) and owner background (corporate
+registration, WHOIS). Uses the full enrichment toolchain:
+  web_search → agent/owner discovery
+  hunter_email_search → email lookup by domain/company
+  opencorporates_owner → owner LLC / corporate registration + officers
+  whois_owner → domain registrant background
+  apollo_contact → people contact (email/phone/LinkedIn)
+  phone_osint → phone number validation and carrier info
+  pipl_people → aggregated personal contact profiles
+
+Only apify_listings_search is required for the tactic to fire; enrichment
+techniques are best-effort and degrade gracefully.
+"""
+from app.pipeline.catalogs.schemas import Tactic
+
+
+TACTIC = Tactic(
+    id="leads_enrich_gather",
+    phase_compatibility=["gather"],
+    accepts={
+        "signals": (
+            "parsed real-estate leads criteria from extract (location, "
+            "price_min, price_max, listing_type) plus intent to produce "
+            "a contactable-leads list (agent/owner email + phone + background)"
+        ),
+    },
+    produces=[
+        # Step 1: pull listings (required anchor)
+        {
+            "technique_id": "apify_listings_search",
+            "params_template": {
+                "location": "{location}",
+                "min_price": "{price_min}",
+                "max_price": "{price_max}",
+                "listing_type": "{listing_type}",
+                "max_results": 20,
+            },
+            "expect_schema": {"min_results": 1},
+            "fail_modes": ["no_evidence", "tool_error", "schema_violation"],
+            "budget_ru": 10,
+        },
+        # Step 2: web search for listing agent / owner identity per listing
+        {
+            "technique_id": "web_search",
+            "params_template": {
+                "query": "listing agent OR owner contact '{address}' site:zillow.com OR site:realtor.com",
+                "max_results": 5,
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error"],
+            "budget_ru": 2,
+        },
+        # Step 3: Hunter.io email lookup for brokerage / owner domain
+        {
+            "technique_id": "hunter_email_search",
+            "params_template": {
+                "domain": "{brokerage_domain}",
+                "company": "{brokerage_name}",
+                "max_results": 5,
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error", "rate_limited"],
+            "budget_ru": 3,
+        },
+        # Step 4: Apollo contact lookup for listing agent / owner
+        {
+            "technique_id": "apollo_contact",
+            "params_template": {
+                "query": "{agent_name} {brokerage_name} {location}",
+                "search_type": "people",
+                "filters": "{}",
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error", "rate_limited"],
+            "budget_ru": 3,
+        },
+        # Step 5: OpenCorporates for owner LLC background
+        {
+            "technique_id": "opencorporates_owner",
+            "params_template": {
+                "company_name": "{owner_company_name}",
+                "jurisdiction": "{owner_jurisdiction}",
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error", "rate_limited"],
+            "budget_ru": 3,
+        },
+        # Step 6: WHOIS for owner domain registrant background
+        {
+            "technique_id": "whois_owner",
+            "params_template": {
+                "domain": "{owner_domain}",
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error"],
+            "budget_ru": 1,
+        },
+        # Step 7: Phone OSINT to validate or enrich phone numbers found above
+        {
+            "technique_id": "phone_osint",
+            "params_template": {
+                "phone": "{contact_phone}",
+                "country": "US",
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error", "invalid_phone"],
+            "budget_ru": 2,
+        },
+        # Step 8: Pipl people search for aggregated personal contact profile
+        {
+            "technique_id": "pipl_people",
+            "params_template": {
+                "first_name": "{contact_first_name}",
+                "last_name": "{contact_last_name}",
+                "city": "{location_city}",
+                "state": "{location_state}",
+            },
+            "expect_schema": {"min_results": 0},
+            "fail_modes": ["no_evidence", "tool_error", "insufficient_query_data"],
+            "budget_ru": 3,
+        },
+    ],
+    cost_class="expensive",
+    required_techniques=["apify_listings_search"],
+    enforcement={"min_distinct_outputs": 1},
+)

--- a/app/pipeline/catalogs/registries/techniques/apollo_contact.py
+++ b/app/pipeline/catalogs/registries/techniques/apollo_contact.py
@@ -1,0 +1,77 @@
+"""Technique catalog entry: apollo_contact.
+
+Maps to the ``run_apollo_search`` MCP tool — searches Apollo.io for people
+or companies, returning tech stack, intent data, and contact info. Used by
+leads_enrich_gather to find listing agent and property-owner phone/email
+during real-estate leads generation.
+"""
+from __future__ import annotations
+
+TECHNIQUE = {
+    "id": "apollo_contact",
+    "tool_name": "run_apollo_search",
+    "input_schema": {
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Name, company, or search query (e.g. 'Jane Smith RE/MAX Chicago')",
+            },
+            "search_type": {
+                "type": "string",
+                "enum": ["people", "companies"],
+                "default": "people",
+                "description": "Whether to search for people or companies",
+            },
+            "filters": {
+                "type": "string",
+                "default": "{}",
+                "description": "JSON string of Apollo search filters",
+            },
+        },
+        "additionalProperties": False,
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["people"],
+        "properties": {
+            "people": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": ["string", "null"]},
+                        "first_name": {"type": ["string", "null"]},
+                        "last_name": {"type": ["string", "null"]},
+                        "title": {"type": ["string", "null"]},
+                        "email": {"type": ["string", "null"]},
+                        "phone": {"type": ["string", "null"]},
+                        "linkedin_url": {"type": ["string", "null"]},
+                        "organization": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "name": {"type": ["string", "null"]},
+                                "website_url": {"type": ["string", "null"]},
+                            },
+                        },
+                        "city": {"type": ["string", "null"]},
+                        "state": {"type": ["string", "null"]},
+                    },
+                },
+            },
+        },
+    },
+    "cost_class": "moderate",
+    "cost_per_call_ru": 3,
+    "failure_modes": [
+        "no_results",
+        "rate_limited",
+        "api_key_missing",
+    ],
+    "retry_policy": {
+        "max_retries": 2,
+        "backoff_s": 2,
+        "retryable_on": ["transport_error", "timeout"],
+    },
+}

--- a/app/pipeline/catalogs/registries/techniques/hunter_email_search.py
+++ b/app/pipeline/catalogs/registries/techniques/hunter_email_search.py
@@ -1,0 +1,69 @@
+"""Technique catalog entry: hunter_email_search.
+
+Maps to the ``run_hunter_io`` MCP tool — finds email addresses for a company
+domain via Hunter.io. Used by leads_enrich_gather to find listing-agent and
+property-owner contact emails during real-estate leads generation.
+"""
+from __future__ import annotations
+
+TECHNIQUE = {
+    "id": "hunter_email_search",
+    "tool_name": "run_hunter_io",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": "Domain to search emails for (e.g. 'remax.com')",
+            },
+            "company": {
+                "type": "string",
+                "description": "Company name to search when domain is unknown",
+            },
+            "max_results": {
+                "type": "integer",
+                "default": 10,
+                "minimum": 1,
+                "maximum": 100,
+                "description": "Maximum number of email results to return",
+            },
+        },
+        "additionalProperties": False,
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["emails"],
+        "properties": {
+            "emails": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "email": {"type": "string"},
+                        "first_name": {"type": ["string", "null"]},
+                        "last_name": {"type": ["string", "null"]},
+                        "type": {"type": ["string", "null"]},
+                        "confidence": {"type": ["integer", "number", "null"]},
+                        "department": {"type": ["string", "null"]},
+                        "linkedin_url": {"type": ["string", "null"]},
+                        "phone_number": {"type": ["string", "null"]},
+                    },
+                },
+            },
+            "domain": {"type": ["string", "null"]},
+            "company": {"type": ["string", "null"]},
+        },
+    },
+    "cost_class": "moderate",
+    "cost_per_call_ru": 3,
+    "failure_modes": [
+        "no_results",
+        "rate_limited",
+        "domain_not_found",
+    ],
+    "retry_policy": {
+        "max_retries": 2,
+        "backoff_s": 2,
+        "retryable_on": ["transport_error", "timeout"],
+    },
+}

--- a/app/pipeline/catalogs/registries/techniques/opencorporates_owner.py
+++ b/app/pipeline/catalogs/registries/techniques/opencorporates_owner.py
@@ -1,0 +1,73 @@
+"""Technique catalog entry: opencorporates_owner.
+
+Maps to the ``run_opencorporates`` MCP tool — searches OpenCorporates global
+business registry for company registration data and officers. Used by
+leads_enrich_gather to research owner LLCs and property-holding entities
+during real-estate leads generation.
+"""
+from __future__ import annotations
+
+TECHNIQUE = {
+    "id": "opencorporates_owner",
+    "tool_name": "run_opencorporates",
+    "input_schema": {
+        "type": "object",
+        "required": ["company_name"],
+        "properties": {
+            "company_name": {
+                "type": "string",
+                "description": "Company or LLC name to search (e.g. 'Main Street Holdings LLC')",
+            },
+            "jurisdiction": {
+                "type": "string",
+                "description": "Optional jurisdiction filter (e.g. 'us_il' for Illinois)",
+            },
+        },
+        "additionalProperties": False,
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["companies"],
+        "properties": {
+            "companies": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "company_number": {"type": ["string", "null"]},
+                        "jurisdiction_code": {"type": ["string", "null"]},
+                        "incorporation_date": {"type": ["string", "null"]},
+                        "company_type": {"type": ["string", "null"]},
+                        "current_status": {"type": ["string", "null"]},
+                        "registered_address": {"type": ["string", "null"]},
+                        "officers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": "string"},
+                                    "role": {"type": ["string", "null"]},
+                                    "start_date": {"type": ["string", "null"]},
+                                },
+                            },
+                        },
+                        "source_url": {"type": ["string", "null"]},
+                    },
+                },
+            },
+        },
+    },
+    "cost_class": "moderate",
+    "cost_per_call_ru": 3,
+    "failure_modes": [
+        "no_results",
+        "rate_limited",
+        "company_not_found",
+    ],
+    "retry_policy": {
+        "max_retries": 2,
+        "backoff_s": 2,
+        "retryable_on": ["transport_error", "timeout"],
+    },
+}

--- a/app/pipeline/catalogs/registries/techniques/phone_osint.py
+++ b/app/pipeline/catalogs/registries/techniques/phone_osint.py
@@ -1,0 +1,59 @@
+"""Technique catalog entry: phone_osint.
+
+Maps to the ``run_phone_osint`` MCP tool — phone number OSINT lookup.
+Used by leads_enrich_gather to find or validate phone contact info for
+listing agents and property owners during real-estate leads generation.
+"""
+from __future__ import annotations
+
+TECHNIQUE = {
+    "id": "phone_osint",
+    "tool_name": "run_phone_osint",
+    "input_schema": {
+        "type": "object",
+        "required": ["phone"],
+        "properties": {
+            "phone": {
+                "type": "string",
+                "description": "Phone number to look up (e.g. '+13125550100')",
+            },
+            "country": {
+                "type": "string",
+                "description": "Optional ISO-2 country code to disambiguate (e.g. 'US')",
+            },
+        },
+        "additionalProperties": False,
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["result"],
+        "properties": {
+            "result": {
+                "type": "object",
+                "properties": {
+                    "phone": {"type": ["string", "null"]},
+                    "carrier": {"type": ["string", "null"]},
+                    "line_type": {"type": ["string", "null"]},
+                    "country_code": {"type": ["string", "null"]},
+                    "owner_name": {"type": ["string", "null"]},
+                    "owner_address": {"type": ["string", "null"]},
+                    "is_valid": {"type": ["boolean", "null"]},
+                    "is_active": {"type": ["boolean", "null"]},
+                },
+            },
+        },
+    },
+    "cost_class": "moderate",
+    "cost_per_call_ru": 2,
+    "failure_modes": [
+        "no_results",
+        "rate_limited",
+        "invalid_phone",
+        "api_key_missing",
+    ],
+    "retry_policy": {
+        "max_retries": 2,
+        "backoff_s": 2,
+        "retryable_on": ["transport_error", "timeout"],
+    },
+}

--- a/app/pipeline/catalogs/registries/techniques/pipl_people.py
+++ b/app/pipeline/catalogs/registries/techniques/pipl_people.py
@@ -1,0 +1,88 @@
+"""Technique catalog entry: pipl_people.
+
+Maps to the ``run_pipl_search`` MCP tool — people search via Pipl for
+contact aggregation (email, phone, address, social profiles). Used by
+leads_enrich_gather to find listing-agent and property-owner personal
+contact details during real-estate leads generation.
+"""
+from __future__ import annotations
+
+TECHNIQUE = {
+    "id": "pipl_people",
+    "tool_name": "run_pipl_search",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "first_name": {
+                "type": "string",
+                "description": "First name of the person",
+            },
+            "last_name": {
+                "type": "string",
+                "description": "Last name of the person",
+            },
+            "email": {
+                "type": "string",
+                "description": "Email address to cross-reference",
+            },
+            "phone": {
+                "type": "string",
+                "description": "Phone number to cross-reference",
+            },
+            "city": {
+                "type": "string",
+                "description": "City to narrow the search",
+            },
+            "state": {
+                "type": "string",
+                "description": "State abbreviation (e.g. 'IL')",
+            },
+        },
+        "additionalProperties": False,
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["people"],
+        "properties": {
+            "people": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": ["string", "null"]},
+                        "emails": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "phones": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "addresses": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "social_profiles": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "match_score": {"type": ["number", "null"]},
+                    },
+                },
+            },
+        },
+    },
+    "cost_class": "moderate",
+    "cost_per_call_ru": 3,
+    "failure_modes": [
+        "no_results",
+        "rate_limited",
+        "api_key_missing",
+        "insufficient_query_data",
+    ],
+    "retry_policy": {
+        "max_retries": 2,
+        "backoff_s": 2,
+        "retryable_on": ["transport_error", "timeout"],
+    },
+}

--- a/app/pipeline/catalogs/registries/techniques/whois_owner.py
+++ b/app/pipeline/catalogs/registries/techniques/whois_owner.py
@@ -1,0 +1,61 @@
+"""Technique catalog entry: whois_owner.
+
+Maps to the ``run_whois_lookup`` MCP tool — WHOIS lookup for domain
+registration info (registrant, dates, nameservers). Used by
+leads_enrich_gather to surface property-owner domain registrant details
+and company background during real-estate leads generation.
+"""
+from __future__ import annotations
+
+TECHNIQUE = {
+    "id": "whois_owner",
+    "tool_name": "run_whois_lookup",
+    "input_schema": {
+        "type": "object",
+        "required": ["domain"],
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": "Domain to look up (e.g. 'acme-realty.com')",
+            },
+        },
+        "additionalProperties": False,
+    },
+    "output_schema": {
+        "type": "object",
+        "required": ["registrant"],
+        "properties": {
+            "registrant": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "organization": {"type": ["string", "null"]},
+                    "email": {"type": ["string", "null"]},
+                    "phone": {"type": ["string", "null"]},
+                    "address": {"type": ["string", "null"]},
+                    "country": {"type": ["string", "null"]},
+                },
+            },
+            "domain": {"type": ["string", "null"]},
+            "creation_date": {"type": ["string", "null"]},
+            "expiration_date": {"type": ["string", "null"]},
+            "registrar": {"type": ["string", "null"]},
+            "nameservers": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+    },
+    "cost_class": "cheap",
+    "cost_per_call_ru": 1,
+    "failure_modes": [
+        "no_results",
+        "domain_not_found",
+        "rate_limited",
+    ],
+    "retry_policy": {
+        "max_retries": 2,
+        "backoff_s": 1,
+        "retryable_on": ["transport_error", "timeout"],
+    },
+}

--- a/app/pipeline/runners/working_memory.py
+++ b/app/pipeline/runners/working_memory.py
@@ -87,6 +87,8 @@ MCP_TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "run_sec_edgar":                 "lookup",
     "run_whois_lookup":              "lookup",
     "run_hunter_io":                 "lookup",
+    "run_phone_osint":               "lookup",
+    "run_pipl_search":               "lookup",
     "run_h1bdata_search":            "lookup",
     "run_name_origin_lookup":        "lookup",
     "run_migration_corridor_lookup": "lookup",

--- a/app/pipeline/tests/test_resolve_strategy.py
+++ b/app/pipeline/tests/test_resolve_strategy.py
@@ -2,6 +2,7 @@
 
 Verifies the 4-step fallback chain that maps (intent, mode) → strategy_id:
 
+    0. Composite map: (intent, mode) → dedicated composite strategy
     1. Intent has a dedicated strategy module      → use it
     2. Mode has strategy_suggestions               → first registered wins
     3. generic_search is registered                → fallback floor
@@ -19,6 +20,35 @@ from app.routers.v3.preflight import (
     _resolve_strategy,
     _suggest_mode,
 )
+
+
+# ---------------------------------------------------------------------------
+# Step 0: composite (intent, mode) map wins before plain intent match
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeStrategyRouting:
+    def test_real_estate_plus_leads_generation_routes_to_real_estate_leads(self):
+        """Core contract: real_estate + leads_generation → real_estate_leads."""
+        result = _resolve_strategy("real_estate", "leads_generation")
+        assert result == "real_estate_leads", (
+            f"Expected real_estate_leads, got {result!r}. "
+            "Composite map in _resolve_strategy may be missing or mis-ordered."
+        )
+
+    def test_real_estate_without_mode_still_routes_to_real_estate(self):
+        """Composite map must not affect plain real_estate routing (no mode)."""
+        result = _resolve_strategy("real_estate", None)
+        assert result == "real_estate"
+
+    def test_real_estate_with_non_leads_mode_still_routes_to_real_estate(self):
+        """Only leads_generation triggers the composite; other modes don't."""
+        result = _resolve_strategy("real_estate", "data_retrieval")
+        assert result == "real_estate"
+
+    def test_real_estate_leads_suggest_mode_is_leads_generation(self):
+        """real_estate_leads strategy declares default_mode='leads_generation'."""
+        assert _suggest_mode("real_estate_leads") == "leads_generation"
 
 
 # ---------------------------------------------------------------------------

--- a/app/pipeline/tests/test_startup_audit.py
+++ b/app/pipeline/tests/test_startup_audit.py
@@ -340,3 +340,96 @@ def test_phasespec_id_validator_accepts_unified_ids():
     for legal in ("extract", "gather", "disconfirm", "synthesize"):
         p = PhaseSpec(id=legal, unit_of_work_contract={}, hypothesis_count_policy="fixed:1", gate=gate)
         assert p.id == legal
+
+
+# ---------------------------------------------------------------------------
+# real_estate_leads strategy, leads_enrich_gather tactic, and techniques
+# ---------------------------------------------------------------------------
+
+
+def test_real_estate_leads_strategy_loads():
+    """real_estate_leads strategy is importable and declares extract/gather/synthesize."""
+    from app.pipeline.catalogs.registries.strategies.real_estate_leads import STRATEGY
+    phase_ids = [p["id"] for p in STRATEGY["phases"]]
+    assert set(phase_ids) >= {"extract", "gather", "synthesize"}
+    legal = {"extract", "gather", "disconfirm", "synthesize"}
+    assert set(phase_ids).issubset(legal)
+
+
+def test_real_estate_leads_gather_uses_leads_enrich_gather():
+    """real_estate_leads strategy's gather phase must prefer leads_enrich_gather."""
+    from app.pipeline.catalogs.registries.strategies.real_estate_leads import STRATEGY
+    gather = next(p for p in STRATEGY["phases"] if p["id"] == "gather")
+    assert gather.get("preferred_tactic_id") == "leads_enrich_gather"
+
+
+def test_real_estate_leads_strategy_default_mode_is_leads_generation():
+    """real_estate_leads must declare default_mode='leads_generation'."""
+    from app.pipeline.catalogs.registries.strategies.real_estate_leads import STRATEGY
+    assert STRATEGY["default_mode"] == "leads_generation"
+
+
+def test_leads_enrich_gather_tactic_loads():
+    """leads_enrich_gather tactic is importable and compatible with gather phase."""
+    from app.pipeline.catalogs.registries.tactics.leads_enrich_gather import TACTIC
+    from app.pipeline.catalogs.audit import _get_phase_compatibility
+    assert "gather" in _get_phase_compatibility(TACTIC)
+
+
+def test_leads_enrich_gather_requires_apify_listings_search():
+    """leads_enrich_gather must list apify_listings_search as a required technique."""
+    from app.pipeline.catalogs.registries.tactics.leads_enrich_gather import TACTIC
+    required = TACTIC.required_techniques if hasattr(TACTIC, "required_techniques") else TACTIC.get("required_techniques", [])
+    assert "apify_listings_search" in required
+
+
+def test_leads_enrich_gather_produces_all_enrichment_techniques():
+    """leads_enrich_gather must produce tasks for the full enrichment toolchain."""
+    from app.pipeline.catalogs.registries.tactics.leads_enrich_gather import TACTIC
+    technique_ids = {t.technique_id for t in TACTIC.produces}
+    required_subset = {
+        "apify_listings_search",
+        "web_search",
+        "hunter_email_search",
+        "apollo_contact",
+        "opencorporates_owner",
+        "whois_owner",
+        "phone_osint",
+        "pipl_people",
+    }
+    assert required_subset.issubset(technique_ids), (
+        f"Missing techniques: {required_subset - technique_ids}"
+    )
+
+
+def test_enrichment_techniques_load_through_catalog_loader():
+    """All 6 new enrichment techniques load cleanly via the catalog loader."""
+    from app.pipeline.catalogs.loader import load_catalog
+    from pathlib import Path
+    techniques_dir = Path(__file__).resolve().parents[2] / "pipeline" / "catalogs" / "registries" / "techniques"
+    techniques = load_catalog("technique", techniques_dir)
+    for tid in [
+        "hunter_email_search",
+        "opencorporates_owner",
+        "whois_owner",
+        "apollo_contact",
+        "phone_osint",
+        "pipl_people",
+    ]:
+        assert tid in techniques, f"Technique {tid!r} not found in catalog"
+        t = techniques[tid]
+        assert isinstance(t.input_schema, dict), f"{tid}: input_schema must be a dict"
+        assert isinstance(t.output_schema, dict), f"{tid}: output_schema must be a dict"
+        assert t.output_schema.get("type") == "object", f"{tid}: output_schema.type must be 'object'"
+
+
+def test_full_catalog_audit_passes_with_new_entries():
+    """The startup audit passes when real_estate_leads + leads_enrich_gather are included."""
+    from app.pipeline.catalogs.loader import load_catalog
+    from app.pipeline.catalogs.audit import run_audit_or_fail
+    from pathlib import Path
+    base = Path(__file__).resolve().parents[2] / "pipeline" / "catalogs" / "registries"
+    strategies = load_catalog("strategy", base / "strategies")
+    tactics = load_catalog("tactic", base / "tactics")
+    # Must not raise StrategyTacticAuditError
+    run_audit_or_fail(strategies, tactics)

--- a/app/routers/v3/investigation_templates.py
+++ b/app/routers/v3/investigation_templates.py
@@ -142,6 +142,60 @@ INVESTIGATION_TEMPLATES: list[dict] = [
              "placeholder": "Singapore-based fintech founded ~2017"},
         ],
     },
+    {
+        "id": "real-estate-leads",
+        "name": "Real Estate Leads Generation",
+        "description": (
+            "Find rental or sale listings matching your criteria, then build a "
+            "contactable leads list: listing agent/owner + email + phone + owner background."
+        ),
+        "icon": "Home",
+        "category": "general",
+        "query_template": (
+            "Generate real estate leads for {{listing_type}} properties in {{location}} "
+            "priced {{price_range}}. "
+            "For each matching listing, find: (1) the listing agent's name, brokerage, "
+            "email address, and phone number; (2) the property owner's name or LLC, "
+            "email, and phone if different from the agent; (3) an owner background check "
+            "— other property holdings, LLC/corporate registration state and status, "
+            "WHOIS registrant info if the owner has a web domain. "
+            "Return a contactable leads table sorted by price, with source URLs and "
+            "confidence levels for every contact detail. Mark any listings where "
+            "contact enrichment failed and explain why."
+        ),
+        "parameters": [
+            {"name": "location", "label": "Location (city / neighborhood / zip)", "type": "text",
+             "required": True, "placeholder": "Chicago, IL"},
+            {"name": "price_range", "label": "Price range", "type": "text", "required": True,
+             "placeholder": "$500–$1,000/mo"},
+            {"name": "listing_type", "label": "Listing type", "type": "text",
+             "required": True, "placeholder": "rental"},
+        ],
+    },
+    {
+        "id": "real-estate-leads-for-sale",
+        "name": "Real Estate Leads — For Sale",
+        "description": (
+            "Find properties for sale matching your criteria, with a full contact list "
+            "for each listing agent and owner plus ownership background research."
+        ),
+        "icon": "Building",
+        "category": "general",
+        "query_template": (
+            "Find real estate leads — properties for sale in {{location}} priced {{price_range}}. "
+            "I need a contact list for outreach: for each listing return the listing agent "
+            "(name, brokerage, email, phone), the seller/owner (name, email, phone, other "
+            "holdings), and an owner background check (LLC registration, WHOIS domain "
+            "registrant). Produce a flat contactable leads table with confidence scores "
+            "and source URLs per contact. Flag listings with incomplete contact info."
+        ),
+        "parameters": [
+            {"name": "location", "label": "Location (city / neighborhood / zip)", "type": "text",
+             "required": True, "placeholder": "Austin, TX"},
+            {"name": "price_range", "label": "Price range", "type": "text", "required": True,
+             "placeholder": "$400,000–$600,000"},
+        ],
+    },
 ]
 
 

--- a/app/routers/v3/preflight.py
+++ b/app/routers/v3/preflight.py
@@ -144,11 +144,28 @@ def _classify_query(query: str, mode: str | None = None) -> str:
     return _resolve_strategy(_classify_intent(query), mode)
 
 
+
+# ---------------------------------------------------------------------------
+# Composite strategy routing: (intent, mode) → strategy_id
+#
+# When a user picks a specific intent + mode combination that warrants a
+# dedicated strategy (rather than the intent's default strategy), this map
+# overrides step 1 of the resolution chain before the plain intent match.
+# ---------------------------------------------------------------------------
+
+_COMPOSITE_STRATEGY: dict[tuple[str, str], str] = {
+    ("real_estate", "leads_generation"): "real_estate_leads",
+}
+
+
 def _resolve_strategy(intent: str, mode: str | None = None) -> str:
     """Map an intent (and optional mode) to an engine_v2-runnable strategy_id.
 
     Resolution chain (most specific → most permissive):
 
+      0. **Composite map** — (intent, mode) pair matches a dedicated composite
+         strategy (e.g. real_estate + leads_generation → real_estate_leads).
+         Runs BEFORE the plain intent match so specialised strategies win.
       1. **Intent module** — a dedicated strategy module whose id matches
          ``intent`` (e.g. ``real_estate`` → ``real_estate.py``). Most precise.
       2. **Mode-anchored strategy** — the first id in the mode's
@@ -168,6 +185,12 @@ def _resolve_strategy(intent: str, mode: str | None = None) -> str:
     the same place.
     """
     supported = _engine_v2_supported_strategies()
+
+    # 0. Composite map: (intent, mode) → dedicated strategy.
+    if mode and (intent, mode) in _COMPOSITE_STRATEGY:
+        cand = _COMPOSITE_STRATEGY[(intent, mode)]
+        if cand in supported:
+            return cand
 
     # 1. Dedicated intent module wins.
     if intent in supported:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -358,6 +358,51 @@ async def run_whois_lookup(domain: str) -> str:
 
 
 @mcp.tool()
+async def run_phone_osint(phone: str, country: str = "") -> str:
+    """Phone number OSINT lookup — carrier, line type, owner name, and address.
+
+    phone: Phone number to look up (e.g. '+13125550100' or '3125550100').
+    country: Optional ISO-2 country code to disambiguate (e.g. 'US').
+    Use this to validate or enrich a phone number found during leads generation.
+    """
+    result = await api_call(
+        "POST",
+        "/v3/nodes/phone_osint/execute",
+        json={"phone": phone, "country": country},
+    )
+    return json.dumps(result)
+
+
+@mcp.tool()
+async def run_pipl_search(
+    first_name: str = "",
+    last_name: str = "",
+    email: str = "",
+    phone: str = "",
+    city: str = "",
+    state: str = "",
+) -> str:
+    """People search via Pipl — aggregates email, phone, address, and social profiles.
+
+    Provide at least one identity anchor (name, email, or phone) to get results.
+    Use this to find or verify contact details for listing agents and property owners.
+    """
+    result = await api_call(
+        "POST",
+        "/v3/nodes/pipl_search/execute",
+        json={
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "phone": phone,
+            "city": city,
+            "state": state,
+        },
+    )
+    return json.dumps(result)
+
+
+@mcp.tool()
 async def run_google_news(query: str, max_results: int = 10) -> str:
     """Search Google News for recent articles about a topic, company, or person."""
     result = await api_call(


### PR DESCRIPTION
## Summary

- **New strategy** `real_estate_leads` — dedicated leads-gen path that branches at the routing layer when `intent=real_estate` AND `mode=leads_generation`, delivering listings THEN per-listing contact enrichment (agent email/phone) AND owner background research (LLC, WHOIS).
- **New tactic** `leads_enrich_gather` — 8-technique produce chain: `apify_listings_search` (anchor) → `web_search` + `hunter_email_search` + `apollo_contact` + `opencorporates_owner` + `whois_owner` + `phone_osint` + `pipl_people`.
- **6 new catalog techniques** with valid `output_schema` (startup-audit requirement): `hunter_email_search`, `opencorporates_owner`, `whois_owner`, `apollo_contact`, `phone_osint`, `pipl_people`.
- **2 new MCP wrappers** in `mcp_server/server.py`: `run_phone_osint` → `/v3/nodes/phone_osint/execute`, `run_pipl_search` → `/v3/nodes/pipl_search/execute`. Both registered in `MCP_TOOL_CATEGORIES` as `"lookup"`.
- **Composite routing** in `_resolve_strategy` — `_COMPOSITE_STRATEGY = {("real_estate","leads_generation"): "real_estate_leads"}` checked at step 0, before the plain intent match.
- **2 investigation templates** added: `real-estate-leads` (rental) and `real-estate-leads-for-sale`, with query wording that makes the classifier land on `leads_generation` mode.

## Routing verification

```
_resolve_strategy("real_estate", "leads_generation")  → "real_estate_leads"  ✓
_resolve_strategy("real_estate", None)                → "real_estate"        ✓  (unchanged)
_resolve_strategy("real_estate", "data_retrieval")    → "real_estate"        ✓  (unchanged)
_suggest_mode("real_estate_leads")                    → "leads_generation"   ✓
```

## Startup audit

Catalog audit passes with all new entries (`run_audit_or_fail` raises no `StrategyTacticAuditError`).

## Test plan

- [x] `pytest app/pipeline/tests/test_resolve_strategy.py` — 4 new composite routing assertions added; 20 total pass
- [x] `pytest app/pipeline/tests/test_startup_audit.py` — 7 new catalog/audit assertions added; 42 total pass
- [x] `pytest app/pipeline/tests/test_no_legacy_phase_ids.py` — 2 passed
- [x] `ruff check app` — 0 new errors (baseline 10, all pre-existing)
- [x] `pytest tests/ -q -p no:randomly --ignore=tests/pipeline/nodes/test_github_search.py` — 1710 passed, 3 skipped (the 3 failures in `tests/v3/test_agent.py` are rate-limit bleed-over from prior tests in the full-suite sequence; they pass when run in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)