### PR TITLE
feat(preflight): infer leads_generation mode from lead-gen phrasing (completes #138)

### DIFF
--- a/app/pipeline/tests/test_resolve_strategy.py
+++ b/app/pipeline/tests/test_resolve_strategy.py
@@ -17,9 +17,33 @@ from unittest.mock import patch
 
 from app.routers.v3.preflight import (
     _classify_query,
+    _infer_mode,
     _resolve_strategy,
     _suggest_mode,
 )
+
+
+class TestInferMode:
+    """Lead-gen phrasing infers leads_generation mode so real-estate-leads
+    queries/templates reach the (real_estate, leads_generation) composite route."""
+
+    def test_lead_list_phrase_infers_leads_generation(self):
+        assert _infer_mode("generate a lead list of rentals with owner contact info") == "leads_generation"
+
+    def test_find_leads_phrase_infers_leads_generation(self):
+        assert _infer_mode("find leads: CTOs at fintech startups") == "leads_generation"
+
+    def test_plain_listing_query_infers_nothing(self):
+        assert _infer_mode("properties for rent in chicago under $1000") is None
+
+    def test_empty_query_infers_nothing(self):
+        assert _infer_mode("") is None
+
+    def test_real_estate_plus_inferred_leads_mode_routes_to_real_estate_leads(self):
+        assert _resolve_strategy("real_estate", _infer_mode("lead list of rentals in chicago")) == "real_estate_leads"
+
+    def test_real_estate_without_lead_phrase_stays_real_estate(self):
+        assert _resolve_strategy("real_estate", _infer_mode("rentals in chicago")) == "real_estate"
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/v3/preflight.py
+++ b/app/routers/v3/preflight.py
@@ -144,6 +144,32 @@ def _classify_query(query: str, mode: str | None = None) -> str:
     return _resolve_strategy(_classify_intent(query), mode)
 
 
+# Lead-generation phrasing → infer leads_generation mode when the user didn't
+# pick one explicitly. This is what lets a real-estate query (or the
+# real-estate-leads template) reach the composite (real_estate, leads_generation)
+# → real_estate_leads route, so the brain branches to contact + owner-background
+# enrichment instead of listings-only. Kept to explicit lead phrasing to avoid
+# steering ordinary searches into leads mode.
+_LEADS_MODE_SIGNALS = (
+    "lead list", "leads list", "lead generation", "lead-gen", "leadgen",
+    "generate leads", "find leads", "prospect list", "prospecting",
+    "outreach list", "contact list", "build a list of contacts",
+)
+
+
+def _infer_mode(query: str) -> str | None:
+    """Infer an optimization mode from query phrasing when none was supplied.
+
+    Currently only detects leads_generation (the one mode with a composite
+    strategy route). Returns None when no signal matches, preserving the
+    existing default-mode behavior.
+    """
+    q = (query or "").lower()
+    if any(sig in q for sig in _LEADS_MODE_SIGNALS):
+        return "leads_generation"
+    return None
+
+
 
 # ---------------------------------------------------------------------------
 # Composite strategy routing: (intent, mode) → strategy_id
@@ -455,13 +481,17 @@ def preflight(body: PreflightIn, user: dict = Depends(get_current_user)):
     # Classifier — override wins over auto-detection. Mode (if user-supplied)
     # feeds the resolution chain's mode-anchor step, so users picking a mode
     # with a vague query route through that mode's preferred strategy.
+    # Mode: explicit user choice wins; otherwise infer from lead-gen phrasing so
+    # a real-estate-leads query/template reaches the (real_estate, leads_generation)
+    # → real_estate_leads composite route. Falls back to the strategy default.
+    effective_mode = body.mode or _infer_mode(body.query)
     if body.intent_override:
         effective_intent = body.intent_override
-        strategy_id = body.strategy or _resolve_strategy(effective_intent, body.mode)
+        strategy_id = body.strategy or _resolve_strategy(effective_intent, effective_mode)
     else:
         effective_intent = _classify_intent(body.query)
-        strategy_id = body.strategy or _classify_query(body.query, body.mode)
-    suggested_mode = body.mode or _suggest_mode(strategy_id)
+        strategy_id = body.strategy or _classify_query(body.query, effective_mode)
+    suggested_mode = effective_mode or _suggest_mode(strategy_id)
 
     # Resolve mode dial defaults — mode sets the baseline; explicit dials override per-dial
     mode_entry = _MODE_CATALOG.get(suggested_mode)


### PR DESCRIPTION
Completes the real-estate leads-gen routing. The `(real_estate, leads_generation)` → `real_estate_leads` composite (from #138) only fired on explicit mode selection; leads-worded queries + the real-estate-leads template still routed to listings-only `real_estate`. Adds `_infer_mode(query)` — explicit lead phrasing → `leads_generation` when no mode is supplied — wired into the preflight handler. **Verified live:** leads-worded real-estate query → `real_estate_leads`; plain listings → `real_estate` (no regression). +6 unit tests.