### PR TITLE
feat(brain): deprioritize unhealthy (no-API-key) tools + listings-first leads tactic

### DIFF
--- a/app/pipeline/catalogs/registries/strategies/real_estate_leads.py
+++ b/app/pipeline/catalogs/registries/strategies/real_estate_leads.py
@@ -39,12 +39,11 @@ STRATEGY = build_research_strategy(
     gather={
         "preferred_tactic_id": "leads_enrich_gather",
         "briefing": (
-            "Execute a two-stage enrichment pipeline:\n\n"
-            "STAGE 1 — Listings: Query Zillow/MLS sources via apify_listings_search "
-            "for properties matching the extracted criteria. For each listing capture: "
-            "URL, address, price, beds/baths, sqft, listing type, and listing agent "
-            "name/brokerage if shown.\n\n"
-            "STAGE 2 — Contact enrichment (per listing):\n"
+            "STEP 1 — Get property listings FIRST: Call apify_listings_search "
+            "with the extracted location/price/type criteria. Capture address, price, "
+            "listing URL, beds/baths, and listing-agent name/brokerage for EACH listing. "
+            "Do NOT start enrichment until you have listings in hand.\n\n"
+            "STEP 2 — Contact enrichment (per listing, once you have the list):\n"
             "  a. Agent/owner discovery: run web_search for 'listing agent OR owner "
             "     contact <address>' to surface name, brokerage, and any contact info.\n"
             "  b. Email: if a brokerage domain is known, use hunter_email_search on "
@@ -54,9 +53,14 @@ STRATEGY = build_research_strategy(
             "  d. Owner background: if the listing shows an owner LLC or company, "
             "     use opencorporates_owner to find its officers and registration status; "
             "     if the owner has a web domain, use whois_owner for registrant info.\n\n"
-            "Run stage 2 in parallel across listings where budget allows. Skip enrichment "
+            "Run enrichment in parallel across listings where budget allows. Skip enrichment "
             "steps that clearly won't yield data (e.g. whois_owner without a domain). "
-            "Budget note: apify_listings_search costs 10 RU; enrichment tools cost 1-3 RU each."
+            "Budget note: apify_listings_search costs 10 RU; enrichment tools cost 1-3 RU each.\n\n"
+            "IMPORTANT: The property list from STEP 1 is ALWAYS the primary output. "
+            "Even if all enrichment steps fail (e.g. API keys not configured), "
+            "return the full property list with address + price + listing URL. "
+            "Mark missing contact fields as 'not found (or tool unavailable)' — "
+            "do not drop properties because enrichment was thin."
         ),
         "gate_checks": [
             {"kind": "min_listings_returned", "params": {"min": 1}},
@@ -64,19 +68,21 @@ STRATEGY = build_research_strategy(
     },
     synthesize={
         "briefing": (
-            "Produce a contactable leads table, one row per listing, with columns:\n"
-            "  - Property: address, price, beds/baths, listing URL\n"
-            "  - Listing agent: name, brokerage, email, phone, LinkedIn (if found)\n"
-            "  - Owner: name or LLC, email, phone (if different from agent)\n"
-            "  - Owner background: LLC registration state + status, other holdings count, "
-            "    WHOIS registrant (if applicable), OpenCorporates officers\n"
+            "Assemble a contactable leads table — one row per property — with these columns:\n"
+            "  - Property: address | price | listing URL | beds/baths\n"
+            "  - Listing agent: name | brokerage | email | phone | LinkedIn\n"
+            "  - Owner: name or LLC | email | phone (if different from agent)\n"
+            "  - Owner background: LLC registration state + status | other holdings count | "
+            "    WHOIS registrant | OpenCorporates officers\n"
             "  - Source URLs for every contact/background claim\n"
             "  - Confidence: HIGH (directly confirmed) / MEDIUM (cross-referenced) / "
             "    LOW (single source, unverified)\n\n"
-            "Dedupe by address. Mark rows where contact enrichment found nothing as "
-            "'no contact found' rather than dropping them. Sort by price ascending. "
-            "Append a 'data gaps' section listing listings that could not be enriched "
-            "and why (no brokerage domain, private listing, etc.)."
+            "CRITICAL: The property list is ALWAYS returned, even when enrichment is thin. "
+            "Mark every missing contact field as 'not found (or tool unavailable)' rather "
+            "than dropping the property row. Sort by price ascending. "
+            "Dedupe by address. Append a 'data gaps' section listing which enrichment "
+            "tools returned no data and why (key not configured, no brokerage domain, "
+            "private listing, etc.)."
         ),
     },
 )

--- a/app/pipeline/runners/scoped_brain.py
+++ b/app/pipeline/runners/scoped_brain.py
@@ -302,7 +302,21 @@ def _build_scoped_prompt(
     else:
         # Tactics with `produces` MUST emit tool_use blocks. Be explicit about
         # which MCP-prefixed tool to call and what params to use.
-        lines += [
+        #
+        # Health-aware ordering: partition into healthy vs unhealthy (no key /
+        # requires_key set).  Healthy tools are listed first; unhealthy ones are
+        # annotated with ⚠ UNAVAILABLE but still listed so required_techniques
+        # can be called if no alternative exists.  Best-effort: unknown health
+        # (cache miss) is treated as healthy — we never over-suppress.
+        from app.pipeline.runners.tool_health import (
+            is_unhealthy,
+            missing_key as _missing_key,
+        )
+
+        healthy_prods = [p for p in tactic.produces if not is_unhealthy(p.technique_id)]
+        unhealthy_prods = [p for p in tactic.produces if is_unhealthy(p.technique_id)]
+
+        tool_header = [
             "",
             "## EXECUTION MODE: TOOL USE REQUIRED",
             f"You MUST call EXACTLY {len(tactic.produces)} MCP tool(s) for this tactic.",
@@ -312,6 +326,11 @@ def _build_scoped_prompt(
             "",
             "### Mandatory tool calls (call each one once with the params shown):",
         ]
+        if unhealthy_prods:
+            tool_header.append(
+                "Prefer the healthy tools; treat ⚠ ones as last-resort — they will return empty without their API key."
+            )
+        lines += tool_header
         # Map technique_id → fully-qualified MCP tool name.
         # The actual search string is the user's query — never the briefing.
         sample_query = (
@@ -319,10 +338,23 @@ def _build_scoped_prompt(
             or unit_of_work.get("objective")
             or ""
         )
-        for prod in tactic.produces:
+
+        # Emit healthy tools first (unchanged behaviour)
+        for prod in healthy_prods:
             mcp_tool = f"mcp__info-broker-mcp__run_{prod.technique_id}"
             lines.append(
                 f"  • {mcp_tool}  —  template params: {prod.params_template}"
+            )
+            lines.append(
+                f"    Substitute {{hypothesis_query}}/{{original_query}}/etc. with: \"{sample_query}\""
+            )
+
+        # Emit unhealthy tools last, annotated with ⚠
+        for prod in unhealthy_prods:
+            mcp_tool = f"mcp__info-broker-mcp__run_{prod.technique_id}"
+            key_label = _missing_key(prod.technique_id) or "API key"
+            lines.append(
+                f"  ⚠ {mcp_tool} — UNAVAILABLE (needs {key_label}); prefer the healthy tools above, use this only if no alternative."
             )
             lines.append(
                 f"    Substitute {{hypothesis_query}}/{{original_query}}/etc. with: \"{sample_query}\""

--- a/app/pipeline/runners/tool_health.py
+++ b/app/pipeline/runners/tool_health.py
@@ -1,0 +1,139 @@
+"""tool_health.py — Sync health lookup for techniques via the node health cache.
+
+Reads the module-level ``_health_cache`` populated by
+``app.routers.v3.pipelines.get_nodes_health``.  Never calls async
+health_check() directly — best-effort read of whatever is already cached.
+Unknown / cache-miss → treated as healthy (don't over-suppress).
+
+Usage::
+
+    from app.pipeline.runners.tool_health import is_unhealthy, missing_key
+
+    if is_unhealthy("hunter_email_search"):
+        key = missing_key("hunter_email_search")  # "HUNTER_API_KEY"
+"""
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Technique → node_type resolution
+# ---------------------------------------------------------------------------
+# Primary rule: strip "run_" prefix from tool_name (run_hunter_io → hunter_io).
+# Explicit overrides for tool_names that don't follow the convention.
+
+_TOOL_NAME_TO_NODE: dict[str, str | None] = {
+    # Non-run_ prefixed special cases
+    "apify_actor_run": "apify_actor",
+    "get_past_research": None,          # internal; no node, always healthy
+    # run_* convention (listed explicitly so grepping is easy)
+    "run_web_search":      "web_search",
+    "run_hunter_io":       "hunter_io",
+    "run_apollo_search":   "apollo_search",
+    "run_opencorporates":  "opencorporates",
+    "run_whois_lookup":    "whois_lookup",
+    "run_phone_osint":     "phone_osint",
+    "run_pipl_search":     "pipl_search",
+    "run_google_news":     "google_news",
+    "run_tmdb_search":     "tmdb_search",
+    "run_image_search":    "image_search",
+}
+
+
+def _tool_name_to_node(tool_name: str) -> str | None:
+    """Resolve a technique's tool_name to the pipeline node_type that backs it.
+
+    Returns None when the tool has no backing node (treat as healthy).
+    Falls back to stripping the "run_" prefix for unknown tool_names.
+    """
+    if tool_name in _TOOL_NAME_TO_NODE:
+        return _TOOL_NAME_TO_NODE[tool_name]
+    # Generic fallback: strip run_ prefix
+    if tool_name.startswith("run_"):
+        return tool_name[4:]
+    # Unknown pattern — can't map; treat as healthy
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Health lookup
+# ---------------------------------------------------------------------------
+
+def technique_health(technique_id: str) -> dict | None:
+    """Return the cached HealthStatus for the node backing *technique_id*.
+
+    Reads the technique from the catalog, resolves the node_type, then
+    reads ``_health_cache`` from the pipelines router.
+
+    Returns:
+        A HealthStatus-shaped dict if the node has a fresh cached status,
+        else None.  None means unknown — callers MUST treat None as healthy
+        (best-effort; don't over-suppress).
+    """
+    from pathlib import Path
+
+    from app.pipeline.catalogs.loader import load_catalog
+
+    # Load the technique catalog to get the tool_name
+    technique_dir = (
+        Path(__file__).parent.parent / "catalogs" / "registries" / "techniques"
+    )
+    try:
+        techniques = load_catalog("technique", technique_dir)
+    except Exception as exc:
+        log.debug("tool_health: could not load technique catalog: %s", exc)
+        return None
+
+    technique = techniques.get(technique_id)
+    if technique is None:
+        log.debug("tool_health: technique %r not in catalog", technique_id)
+        return None
+
+    node_type = _tool_name_to_node(technique.tool_name)
+    if node_type is None:
+        # No node backing this tool — treat as healthy
+        return None
+
+    # Read the shared health cache from the pipelines router (no async needed)
+    try:
+        import time
+
+        from app.routers.v3.pipelines import _HEALTH_CACHE_TTL, _health_cache
+
+        entry = _health_cache.get(node_type)
+        if entry is None:
+            return None
+        cached_time, status = entry
+        if time.time() - cached_time > _HEALTH_CACHE_TTL:
+            # Stale — treat as unknown (healthy)
+            return None
+        return status
+    except Exception as exc:
+        log.debug("tool_health: error reading _health_cache: %s", exc)
+        return None
+
+
+def is_unhealthy(technique_id: str) -> bool:
+    """Return True only if the technique's node is KNOWN to be unhealthy.
+
+    Unknown / cache-miss → False (don't over-suppress).
+    """
+    status = technique_health(technique_id)
+    if status is None:
+        return False
+    return not status.get("healthy", True)
+
+
+def missing_key(technique_id: str) -> str | None:
+    """Return the requires_key string if the node is unhealthy due to a missing key.
+
+    Returns None if the node is healthy, unknown, or unhealthy for another reason.
+    """
+    status = technique_health(technique_id)
+    if status is None:
+        return None
+    if status.get("healthy", True):
+        return None
+    return status.get("requires_key") or None

--- a/tests/pipeline/runners/test_scoped_brain_health_prompt.py
+++ b/tests/pipeline/runners/test_scoped_brain_health_prompt.py
@@ -1,0 +1,124 @@
+"""Unit tests for health-aware tool ordering in scoped_brain._build_scoped_prompt."""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from app.pipeline.catalogs.schemas import Tactic, TaskSpec
+from app.pipeline.runners.scoped_brain import _build_scoped_prompt
+
+
+def _make_tactic(technique_ids: list[str]) -> Tactic:
+    """Build a minimal Tactic with the given techniques in produces."""
+    return Tactic(
+        id="test_tactic",
+        phase_compatibility=["gather"],
+        accepts={"signals": "test"},
+        produces=[
+            TaskSpec(
+                technique_id=tid,
+                params_template={"query": "{hypothesis_query}"},
+                expect_schema={},
+                fail_modes=[],
+                budget_ru=1,
+            )
+            for tid in technique_ids
+        ],
+        cost_class="moderate",
+        required_techniques=[],
+    )
+
+
+def _fake_cache_with_unhealthy(node_type: str, key_name: str) -> dict:
+    return {
+        node_type: (
+            time.time(),
+            {
+                "healthy": False,
+                "error": f"{key_name} not set",
+                "requires_key": key_name,
+                "setup_url": None,
+                "setup_instructions": None,
+            },
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# Healthy-only tactic: no change in ordering
+# ---------------------------------------------------------------------------
+
+def test_all_healthy_tools_listed_without_warning():
+    tactic = _make_tactic(["web_search"])
+    with patch("app.routers.v3.pipelines._health_cache", {}):
+        prompt = _build_scoped_prompt(tactic, {"query": "test query"}, "general")
+    assert "mcp__info-broker-mcp__run_web_search" in prompt
+    assert "⚠" not in prompt
+    assert "UNAVAILABLE" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Mixed tactic: healthy BEFORE unhealthy in the prompt
+# ---------------------------------------------------------------------------
+
+def test_healthy_tools_listed_before_unhealthy():
+    """web_search (healthy) must appear BEFORE hunter_email_search (unhealthy)."""
+    tactic = _make_tactic(["hunter_email_search", "web_search"])
+    fake_cache = _fake_cache_with_unhealthy("hunter_io", "HUNTER_API_KEY")
+
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        prompt = _build_scoped_prompt(
+            tactic, {"query": "test query"}, "general"
+        )
+
+    pos_web = prompt.index("run_web_search")
+    pos_hunter = prompt.index("run_hunter_email_search")
+    assert pos_web < pos_hunter, (
+        "web_search (healthy) should appear before hunter_email_search (unhealthy)"
+    )
+
+
+def test_unhealthy_tool_annotated_with_warning_glyph():
+    """Unhealthy tools must carry ⚠ in the prompt."""
+    tactic = _make_tactic(["hunter_email_search", "web_search"])
+    fake_cache = _fake_cache_with_unhealthy("hunter_io", "HUNTER_API_KEY")
+
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        prompt = _build_scoped_prompt(tactic, {"query": "test query"}, "general")
+
+    assert "⚠" in prompt
+    assert "UNAVAILABLE" in prompt
+    assert "HUNTER_API_KEY" in prompt
+
+
+def test_prompt_contains_prefer_healthy_instruction():
+    """The prompt must contain the instruction to prefer healthy tools."""
+    tactic = _make_tactic(["hunter_email_search", "web_search"])
+    fake_cache = _fake_cache_with_unhealthy("hunter_io", "HUNTER_API_KEY")
+
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        prompt = _build_scoped_prompt(tactic, {"query": "test query"}, "general")
+
+    assert "Prefer the healthy tools" in prompt
+
+
+def test_all_unhealthy_still_included():
+    """Even with all tools unhealthy, all are still listed (tactic may require them)."""
+    tactic = _make_tactic(["hunter_email_search"])
+    fake_cache = _fake_cache_with_unhealthy("hunter_io", "HUNTER_API_KEY")
+
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        prompt = _build_scoped_prompt(tactic, {"query": "test query"}, "general")
+
+    assert "run_hunter_email_search" in prompt
+    assert "⚠" in prompt
+
+
+def test_cache_miss_treated_as_healthy():
+    """A technique with no cache entry (unknown) must be listed as healthy (no ⚠)."""
+    tactic = _make_tactic(["hunter_email_search"])
+    with patch("app.routers.v3.pipelines._health_cache", {}):
+        prompt = _build_scoped_prompt(tactic, {"query": "test query"}, "general")
+
+    assert "⚠" not in prompt
+    assert "mcp__info-broker-mcp__run_hunter_email_search" in prompt

--- a/tests/pipeline/runners/test_tool_health.py
+++ b/tests/pipeline/runners/test_tool_health.py
@@ -1,0 +1,147 @@
+"""Unit tests for app.pipeline.runners.tool_health."""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from app.pipeline.runners.tool_health import (
+    _tool_name_to_node,
+    is_unhealthy,
+    missing_key,
+    technique_health,
+)
+
+
+# ---------------------------------------------------------------------------
+# _tool_name_to_node mapping
+# ---------------------------------------------------------------------------
+
+def test_run_prefix_strips_to_node():
+    assert _tool_name_to_node("run_hunter_io") == "hunter_io"
+    assert _tool_name_to_node("run_apollo_search") == "apollo_search"
+    assert _tool_name_to_node("run_phone_osint") == "phone_osint"
+    assert _tool_name_to_node("run_pipl_search") == "pipl_search"
+    assert _tool_name_to_node("run_opencorporates") == "opencorporates"
+    assert _tool_name_to_node("run_whois_lookup") == "whois_lookup"
+    assert _tool_name_to_node("run_web_search") == "web_search"
+
+
+def test_apify_actor_run_maps_to_apify_actor():
+    assert _tool_name_to_node("apify_actor_run") == "apify_actor"
+
+
+def test_get_past_research_maps_to_none():
+    # no backing node → always healthy
+    assert _tool_name_to_node("get_past_research") is None
+
+
+def test_unknown_tool_name_falls_back_to_strip():
+    # Generic fallback: strip run_ prefix
+    assert _tool_name_to_node("run_some_future_tool") == "some_future_tool"
+
+
+def test_no_run_prefix_unknown_returns_none():
+    # Can't map — return None (treat healthy)
+    assert _tool_name_to_node("totally_unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# technique_health — cache-empty → None (treat healthy)
+# ---------------------------------------------------------------------------
+
+def test_technique_health_empty_cache_returns_none():
+    """When the health cache has no entry for a node, return None (treat as healthy)."""
+    with patch("app.routers.v3.pipelines._health_cache", {}):
+        result = technique_health("hunter_email_search")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# technique_health — cache populated with requires_key
+# ---------------------------------------------------------------------------
+
+def test_technique_health_returns_unhealthy_when_cache_says_requires_key():
+    """When cache says requires_key, technique_health returns the HealthStatus dict."""
+    fake_status = {
+        "healthy": False,
+        "error": "HUNTER_API_KEY not set",
+        "requires_key": "HUNTER_API_KEY",
+        "setup_url": "/settings",
+        "setup_instructions": None,
+    }
+    fake_cache = {"hunter_io": (time.time(), fake_status)}
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        result = technique_health("hunter_email_search")
+    assert result is not None
+    assert result["healthy"] is False
+    assert result["requires_key"] == "HUNTER_API_KEY"
+
+
+def test_is_unhealthy_true_when_requires_key():
+    fake_status = {
+        "healthy": False,
+        "error": "HUNTER_API_KEY not set",
+        "requires_key": "HUNTER_API_KEY",
+        "setup_url": None,
+        "setup_instructions": None,
+    }
+    fake_cache = {"hunter_io": (time.time(), fake_status)}
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        assert is_unhealthy("hunter_email_search") is True
+
+
+def test_is_unhealthy_false_when_cache_empty():
+    """Cache miss → not unhealthy (best-effort, don't over-suppress)."""
+    with patch("app.routers.v3.pipelines._health_cache", {}):
+        assert is_unhealthy("hunter_email_search") is False
+
+
+def test_missing_key_returns_key_name():
+    fake_status = {
+        "healthy": False,
+        "error": "HUNTER_API_KEY not set",
+        "requires_key": "HUNTER_API_KEY",
+        "setup_url": None,
+        "setup_instructions": None,
+    }
+    fake_cache = {"hunter_io": (time.time(), fake_status)}
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        assert missing_key("hunter_email_search") == "HUNTER_API_KEY"
+
+
+def test_missing_key_returns_none_when_healthy():
+    fake_status = {
+        "healthy": True,
+        "error": None,
+        "requires_key": None,
+        "setup_url": None,
+        "setup_instructions": None,
+    }
+    fake_cache = {"hunter_io": (time.time(), fake_status)}
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        assert missing_key("hunter_email_search") is None
+
+
+def test_technique_health_stale_cache_returns_none():
+    """A stale cache entry (beyond TTL) should be treated as unknown → None."""
+    fake_status = {
+        "healthy": False,
+        "error": "key missing",
+        "requires_key": "HUNTER_API_KEY",
+        "setup_url": None,
+        "setup_instructions": None,
+    }
+    # timestamp far in the past (3600s old)
+    stale_time = time.time() - 3600
+    fake_cache = {"hunter_io": (stale_time, fake_status)}
+    with patch("app.routers.v3.pipelines._health_cache", fake_cache):
+        result = technique_health("hunter_email_search")
+    assert result is None
+
+
+def test_is_unhealthy_apify_listings_search_cache_miss():
+    """apify_listings_search maps to apify_actor; cache miss → not unhealthy."""
+    with patch("app.routers.v3.pipelines._health_cache", {}):
+        assert is_unhealthy("apify_listings_search") is False


### PR DESCRIPTION
## Summary
- Add `app/pipeline/runners/tool_health.py`: sync best-effort health lookup via the cached node health from `app.routers.v3.pipelines._health_cache`. Maps `technique_id → node_type` via `_tool_name_to_node` (strip `run_` prefix + explicit overrides for `apify_actor_run → apify_actor`, `get_past_research → None`, etc.). Cache miss / stale cache treated as healthy — never over-suppress.
- Modify `scoped_brain._build_scoped_prompt`: partition `tactic.produces` into `healthy_prods` / `unhealthy_prods`; list healthy tools first (unchanged behaviour); annotate unhealthy with `⚠ UNAVAILABLE (needs <KEY>)` + prefer-healthy instruction. Still lists all tools so `required_techniques` remain callable even when unhealthy.
- Update `real_estate_leads.py` gather briefing: explicit STEP 1 (listings first, capture address+price+URL before enrichment) + STEP 2 (contact enrichment). IMPORTANT note: property list is ALWAYS the primary output even when API keys not configured.
- Update `real_estate_leads.py` synthesize briefing: CRITICAL instruction to always return full property table; mark missing contact fields as `'not found (or tool unavailable)'`; data-gaps section.
- 19 new unit tests covering: technique→node mapping, cache-miss → healthy, stale cache → healthy, requires_key → unhealthy, healthy tools listed before unhealthy in prompt, ⚠ annotation, prefer-healthy instruction, cache-miss treated as healthy in prompt.

## Test plan
- [x] 13 unit tests for `tool_health`: `tests/pipeline/runners/test_tool_health.py` — all pass
- [x] 6 unit tests for health-aware scoped_brain prompt: `tests/pipeline/runners/test_scoped_brain_health_prompt.py` — all pass
- [x] Catalog audit: `tests/pipeline/test_all_strategies.py` — 8 passed
- [x] Legacy-phase lint: 38 phase-related tests pass
- [x] Full suite: **1732 passed, 0 failed, 3 skipped** (baseline 1713 + 19 new)
- [x] Ruff: 10 errors (all pre-existing baseline — zero new errors)
- [ ] Live verification: start a real-estate leads run — observe `apify_listings_search` called first; unhealthy enrichment tools annotated `⚠` in brain prompt; property list returned even when enrichment is thin (API keys not configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)