### PR TITLE
feat(preflight): tune _infer_mode with real-estate lead idioms

### DIFF
--- a/app/pipeline/tests/test_resolve_strategy.py
+++ b/app/pipeline/tests/test_resolve_strategy.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from app.routers.v3.preflight import (
     _classify_query,
     _infer_mode,
@@ -44,6 +46,25 @@ class TestInferMode:
 
     def test_real_estate_without_lead_phrase_stays_real_estate(self):
         assert _resolve_strategy("real_estate", _infer_mode("rentals in chicago")) == "real_estate"
+
+    @pytest.mark.parametrize("query", [
+        "for sale by owner homes in austin",
+        "FRBO rental leads near downtown",
+        "motivated sellers list in dallas",
+        "find property owners in chicago with owner contact info",
+        "agent contact for listings in miami",
+    ])
+    def test_real_estate_lead_idioms_infer_leads_generation(self, query):
+        assert _infer_mode(query) == "leads_generation"
+        assert _resolve_strategy("real_estate", _infer_mode(query)) == "real_estate_leads"
+
+    @pytest.mark.parametrize("query", [
+        "show all properties for rent in chicago with a budget of 500 to 1000 near the metro studio",
+        "what is the contact info for openai support",
+    ])
+    def test_lead_idioms_do_not_over_trigger(self, query):
+        # Ordinary property/contact queries must NOT flip to leads mode.
+        assert _infer_mode(query) is None
 
 
 # ---------------------------------------------------------------------------

--- a/app/routers/v3/preflight.py
+++ b/app/routers/v3/preflight.py
@@ -151,9 +151,21 @@ def _classify_query(query: str, mode: str | None = None) -> str:
 # enrichment instead of listings-only. Kept to explicit lead phrasing to avoid
 # steering ordinary searches into leads mode.
 _LEADS_MODE_SIGNALS = (
+    # Generic lead-gen phrasing
     "lead list", "leads list", "lead generation", "lead-gen", "leadgen",
     "generate leads", "find leads", "prospect list", "prospecting",
     "outreach list", "contact list", "build a list of contacts",
+    "rental leads", "sales leads", "real estate leads", "real-estate leads",
+    "property leads",
+    # Real-estate lead-gen idioms (owner/agent outreach sourcing).
+    # Kept specific (paired with "owner"/"agent"/"seller"/"landlord") so an
+    # ordinary "what's the contact info for X" query doesn't flip to leads mode.
+    "fsbo", "for sale by owner", "frbo", "for rent by owner",
+    "motivated seller", "motivated sellers", "off-market owner",
+    "owner contact", "owner contacts", "owners' contact", "agent contact",
+    "landlord contact", "broker contact", "seller contact",
+    "property owners", "list of owners", "find owners", "owner information",
+    "skip trace", "skip-trace",
 )
 
 


### PR DESCRIPTION
Adds real-estate lead-gen signals to `_infer_mode` (FSBO/FRBO, for-sale/rent-by-owner, motivated sellers, owner/agent contact, property owners, rental/property leads, skip trace) so real-estate leads queries auto-route to `real_estate_leads`. Signals kept specific so ordinary property searches and 'contact info for X' don't over-trigger. Parametrized tests cover both.