### PR TITLE
feat(ui): admin action-items for unhealthy / needs-key tools

### DIFF
--- a/frontend/src/components/settings/AdminActionItems.test.tsx
+++ b/frontend/src/components/settings/AdminActionItems.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before importing component under test
+// ---------------------------------------------------------------------------
+
+const mockGetNodeHealth = vi.fn()
+
+vi.mock('../../api/v3', () => ({
+  getNodeHealth: () => mockGetNodeHealth(),
+}))
+
+// sessionStore mock — we control isAdmin per test via `mockIsAdmin`
+let mockIsAdmin = true
+
+vi.mock('../../stores/sessionStore', () => ({
+  useSessionStore: (selector: (s: { isAdmin: boolean }) => unknown) =>
+    selector({ isAdmin: mockIsAdmin }),
+}))
+
+import AdminActionItems from './AdminActionItems'
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+const UNHEALTHY_NODE = {
+  node_type: 'apify_zillow',
+  display_name: 'Apify Zillow',
+  healthy: false,
+  error: 'Missing API key',
+  requires_key: 'APIFY_API_TOKEN',
+  setup_url: 'https://apify.com/signup',
+  setup_instructions: 'Sign up at Apify and copy your token from Account > Integrations.',
+}
+
+const HEALTHY_NODE = {
+  node_type: 'google_search',
+  display_name: 'Google Search',
+  healthy: true,
+  error: null,
+  requires_key: null,
+  setup_url: null,
+  setup_instructions: null,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function wrap(ui: React.ReactNode) {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsAdmin = true
+})
+
+describe('AdminActionItems', () => {
+  it('shows the unhealthy node as an action item', async () => {
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE, HEALTHY_NODE])
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('admin-action-items')).toBeInTheDocument(),
+    )
+
+    // Action item for the unhealthy node should appear
+    expect(screen.getByTestId('action-item-apify_zillow')).toBeInTheDocument()
+    expect(screen.getByText('Apify Zillow')).toBeInTheDocument()
+  })
+
+  it('shows requires_key on the action item', async () => {
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE, HEALTHY_NODE])
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('action-item-requires-key-apify_zillow')).toBeInTheDocument(),
+    )
+
+    expect(screen.getByTestId('action-item-requires-key-apify_zillow').textContent).toContain(
+      'APIFY_API_TOKEN',
+    )
+  })
+
+  it('shows the setup_url link for the unhealthy node', async () => {
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE, HEALTHY_NODE])
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('action-item-setup-url-apify_zillow')).toBeInTheDocument(),
+    )
+
+    const link = screen.getByTestId('action-item-setup-url-apify_zillow') as HTMLAnchorElement
+    expect(link.href).toBe('https://apify.com/signup')
+    expect(link.target).toBe('_blank')
+  })
+
+  it('does NOT show the healthy node as an action item', async () => {
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE, HEALTHY_NODE])
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('admin-action-items')).toBeInTheDocument(),
+    )
+
+    expect(screen.queryByTestId('action-item-google_search')).not.toBeInTheDocument()
+  })
+
+  it('shows "All tools healthy" empty state when no action items', async () => {
+    mockGetNodeHealth.mockResolvedValue([HEALTHY_NODE])
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('all-healthy-state')).toBeInTheDocument(),
+    )
+
+    expect(screen.getByText(/All tools healthy/)).toBeInTheDocument()
+  })
+
+  it('shows action-items badge count when items exist', async () => {
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE, HEALTHY_NODE])
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('action-items-badge')).toBeInTheDocument(),
+    )
+
+    expect(screen.getByTestId('action-items-badge').textContent).toBe('1')
+  })
+
+  it('renders nothing for non-admin users', () => {
+    mockIsAdmin = false
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE])
+
+    const { container } = wrap(<AdminActionItems onNavigateToCoreSettings={vi.fn()} />)
+
+    // Component returns null for non-admin
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('calls onNavigateToCoreSettings when Configure button is clicked', async () => {
+    mockGetNodeHealth.mockResolvedValue([UNHEALTHY_NODE])
+    const onNavigate = vi.fn()
+
+    wrap(<AdminActionItems onNavigateToCoreSettings={onNavigate} />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('action-item-configure-apify_zillow')).toBeInTheDocument(),
+    )
+
+    screen.getByTestId('action-item-configure-apify_zillow').click()
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/settings/AdminActionItems.tsx
+++ b/frontend/src/components/settings/AdminActionItems.tsx
@@ -1,0 +1,225 @@
+import { useQuery } from '@tanstack/react-query'
+import { getNodeHealth, NodeHealthOut } from '../../api/v3'
+import { useSessionStore } from '../../stores/sessionStore'
+
+/**
+ * Admin-only "Action needed" panel.
+ * Surfaces every tool/node that is unhealthy OR requires an API key.
+ * Links into the existing "Core Settings" tab for key configuration.
+ */
+
+interface AdminActionItemsProps {
+  /** Called when the user clicks "Configure" on an item — used to navigate to Core Settings. */
+  onNavigateToCoreSettings: () => void
+}
+
+export default function AdminActionItems({ onNavigateToCoreSettings }: AdminActionItemsProps) {
+  const isAdmin = useSessionStore(s => s.isAdmin)
+
+  const { data: nodes = [], isLoading, isError, refetch } = useQuery({
+    queryKey: ['nodeHealth'],
+    queryFn: getNodeHealth,
+    enabled: isAdmin,
+  })
+
+  if (!isAdmin) return null
+
+  if (isLoading) {
+    return (
+      <div
+        className="rounded p-3"
+        style={{ background: 'var(--panel)', border: '1px solid var(--border)' }}
+      >
+        <p className="text-xs" style={{ color: 'var(--muted)' }}>Checking tool health…</p>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div
+        className="rounded p-3 flex flex-col gap-2"
+        style={{ background: 'var(--panel)', border: '1px solid var(--border)' }}
+      >
+        <p className="text-xs" style={{ color: '#f87171' }}>Failed to load tool health status</p>
+        <button
+          onClick={() => refetch()}
+          className="px-3 py-1 rounded text-xs w-fit"
+          style={{
+            background: 'var(--panel)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            cursor: 'pointer',
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  const actionItems: NodeHealthOut[] = nodes.filter(n => !n.healthy || n.requires_key)
+
+  return (
+    <div
+      data-testid="admin-action-items"
+      className="rounded flex flex-col gap-3 p-3"
+      style={{
+        background: 'var(--panel)',
+        border: actionItems.length > 0 ? '1px solid #ef444433' : '1px solid var(--border)',
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold" style={{ color: 'var(--text)' }}>
+            Action needed
+          </span>
+          {actionItems.length > 0 && (
+            <span
+              className="text-[10px] font-semibold px-2 py-0.5 rounded"
+              data-testid="action-items-badge"
+              style={{ background: '#ef444422', color: '#f87171', border: '1px solid #ef444433' }}
+            >
+              {actionItems.length}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={() => refetch()}
+          className="text-[10px] px-2 py-1 rounded"
+          style={{
+            background: 'transparent',
+            color: 'var(--muted)',
+            border: '1px solid var(--border)',
+            cursor: 'pointer',
+          }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {/* Empty state */}
+      {actionItems.length === 0 && (
+        <div className="flex items-center gap-2" data-testid="all-healthy-state">
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: '#4ade80',
+              flexShrink: 0,
+              display: 'inline-block',
+            }}
+          />
+          <span className="text-xs" style={{ color: '#4ade80' }}>
+            All tools healthy — no action required
+          </span>
+        </div>
+      )}
+
+      {/* Action item list */}
+      {actionItems.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {actionItems.map(node => (
+            <div
+              key={node.node_type}
+              data-testid={`action-item-${node.node_type}`}
+              className="rounded p-3 flex flex-col gap-2"
+              style={{
+                background: 'var(--bg, #0f0f0f)',
+                border: '1px solid #ef444433',
+              }}
+            >
+              {/* Title row */}
+              <div className="flex items-center gap-2">
+                <span
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    background: '#f87171',
+                    flexShrink: 0,
+                    display: 'inline-block',
+                  }}
+                />
+                <span className="flex-1 text-xs font-medium" style={{ color: 'var(--text)' }}>
+                  {node.display_name}
+                </span>
+                {!node.healthy && (
+                  <span
+                    className="text-[10px] px-2 py-0.5 rounded"
+                    style={{ background: '#ef444422', color: '#f87171', border: '1px solid #ef444433' }}
+                  >
+                    Unhealthy
+                  </span>
+                )}
+              </div>
+
+              {/* Error / requires_key message */}
+              {node.error && (
+                <p
+                  className="text-[11px]"
+                  data-testid={`action-item-error-${node.node_type}`}
+                  style={{ color: '#f87171' }}
+                >
+                  {node.error}
+                </p>
+              )}
+
+              {node.requires_key && (
+                <p
+                  className="text-[11px]"
+                  data-testid={`action-item-requires-key-${node.node_type}`}
+                  style={{ color: 'var(--subtext)' }}
+                >
+                  Requires API key: <code style={{ color: 'var(--text)' }}>{node.requires_key}</code>
+                </p>
+              )}
+
+              {/* Setup instructions */}
+              {node.setup_instructions && (
+                <p
+                  className="text-[11px]"
+                  style={{ color: 'var(--subtext)', lineHeight: 1.5, whiteSpace: 'pre-line' }}
+                >
+                  {node.setup_instructions}
+                </p>
+              )}
+
+              {/* Action links */}
+              <div className="flex items-center gap-3 flex-wrap">
+                {node.setup_url && !node.setup_url.startsWith('/') && (
+                  <a
+                    href={node.setup_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px]"
+                    data-testid={`action-item-setup-url-${node.node_type}`}
+                    style={{ color: 'var(--accent)' }}
+                  >
+                    Get API key →
+                  </a>
+                )}
+
+                <button
+                  onClick={onNavigateToCoreSettings}
+                  className="text-[11px] px-3 py-1 rounded"
+                  data-testid={`action-item-configure-${node.node_type}`}
+                  style={{
+                    background: 'var(--panel)',
+                    color: 'var(--text)',
+                    border: '1px solid var(--border)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  Configure in Core Settings
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form'
 import IconRail from '../components/layout/IconRail'
 import { useSessionStore } from '../stores/sessionStore'
 import AccountSection from '../components/settings/AccountSection'
+import AdminActionItems from '../components/settings/AdminActionItems'
 import { api } from '../api/client'
 
 const CORE_FIELDS = [
@@ -665,8 +666,8 @@ export default function Settings() {
   const role = useSessionStore(s => s.role)
   const canSeeDefaultMode = isAdmin || role === 'admin'
   const canSeeVisibility = isAdmin || role === 'admin'
-  const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health' | 'account' | 'default-mode' | 'visibility'>(
-    isAdmin ? 'core' : 'account',
+  const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health' | 'account' | 'default-mode' | 'visibility' | 'action-items'>(
+    isAdmin ? 'action-items' : 'account',
   )
 
   return (
@@ -716,6 +717,18 @@ export default function Settings() {
           {isAdmin && (
             <>
               <div className="text-[10px] font-semibold mb-2 mt-3 px-1" style={{ color: 'var(--muted)' }}>SYSTEM</div>
+              <button
+                onClick={() => setSection('action-items')}
+                className="w-full text-left px-2 py-1 rounded text-xs mb-1"
+                data-testid="settings-nav-action-items"
+                style={{
+                  background: section === 'action-items' ? 'var(--panel2)' : 'transparent',
+                  color: section === 'action-items' ? 'var(--accent)' : 'var(--text)',
+                  border: 'none', cursor: 'pointer',
+                }}
+              >
+                Action Items
+              </button>
               <button
                 onClick={() => setSection('core')}
                 className="w-full text-left px-2 py-1 rounded text-xs mb-1"
@@ -782,9 +795,13 @@ export default function Settings() {
               : section === 'node-health' ? 'Node Health'
               : section === 'default-mode' ? 'Default Mode'
               : section === 'visibility' ? 'Modes & Templates'
+              : section === 'action-items' ? 'Action Items'
               : 'Plugin Settings'}
           </h2>
           {section === 'account' && <AccountSection />}
+          {isAdmin && section === 'action-items' && (
+            <AdminActionItems onNavigateToCoreSettings={() => setSection('core')} />
+          )}
           {isAdmin && section === 'core' && <CoreSettingsForm />}
           {isAdmin && section === 'plugins' && <PluginSettingsForm />}
           {section === 'agent' && <AgentSettingsForm />}


### PR DESCRIPTION
## Summary

- Adds `AdminActionItems` component (`frontend/src/components/settings/AdminActionItems.tsx`) — admin-only panel that lists every tool where `healthy === false` OR `requires_key` is set
- Shows per-item: `display_name`, `error`, `requires_key`, `setup_instructions`, external `setup_url` link (opens in new tab), and a **"Configure in Core Settings"** button that navigates to the existing key-config UI
- Shows "All tools healthy — no action required" empty state when all nodes are green
- Wires into `Settings.tsx`: new **"Action Items"** nav entry in the SYSTEM sidebar group; admins land here by default instead of Core Settings
- Non-admin users: component returns `null` immediately; no API call made (`enabled: isAdmin`)
- Reuses `getNodeHealth` / `NodeHealthOut` from `api/v3.ts` and `useSessionStore` `isAdmin` pattern — no backend changes

## Test plan

- [x] 8 vitest unit tests in `AdminActionItems.test.tsx`
  - unhealthy node appears as action item
  - `requires_key` value rendered
  - `setup_url` link with correct `href` and `target="_blank"`
  - healthy node not shown as action item
  - "All tools healthy" empty state
  - badge count correct
  - non-admin renders nothing
  - Configure button calls `onNavigateToCoreSettings`
- [x] `tsc --noEmit` clean (0 errors)
- [x] Full vitest suite: **20 files / 132 tests — all green**, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)