### PR TITLE
feat(benchmarks): factual-accuracy eval harness with anti-gaming guards (#145)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,221 @@
+# Benchmark Harness — Factual-Accuracy Eval with Anti-Gaming Guards
+
+Repeatable benchmark that measures how well the app's templates, modes,
+strategies, tactics, and techniques surface **established, citable facts** —
+and that **cannot be gamed** by the brain bypassing the registered research
+process.
+
+Related: GitHub issue #145.
+
+---
+
+## Quick Start
+
+```bash
+# Make sure the local stack is running (docker-compose up -d)
+export LOCAL_STACK_URL=http://localhost:8000
+export BENCH_USERNAME=admin
+export BENCH_PASSWORD=admin
+
+# Run all gold-set items
+python -m benchmarks.run_benchmark
+
+# Run specific items only
+python -m benchmarks.run_benchmark --items person-jobs-001 company-kyb-001
+
+# Write a JSON report
+python -m benchmarks.run_benchmark --out-json /tmp/report.json
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOCAL_STACK_URL` | `http://localhost:8000` | Base URL of the running API |
+| `BENCH_USERNAME` | `admin` | Login username |
+| `BENCH_PASSWORD` | `admin` | Login password |
+| `BENCH_TIMEOUT_S` | `300` | Max seconds to wait per run |
+| `BENCH_POLL_INTERVAL_S` | `5` | Poll interval for run status |
+
+---
+
+## API Keys and Live Data
+
+Gold-set items with `must_be_live: true` expected facts require live tool
+calls, which in turn require configured search/enrichment API keys:
+
+- `web_search` — requires Bing / Serper / Brave API key
+- `image_search` — requires image search API key
+- `opencorporates_owner` — requires OpenCorporates API key
+- `hunter_email_search` — requires Hunter.io API key
+- `apollo_contact` — requires Apollo.io API key
+- `pipl_people` — requires Pipl API key
+
+Without these keys, items needing live data will correctly **fail** (gaming
+guard `training_only` fires). This is expected behaviour — the benchmark
+surfaces key-configuration gaps (see also issues #131, key-vault work).
+
+Items with `must_be_live: false` (historically-stable facts) may pass even
+without live search keys, as long as prior_research or training_knowledge
+covers the claim and the `training_only` guard does not fire.
+
+---
+
+## Gold-set Schema
+
+See `benchmarks/goldset/schema.yaml` for the full annotated schema.
+Each item YAML file is a list:
+
+```yaml
+- id: person-jobs-001          # unique stable id
+  query: "Who is Tim Cook?"    # exact query to POST /v3/preflight
+  template: person             # optional: force strategy id
+  mode: investigation          # optional: force optimization mode
+  domain: person               # person | company | real_estate | due_diligence
+  notes: "Optional rationale"
+  expected_facts:
+    - claim: "Tim Cook is the CEO of Apple Inc"
+      authoritative_source: "https://www.apple.com/leadership/tim-cook/"
+      must_be_live: false      # true = must come from live tool, not cache/training
+```
+
+### Adding Items
+
+1. Create or edit a YAML file under `benchmarks/goldset/` (e.g. `my_items.yaml`).
+2. Each file must be a YAML list (`- id: ...`).
+3. Item `id` must be unique across **all** goldset files.
+4. Provide at least one `expected_fact` with a real `authoritative_source` URL.
+5. Set `must_be_live: true` for claims that require fresh evidence.
+6. Verify schema: `python -m pytest tests/benchmarks/ -v` (no live stack needed).
+
+---
+
+## Anti-Gaming Guards
+
+A correct-looking result reached by any of these vectors scores **zero**.
+The report names the tripped guard per item.
+
+### Guard 1 — `training_only`
+
+**What it detects:** The run produced no real tool calls, or every branch has
+`source_class ∈ {training_knowledge}`. The brain answered purely from its
+training weights without contacting any external tool.
+
+**Why it matters:** Training-data recall is not evidence. The benchmark
+requires live retrieval.
+
+### Guard 2 — `unregistered_tool`
+
+**What it detects:** A `technique_id` appears in the trail branches that is
+NOT in the registered technique catalog
+(`app/pipeline/catalogs/registries/techniques/`).
+
+**Why it matters:** Shell-outs, ad-hoc tool calls, or un-cataloged techniques
+bypass the registered research process and its auditability guarantees.
+
+### Guard 3 — `skipped_phases`
+
+**What it detects:** The resolved strategy declared phases (e.g.
+`extract → gather → disconfirm → synthesize`) but not all of them appear in
+the trail's `phases` list.
+
+**Why it matters:** Required gate checks (e.g. distinct-candidate-count,
+live-source-per-hypothesis) only run within their phase. Skipping a phase
+skips its gate.
+
+### Guard 4 — `rag_shortcut`
+
+**What it detects:** An `expected_fact` with `must_be_live: true` was
+satisfied, but every contributing finding has
+`source_class ∈ {prior_research}` — i.e. cached prior-run results, not fresh
+live evidence.
+
+**Why it matters:** Prior-research cache may be stale. Live facts must come
+from a fresh tool call.
+
+---
+
+## Scoring
+
+When no guard trips, `score_item` computes:
+
+```
+coverage       = matched_facts / total_expected_facts
+source_quality = mean weight of best source_class across matched facts
+item_score     = coverage × source_quality
+```
+
+Source-class quality weights (higher = better provenance):
+
+| source_class | weight |
+|---|---|
+| `live_official` / `primary_official` | 1.00 |
+| `registry` | 0.95 |
+| `live_search` | 0.75 |
+| `news` | 0.65 |
+| `aggregator` | 0.55 |
+| `social` | 0.45 |
+| `prior_research` | 0.30 |
+| `training_knowledge` | 0.10 |
+
+A fact is "matched" when:
+1. ≥ 60 % of its salient tokens appear in the run's findings text, AND
+2. at least one finding has a non-empty `source_url`.
+
+---
+
+## Output
+
+The driver emits:
+
+1. **Console table** — per-item id, score, coverage, source_quality, guard tripped.
+2. **JSON report** — full per-item results + aggregates by strategy / mode /
+   domain / technique.
+
+Aggregate report shape:
+
+```json
+{
+  "overall": { "mean_score": 0.72, "total_items": 6, "gamed_items": 1, "gamed_pct": 16.7 },
+  "by_strategy": { "person": { "mean_score": 0.80, "n": 2 }, ... },
+  "by_mode": { ... },
+  "by_domain": { ... },
+  "by_technique": { "web_search": { "mean_score": 0.75, "n": 5 }, ... }
+}
+```
+
+---
+
+## Unit Tests (no live stack required)
+
+```bash
+.venv/bin/pytest tests/benchmarks/ -v
+```
+
+Tests cover:
+- Each of the 4 anti-gaming guards zeroing the score with the guard named.
+- A clean run scoring proportionally to coverage and source quality.
+- Partial coverage scoring proportionally.
+- Source-quality weighting.
+- Gold-set YAML parsing and schema validation.
+
+---
+
+## File Structure
+
+```
+benchmarks/
+  __init__.py
+  run_benchmark.py   — driver: preflight → confirm → poll → trail → score
+  score.py           — pure scoring + anti-gaming logic (unit-testable)
+  README.md          — this file
+  goldset/
+    schema.yaml      — annotated field schema
+    items.yaml       — initial curated gold-set (6 items)
+
+tests/benchmarks/
+  __init__.py
+  test_score.py      — unit tests for score.py (no live runs)
+```

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+# benchmarks package — factual-accuracy eval harness

--- a/benchmarks/goldset/items.yaml
+++ b/benchmarks/goldset/items.yaml
@@ -1,0 +1,90 @@
+# Initial curated gold-set — benchmark harness v1
+# Domain coverage: person, company, real_estate, due_diligence
+# All facts are publicly verifiable via the listed authoritative_source URLs.
+
+- id: person-jobs-001
+  query: "Who is Tim Cook and what company does he lead?"
+  mode: investigation
+  domain: person
+  notes: >
+    Well-known tech executive. Apple Inc CEO since August 2011.
+    Stable biographical fact with multiple authoritative sources.
+  expected_facts:
+    - claim: "Tim Cook is the CEO of Apple Inc"
+      authoritative_source: "https://www.apple.com/leadership/tim-cook/"
+      must_be_live: false
+    - claim: "Tim Cook succeeded Steve Jobs as Apple CEO"
+      authoritative_source: "https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0000320193&type=DEF+14A&dateb=&owner=include&count=10"
+      must_be_live: false
+
+- id: company-kyb-001
+  query: "Tell me about Anthropic, the AI safety company — who founded it and when?"
+  mode: investigation
+  domain: company
+  notes: >
+    Anthropic is a well-known AI safety company founded in 2021 by former OpenAI
+    researchers. Founding facts are stable and well-documented.
+  expected_facts:
+    - claim: "Anthropic was founded by Dario Amodei and Daniela Amodei"
+      authoritative_source: "https://www.anthropic.com/about"
+      must_be_live: false
+    - claim: "Anthropic was founded in 2021"
+      authoritative_source: "https://www.crunchbase.com/organization/anthropic"
+      must_be_live: false
+
+- id: company-kyb-002
+  query: "What is OpenAI and who are its key founders?"
+  mode: investigation
+  domain: company
+  notes: >
+    OpenAI founded in 2015 by Sam Altman, Elon Musk, Greg Brockman, and others.
+    Founding history is well documented across many authoritative sources.
+  expected_facts:
+    - claim: "OpenAI was co-founded by Sam Altman"
+      authoritative_source: "https://openai.com/about"
+      must_be_live: false
+    - claim: "OpenAI was founded in 2015"
+      authoritative_source: "https://openai.com/about"
+      must_be_live: false
+
+- id: real-estate-owner-001
+  query: "Who owns One Microsoft Way, Redmond WA 98052?"
+  template: real_estate
+  mode: data_retrieval
+  domain: real_estate
+  notes: >
+    Microsoft headquarters address. The campus owner is Microsoft Corporation.
+    Property ownership records are available via King County Assessor.
+  expected_facts:
+    - claim: "One Microsoft Way Redmond WA is the headquarters of Microsoft Corporation"
+      authoritative_source: "https://info.kingcounty.gov/assessor/esales/default.aspx"
+      must_be_live: true
+
+- id: person-exec-001
+  query: "Who is Satya Nadella and what is his role at Microsoft?"
+  mode: investigation
+  domain: person
+  notes: >
+    Satya Nadella became Microsoft CEO in 2014. Stable leadership fact.
+  expected_facts:
+    - claim: "Satya Nadella is the CEO of Microsoft"
+      authoritative_source: "https://www.microsoft.com/en-us/about/leadership"
+      must_be_live: false
+    - claim: "Satya Nadella became CEO of Microsoft in 2014"
+      authoritative_source: "https://news.microsoft.com/2014/02/04/satya-nadella-named-microsoft-ceo/"
+      must_be_live: false
+
+- id: due-diligence-001
+  query: "What is Stripe's corporate registration status and who are its founders?"
+  mode: investigation
+  domain: due_diligence
+  notes: >
+    Stripe Inc founded by Patrick Collison and John Collison in 2010.
+    Corporate registration verifiable via Delaware Division of Corporations.
+  expected_facts:
+    - claim: "Stripe was founded by Patrick Collison and John Collison"
+      authoritative_source: "https://stripe.com/about"
+      must_be_live: false
+    - claim: "Stripe was founded in 2010"
+      authoritative_source: "https://www.crunchbase.com/organization/stripe"
+      must_be_live: false

--- a/benchmarks/goldset/schema.yaml
+++ b/benchmarks/goldset/schema.yaml
@@ -1,0 +1,42 @@
+# Gold-set item schema — benchmark harness v1
+# Every file under benchmarks/goldset/ (except this schema.yaml) is a YAML
+# list of items conforming to this schema.
+#
+# REQUIRED FIELDS
+# ---------------
+# id          : string — unique stable identifier across the entire gold-set.
+#               Convention: <domain>-<short-name>-<NNN>, e.g. person-jobs-001
+# query       : string — the exact user query text submitted to POST /v3/preflight
+# expected_facts: list — one or more facts that MUST be surfaced by a clean run
+#   Each expected_fact has:
+#     claim             : string — the specific factual assertion to check
+#     authoritative_source: string URL — where this fact can be verified independently
+#     must_be_live      : bool — true = claim must come from a live tool call
+#                                (source_class NOT in {prior_research, training_knowledge})
+# domain      : string — one of: person | company | real_estate | due_diligence
+#
+# OPTIONAL FIELDS
+# ---------------
+# template    : string — force a specific strategy id (e.g. real_estate_leads)
+# mode        : string — force a specific optimization mode (e.g. investigation)
+# notes       : string — free-text rationale for the item
+#
+# HOW TO ADD ITEMS
+# ----------------
+# 1. Create a new YAML file under benchmarks/goldset/ (e.g. my_items.yaml).
+#    The filename doesn't matter — all *.yaml files are loaded.
+# 2. The file must be a YAML list: start with `- id: ...`
+# 3. Pick a unique id (no duplicates across files — the loader will error).
+# 4. Provide at least one expected_fact with a real authoritative_source URL.
+# 5. Set must_be_live: true for any claim that requires fresh evidence (e.g.
+#    current owner, live listing price). Facts that are historically fixed
+#    (e.g. company founding date) may use must_be_live: false.
+# 6. Run `python -m pytest tests/benchmarks/test_score.py` to validate schema
+#    parsing without a live stack.
+#
+# ITEM QUALITY GUIDELINES
+# -----------------------
+# - Use real, publicly verifiable facts with stable authoritative sources.
+# - Avoid facts that change frequently (stock prices, real-time rankings).
+# - Prefer facts that a search engine can find in <3 hops.
+# - Each item should exercise a distinct pipeline path (strategy/tactic combo).

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -1,0 +1,440 @@
+"""Benchmark driver — runs the real app pipeline against the curated gold-set.
+
+Usage
+-----
+    # Basic run against the local stack
+    LOCAL_STACK_URL=http://localhost:8000 python -m benchmarks.run_benchmark
+
+    # Limit to specific item ids
+    LOCAL_STACK_URL=http://localhost:8000 python -m benchmarks.run_benchmark \
+        --items person-jobs-001 company-kyb-001
+
+    # Write JSON report to a file
+    LOCAL_STACK_URL=http://localhost:8000 python -m benchmarks.run_benchmark \
+        --out-json /tmp/benchmark_report.json
+
+Environment variables
+---------------------
+LOCAL_STACK_URL   Base URL for the API (default: http://localhost:8000)
+BENCH_USERNAME    Username for login (default: admin)
+BENCH_PASSWORD    Password for login (default: admin)
+BENCH_TIMEOUT_S   Max seconds to wait for each run (default: 300)
+BENCH_POLL_INTERVAL_S  Poll interval in seconds (default: 5)
+
+Design notes
+------------
+- No mocking — exercises the real preflight → confirm → poll → trail path.
+- Reads ``research_trails`` row via GET /v3/pipelines/runs/{id}.
+- Strategy phases are extracted from the preflight ``suggested_strategy`` and
+  used to feed the ``skipped_phases`` anti-gaming guard.
+- Per-item run metadata (strategy, mode, techniques used) is recorded and
+  passed to ``aggregate_scores`` for component-level reporting.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+import yaml
+
+# Ensure repo root is on sys.path so we can import from app.*
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from benchmarks.score import (  # noqa: E402
+    aggregate_scores,
+    load_registered_technique_ids,
+    render_summary_table,
+    score_item,
+)
+
+log = logging.getLogger("benchmarks.run")
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+
+BASE_URL: str = os.getenv("LOCAL_STACK_URL", "http://localhost:8000").rstrip("/")
+USERNAME: str = os.getenv("BENCH_USERNAME", "admin")
+PASSWORD: str = os.getenv("BENCH_PASSWORD", "admin")
+TIMEOUT_S: int = int(os.getenv("BENCH_TIMEOUT_S", "300"))
+POLL_INTERVAL_S: float = float(os.getenv("BENCH_POLL_INTERVAL_S", "5"))
+
+_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"succeeded", "failed", "cancelled", "error", "ask_user"}
+)
+
+# ---------------------------------------------------------------------------
+# Gold-set loader
+# ---------------------------------------------------------------------------
+
+GOLDSET_DIR = Path(__file__).resolve().parent / "goldset"
+
+
+def load_goldset(item_ids: list[str] | None = None) -> list[dict]:
+    """Load all gold-set items from YAML files in benchmarks/goldset/.
+
+    Skips schema.yaml. Validates that each item has required fields.
+    Optionally filters to *item_ids*.
+    """
+    items: list[dict] = []
+    seen_ids: set[str] = set()
+
+    for yaml_file in sorted(GOLDSET_DIR.glob("*.yaml")):
+        if yaml_file.name == "schema.yaml":
+            continue
+        raw = yaml.safe_load(yaml_file.read_text())
+        if not isinstance(raw, list):
+            log.warning("Skipping %s — expected a YAML list", yaml_file.name)
+            continue
+        for item in raw:
+            _validate_item(item, yaml_file.name)
+            iid = item["id"]
+            if iid in seen_ids:
+                raise ValueError(f"Duplicate gold-set id {iid!r} in {yaml_file.name}")
+            seen_ids.add(iid)
+            items.append(item)
+
+    if item_ids:
+        items = [it for it in items if it["id"] in set(item_ids)]
+
+    return items
+
+
+def _validate_item(item: dict, filename: str) -> None:
+    required = ("id", "query", "expected_facts", "domain")
+    for field in required:
+        if field not in item:
+            raise ValueError(
+                f"Gold-set item in {filename} missing required field {field!r}: {item}"
+            )
+    if not isinstance(item["expected_facts"], list) or not item["expected_facts"]:
+        raise ValueError(
+            f"Gold-set item {item.get('id')!r} in {filename}: "
+            f"expected_facts must be a non-empty list"
+        )
+    for ef in item["expected_facts"]:
+        for ef_field in ("claim", "authoritative_source", "must_be_live"):
+            if ef_field not in ef:
+                raise ValueError(
+                    f"Gold-set item {item.get('id')!r}: expected_fact missing {ef_field!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# HTTP session helpers
+# ---------------------------------------------------------------------------
+
+def login(session: requests.Session) -> dict:
+    """Login and return the auth token payload."""
+    resp = session.post(
+        f"{BASE_URL}/v3/auth/login",
+        json={"username": USERNAME, "password": PASSWORD},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    token = data.get("access_token") or data.get("token") or ""
+    if not token:
+        raise RuntimeError(f"Login did not return a token: {data}")
+    session.headers["Authorization"] = f"Bearer {token}"
+    log.info("Logged in as %s", USERNAME)
+    return data
+
+
+def post_preflight(session: requests.Session, item: dict) -> dict:
+    """POST /v3/preflight and return the response body."""
+    body: dict[str, Any] = {"query": item["query"]}
+    if item.get("mode"):
+        body["mode"] = item["mode"]
+    if item.get("template"):
+        body["strategy"] = item["template"]
+
+    resp = session.post(f"{BASE_URL}/v3/preflight", json=body, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def post_confirm(
+    session: requests.Session,
+    item: dict,
+    preflight_out: dict,
+) -> dict:
+    """POST /v3/preflight/confirm with start_run=True."""
+    envelope = preflight_out["envelope"]
+    confirm_body = {
+        "query": item["query"],
+        "strategy_id": preflight_out["suggested_strategy"],
+        "envelope": {
+            "capability": envelope.get("capability", "general"),
+            "hypothesis_count": envelope.get("hypothesis_count", "competing"),
+            "depth": envelope.get("depth", "search"),
+            "speed": envelope.get("speed", "normal"),
+            "resource": envelope.get("resource", "medium"),
+        },
+        "start_run": True,
+    }
+    resp = session.post(f"{BASE_URL}/v3/preflight/confirm", json=confirm_body, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def poll_run(session: requests.Session, run_id: str) -> dict:
+    """Poll GET /v3/pipelines/runs/{run_id} until terminal or timeout."""
+    deadline = time.time() + TIMEOUT_S
+    while time.time() < deadline:
+        resp = session.get(f"{BASE_URL}/v3/pipelines/runs/{run_id}", timeout=30)
+        if resp.status_code == 404:
+            log.debug("Run %s not found yet — retrying", run_id)
+            time.sleep(POLL_INTERVAL_S)
+            continue
+        resp.raise_for_status()
+        data = resp.json()
+        status = data.get("status", "")
+        log.info("  run %s status=%s", run_id[:8], status)
+        if status in _TERMINAL_STATUSES:
+            return data
+        time.sleep(POLL_INTERVAL_S)
+
+    raise TimeoutError(
+        f"Run {run_id} did not reach terminal status within {TIMEOUT_S}s"
+    )
+
+
+def fetch_trail(session: requests.Session, run_id: str) -> tuple[dict, list[dict]]:
+    """Return (trail_dict, findings_list) from the research_trails row for run_id."""
+    resp = session.get(f"{BASE_URL}/v3/pipelines/runs/{run_id}", timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    research = data.get("research") or {}
+    trail: dict = research.get("trail") or {}
+    if isinstance(trail, str):
+        trail = json.loads(trail)
+    findings: list[dict] = research.get("findings") or []
+    if isinstance(findings, str):
+        findings = json.loads(findings)
+    return trail, findings
+
+
+# ---------------------------------------------------------------------------
+# Strategy phase extractor
+# ---------------------------------------------------------------------------
+
+def _get_strategy_phases(strategy_id: str) -> list[str]:
+    """Return the declared phase ids for a strategy from the catalog."""
+    try:
+        from pathlib import Path as _Path
+        from app.pipeline.catalogs.loader import load_catalog  # type: ignore[import]
+
+        strategies_dir = _REPO_ROOT / "app" / "pipeline" / "catalogs" / "registries" / "strategies"
+        catalog = load_catalog("strategy", strategies_dir)
+        strategy = catalog.get(strategy_id)
+        if strategy:
+            return [p.id for p in strategy.phases]
+    except Exception as exc:
+        log.warning("Could not load strategy catalog for %s: %s", strategy_id, exc)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Per-item benchmark run
+# ---------------------------------------------------------------------------
+
+def run_item(
+    session: requests.Session,
+    item: dict,
+    registered_ids: frozenset[str],
+) -> tuple[dict, dict]:
+    """Drive the real pipeline for one gold-set item.
+
+    Returns (score_result, run_metadata).
+    """
+    item_id = item["id"]
+    log.info("[%s] starting preflight", item_id)
+
+    # 1. Preflight
+    try:
+        preflight_out = post_preflight(session, item)
+    except requests.HTTPError as exc:
+        log.error("[%s] preflight failed: %s", item_id, exc)
+        return _error_result(item_id, "preflight_http_error"), {}
+
+    strategy_id: str = preflight_out.get("suggested_strategy", "")
+    mode: str = preflight_out.get("suggested_mode", "")
+    strategy_phases = _get_strategy_phases(strategy_id)
+
+    log.info("[%s] strategy=%s mode=%s", item_id, strategy_id, mode)
+
+    # 2. Confirm + launch run
+    try:
+        confirm_out = post_confirm(session, item, preflight_out)
+    except requests.HTTPError as exc:
+        log.error("[%s] confirm failed: %s", item_id, exc)
+        return _error_result(item_id, "confirm_http_error"), {}
+
+    run_id: str = confirm_out.get("run_id", "")
+    log.info("[%s] run_id=%s", item_id, run_id)
+
+    # 3. Poll to terminal
+    try:
+        run_data = poll_run(session, run_id)
+    except (TimeoutError, requests.HTTPError) as exc:
+        log.error("[%s] polling failed: %s", item_id, exc)
+        return _error_result(item_id, "poll_error"), {}
+
+    final_status = run_data.get("status", "unknown")
+    log.info("[%s] run finished status=%s", item_id, final_status)
+
+    # 4. Fetch trail + findings
+    try:
+        trail, findings = fetch_trail(session, run_id)
+    except Exception as exc:
+        log.error("[%s] trail fetch failed: %s", item_id, exc)
+        return _error_result(item_id, "trail_fetch_error"), {}
+
+    # Extract technique_ids used (from trail branches)
+    branches: list[dict] = trail.get("branches", [])
+    technique_ids_used = list({b.get("technique_id", "") for b in branches if b.get("technique_id")})
+
+    # 5. Score
+    score_result = score_item(
+        gold_item=item,
+        trail=trail,
+        findings=findings,
+        registered_technique_ids=registered_ids,
+        strategy_phases=strategy_phases,
+    )
+
+    # Per-item metadata for aggregation
+    run_metadata = {
+        "run_id": run_id,
+        "strategy": strategy_id,
+        "mode": mode,
+        "domain": item.get("domain", "unknown"),
+        "template": item.get("template", ""),
+        "technique_ids": technique_ids_used,
+        "phases_ran": trail.get("phases", []),
+        "final_status": final_status,
+        "trail_tool_calls": trail.get("tool_calls", 0),
+    }
+
+    log.info(
+        "[%s] score=%.3f coverage=%.3f source_quality=%.3f guard=%s",
+        item_id,
+        score_result["item_score"],
+        score_result["coverage"],
+        score_result["source_quality"],
+        score_result.get("tripped_guard") or "-",
+    )
+
+    return score_result, run_metadata
+
+
+def _error_result(item_id: str, reason: str) -> dict:
+    return {
+        "item_id": item_id,
+        "item_score": 0.0,
+        "coverage": 0.0,
+        "source_quality": 0.0,
+        "gaming_flags": [],
+        "tripped_guard": None,
+        "fact_matches": [],
+        "error": reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the benchmark harness against the local infobroker stack."
+    )
+    parser.add_argument(
+        "--items",
+        nargs="*",
+        metavar="ID",
+        help="Limit run to specific gold-set item ids.",
+    )
+    parser.add_argument(
+        "--out-json",
+        metavar="PATH",
+        help="Write the full JSON report to this path.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s  %(levelname)-7s %(name)s — %(message)s",
+    )
+
+    # Load gold-set
+    items = load_goldset(args.items)
+    if not items:
+        log.error("No gold-set items found (or none matched --items filter).")
+        return 1
+    log.info("Loaded %d gold-set items", len(items))
+
+    # Load registered technique catalog once
+    registered_ids = load_registered_technique_ids()
+    log.info("Registered technique ids: %s", sorted(registered_ids))
+
+    # Login
+    session = requests.Session()
+    session.headers["Content-Type"] = "application/json"
+    try:
+        login(session)
+    except Exception as exc:
+        log.error("Login failed: %s", exc)
+        return 1
+
+    # Run items
+    all_results: list[dict] = []
+    all_metadata: list[dict] = []
+    for item in items:
+        result, metadata = run_item(session, item, registered_ids)
+        all_results.append(result)
+        all_metadata.append(metadata)
+
+    # Aggregate
+    aggregates = aggregate_scores(all_results, all_metadata)
+
+    # Human-readable table
+    table = render_summary_table(all_results, aggregates)
+    print(table)
+
+    # JSON report
+    report = {
+        "item_results": all_results,
+        "run_metadata": all_metadata,
+        "aggregates": aggregates,
+    }
+    if args.out_json:
+        out_path = Path(args.out_json)
+        out_path.write_text(json.dumps(report, indent=2))
+        log.info("JSON report written to %s", out_path)
+    else:
+        print("\nJSON report:")
+        print(json.dumps(report, indent=2))
+
+    # Exit code: 0 if any item scored > 0, else 1
+    any_scored = any(r["item_score"] > 0 for r in all_results)
+    return 0 if any_scored else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/score.py
+++ b/benchmarks/score.py
@@ -1,0 +1,570 @@
+"""Scoring + anti-gaming guards for the benchmark harness.
+
+This module is intentionally PURE — ``score_item`` and all its helpers are
+side-effect-free functions that operate on plain dicts. They can be unit-tested
+without a running stack, a database, or any network access.
+
+Anti-gaming guards (hard-fail → item_score=0)
+----------------------------------------------
+1. TRAINING_ONLY   — no real tool calls OR all branches have
+                     source_class ∈ {training_knowledge}.
+2. UNREGISTERED_TOOL — any technique_id in the trail branches that is not
+                       in the registered technique catalog.
+3. SKIPPED_PHASES  — the resolved strategy's declared phases did not all run
+                     (trail.phases subset vs strategy.phases).
+4. RAG_SHORTCUT    — an expected_fact with must_be_live=True was satisfied
+                     only via source_class == "prior_research".
+
+Scoring (when no guard trips)
+------------------------------
+- Per expected_fact: keyword/normalized-substring match against the run's
+  findings text + a citation check.
+- coverage = matched_facts / total_expected_facts
+- source_quality = weighted average of the best source_class seen across
+  matched facts (live_official/primary_official > live_search > prior_research
+  > training_knowledge).
+- item_score = coverage × source_quality  (both in [0, 1])
+
+Aggregation
+-----------
+``aggregate_scores`` groups per-item results by template / mode / strategy /
+tactic / technique and emits per-group mean scores.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Source-class quality weights
+# ---------------------------------------------------------------------------
+
+#: Quality weight per source_class, used for source_quality calculation.
+#: Higher = better provenance. Unknown classes get 0.1 (penalised, not zeroed).
+SOURCE_CLASS_WEIGHTS: dict[str, float] = {
+    "live_official": 1.0,
+    "primary_official": 1.0,
+    "registry": 0.95,
+    "live_search": 0.75,
+    "news": 0.65,
+    "aggregator": 0.55,
+    "social": 0.45,
+    "prior_research": 0.30,
+    "training_knowledge": 0.10,
+    "unknown": 0.10,
+}
+
+#: Source classes that count as "not live" for the RAG_SHORTCUT guard.
+_NON_LIVE_CLASSES: frozenset[str] = frozenset({"prior_research", "training_knowledge"})
+
+#: Source classes that count as "training only" for the TRAINING_ONLY guard.
+_TRAINING_CLASSES: frozenset[str] = frozenset({"training_knowledge"})
+
+
+# ---------------------------------------------------------------------------
+# Registered technique catalog loader
+# ---------------------------------------------------------------------------
+
+def load_registered_technique_ids(
+    techniques_dir: Path | None = None,
+) -> frozenset[str]:
+    """Return the set of technique ids registered in the catalog.
+
+    Loads from ``app/pipeline/catalogs/registries/techniques/`` relative to
+    the repo root (two levels above this file). Accepts an explicit override
+    path for testing.
+
+    Falls back to an empty frozenset (not a hard error) so callers can decide
+    whether a missing catalog is fatal.
+    """
+    if techniques_dir is None:
+        # Resolve relative to this file: benchmarks/ → repo_root/
+        repo_root = Path(__file__).resolve().parent.parent
+        techniques_dir = (
+            repo_root / "app" / "pipeline" / "catalogs" / "registries" / "techniques"
+        )
+
+    if not techniques_dir.exists():
+        return frozenset()
+
+    try:
+        from app.pipeline.catalogs.loader import load_catalog  # type: ignore[import]
+
+        catalog = load_catalog("technique", techniques_dir)
+        return frozenset(catalog.keys())
+    except Exception:
+        # Fallback: parse TECHNIQUE["id"] from each file without importing app
+        ids: set[str] = set()
+        for path in techniques_dir.glob("*.py"):
+            if path.name.startswith("_"):
+                continue
+            text = path.read_text(errors="ignore")
+            m = re.search(r'"id"\s*:\s*"([^"]+)"', text)
+            if m:
+                ids.add(m.group(1))
+        return frozenset(ids)
+
+
+# ---------------------------------------------------------------------------
+# Text-matching helpers
+# ---------------------------------------------------------------------------
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip accents, collapse whitespace."""
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", text.lower().strip())
+
+
+def _salient_tokens(claim: str) -> list[str]:
+    """Extract meaningful tokens from a claim string.
+
+    Strips common stop-words so that a claim like "Tim Cook is the CEO of
+    Apple Inc" yields tokens like ["tim", "cook", "ceo", "apple", "inc"].
+    """
+    _STOPWORDS = {
+        "is", "are", "was", "were", "the", "a", "an", "of", "in", "at",
+        "to", "for", "by", "and", "or", "that", "this", "it", "its",
+        "as", "on", "with", "from", "has", "have", "had", "be", "been",
+        "who", "what", "when", "where", "which", "their", "he", "she",
+        "they", "them", "his", "her",
+    }
+    tokens = re.findall(r"[a-z0-9]+", _normalize(claim))
+    salient = [t for t in tokens if t not in _STOPWORDS and len(t) > 1]
+    return salient
+
+
+def _findings_text(findings: list[dict]) -> str:
+    """Concatenate all text-bearing fields from a findings list into one blob."""
+    parts: list[str] = []
+    for f in findings:
+        for field in ("claim", "evidence_summary", "evidence_snippet",
+                      "candidate_name", "summary", "text", "content"):
+            val = f.get(field)
+            if val and isinstance(val, str):
+                parts.append(val)
+    return " ".join(parts)
+
+
+def _claim_matches(claim: str, findings_blob: str) -> bool:
+    """Return True when enough salient tokens of *claim* appear in *findings_blob*.
+
+    Threshold: ≥ 60 % of salient tokens must be present (handles paraphrasing).
+    Minimum threshold: at least 1 token must match.
+    """
+    tokens = _salient_tokens(claim)
+    if not tokens:
+        return False
+    blob = _normalize(findings_blob)
+    matched = sum(1 for t in tokens if t in blob)
+    return matched / len(tokens) >= 0.60
+
+
+def _has_citation(findings: list[dict]) -> bool:
+    """Return True when at least one finding has a non-empty source_url."""
+    return any(
+        bool(f.get("source_url") or f.get("authoritative_source"))
+        for f in findings
+    )
+
+
+def _best_source_class(findings: list[dict]) -> str:
+    """Return the source_class with the highest quality weight across all findings."""
+    best_weight = 0.0
+    best_class = "unknown"
+    for f in findings:
+        sc = f.get("source_class") or "unknown"
+        w = SOURCE_CLASS_WEIGHTS.get(sc, 0.10)
+        if w > best_weight:
+            best_weight = w
+            best_class = sc
+    return best_class
+
+
+# ---------------------------------------------------------------------------
+# Anti-gaming guard helpers
+# ---------------------------------------------------------------------------
+
+def _guard_training_only(trail: dict) -> str | None:
+    """Guard 1 — training_only: no real tool calls or all branches are training-only.
+
+    Returns the guard name if tripped, else None.
+    """
+    tool_calls: int = trail.get("tool_calls", 0)
+    branches: list[dict] = trail.get("branches", [])
+
+    # Explicit tool_calls counter at trail level is the fastest check.
+    if isinstance(tool_calls, int) and tool_calls == 0 and branches:
+        return "training_only"
+
+    # All branches have source_class in the training set.
+    if branches and all(
+        (b.get("source_class") or "training_knowledge") in _TRAINING_CLASSES
+        for b in branches
+    ):
+        return "training_only"
+
+    # No branches at all — nothing was researched.
+    if not branches:
+        return "training_only"
+
+    return None
+
+
+def _guard_unregistered_tools(
+    trail: dict,
+    registered_ids: frozenset[str],
+) -> str | None:
+    """Guard 2 — unregistered_tool: any technique_id not in the catalog.
+
+    Returns the guard name if tripped, else None.
+    Skips the check when registered_ids is empty (catalog unavailable).
+    """
+    if not registered_ids:
+        return None  # Can't check — skip
+
+    branches: list[dict] = trail.get("branches", [])
+    for branch in branches:
+        tid = branch.get("technique_id") or ""
+        if tid and tid not in registered_ids:
+            return "unregistered_tool"
+
+    return None
+
+
+def _guard_skipped_phases(
+    trail: dict,
+    strategy_phases: list[str],
+) -> str | None:
+    """Guard 3 — skipped_phases: a required strategy phase did not run.
+
+    Compares the trail's ``phases`` list against *strategy_phases*.
+    Returns the guard name if any required phase is absent, else None.
+    """
+    if not strategy_phases:
+        return None  # No declared phases to check against
+
+    phases_ran: list[str] = trail.get("phases", [])
+    ran_set = set(phases_ran)
+    for required_phase in strategy_phases:
+        if required_phase not in ran_set:
+            return "skipped_phases"
+
+    return None
+
+
+def _guard_rag_shortcut(
+    expected_facts: list[dict],
+    findings: list[dict],
+    findings_blob: str,
+) -> str | None:
+    """Guard 4 — rag_shortcut: a must_be_live fact matched only via prior_research.
+
+    For each expected_fact with must_be_live=True that DID match the findings,
+    check whether EVERY finding that could supply that match has a non-live
+    source_class. If so, the shortcut guard fires.
+
+    Returns the guard name if tripped, else None.
+    """
+    live_facts = [f for f in expected_facts if f.get("must_be_live")]
+    if not live_facts:
+        return None
+
+    # Build a list of (claim, source_classes_that_matched) from findings.
+    # A finding "contributes" to a claim if its text helps the claim match.
+    for fact in live_facts:
+        claim = fact.get("claim", "")
+        if not _claim_matches(claim, findings_blob):
+            # Fact didn't match at all — skipped_phases or coverage handles this;
+            # not a RAG shortcut.
+            continue
+
+        # The fact DID match. Check whether any contributing finding is live.
+        tokens = _salient_tokens(claim)
+        contributing: list[dict] = []
+        for fd in findings:
+            fd_text = " ".join(
+                str(fd.get(field, ""))
+                for field in ("claim", "evidence_summary", "evidence_snippet",
+                              "candidate_name", "summary", "text", "content")
+            )
+            fd_tokens = set(re.findall(r"[a-z0-9]+", _normalize(fd_text)))
+            overlap = sum(1 for t in tokens if t in fd_tokens)
+            if overlap / max(len(tokens), 1) >= 0.50:
+                contributing.append(fd)
+
+        if not contributing:
+            continue  # Weird edge-case — no individual finding matched; skip
+
+        # If ALL contributing findings are non-live, the guard fires.
+        all_non_live = all(
+            (fd.get("source_class") or "unknown") in _NON_LIVE_CLASSES
+            for fd in contributing
+        )
+        if all_non_live:
+            return "rag_shortcut"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-item scoring
+# ---------------------------------------------------------------------------
+
+def score_item(
+    gold_item: dict,
+    trail: dict,
+    findings: list[dict],
+    *,
+    registered_technique_ids: frozenset[str] | None = None,
+    strategy_phases: list[str] | None = None,
+) -> dict[str, Any]:
+    """Score a single benchmark item against its run output.
+
+    This function is PURE — no I/O, no side effects.
+
+    Parameters
+    ----------
+    gold_item:
+        The gold-set item dict (id, query, expected_facts, domain, …).
+    trail:
+        The ``trail`` JSON blob from the ``research_trails`` DB row.
+        Expected keys: ``branches``, ``phases``, ``phases_full``, ``tool_calls``.
+    findings:
+        The ``findings`` JSON list from the ``research_trails`` DB row.
+        Each finding is a dict with optional keys: claim, evidence_summary,
+        source_class, source_url, technique_id, etc.
+    registered_technique_ids:
+        Frozenset of technique ids from the catalog. Pass None to skip guard 2.
+    strategy_phases:
+        List of phase ids the resolved strategy declares. Pass None to skip guard 3.
+
+    Returns
+    -------
+    dict with keys:
+        item_id          : str
+        item_score       : float  — 0.0 if gamed, else coverage * source_quality
+        coverage         : float  — matched / expected (0.0 if gamed)
+        source_quality   : float  — weighted source class score (0.0 if gamed)
+        gaming_flags     : list[str] — empty when clean, else guard name(s) tripped
+        fact_matches     : list[dict] — per-expected-fact match detail
+        tripped_guard    : str | None — first guard name that fired (for report)
+    """
+    item_id: str = gold_item.get("id", "unknown")
+    expected_facts: list[dict] = gold_item.get("expected_facts", [])
+
+    # Resolve registered technique ids (lazy load catalog if not supplied)
+    if registered_technique_ids is None:
+        registered_technique_ids = load_registered_technique_ids()
+
+    # -----------------------------------------------------------------------
+    # Anti-gaming guards — evaluated in order; first tripped guard wins.
+    # -----------------------------------------------------------------------
+    gaming_flags: list[str] = []
+
+    guard1 = _guard_training_only(trail)
+    if guard1:
+        gaming_flags.append(guard1)
+
+    guard2 = _guard_unregistered_tools(trail, registered_technique_ids)
+    if guard2:
+        gaming_flags.append(guard2)
+
+    if strategy_phases is not None:
+        guard3 = _guard_skipped_phases(trail, strategy_phases)
+        if guard3:
+            gaming_flags.append(guard3)
+
+    # Build findings blob for text matching (needed for guard 4 + scoring)
+    findings_blob = _findings_text(findings)
+
+    guard4 = _guard_rag_shortcut(expected_facts, findings, findings_blob)
+    if guard4:
+        gaming_flags.append(guard4)
+
+    tripped_guard: str | None = gaming_flags[0] if gaming_flags else None
+
+    # If ANY guard tripped, item_score = 0 immediately.
+    if gaming_flags:
+        fact_matches = [
+            {
+                "claim": f.get("claim", ""),
+                "matched": False,
+                "has_citation": False,
+                "source_class": None,
+                "score": 0.0,
+                "skip_reason": f"gaming guard: {tripped_guard}",
+            }
+            for f in expected_facts
+        ]
+        return {
+            "item_id": item_id,
+            "item_score": 0.0,
+            "coverage": 0.0,
+            "source_quality": 0.0,
+            "gaming_flags": gaming_flags,
+            "tripped_guard": tripped_guard,
+            "fact_matches": fact_matches,
+        }
+
+    # -----------------------------------------------------------------------
+    # Per-fact matching
+    # -----------------------------------------------------------------------
+    matched_count = 0
+    quality_weights: list[float] = []
+    fact_matches: list[dict] = []
+
+    for fact in expected_facts:
+        claim = fact.get("claim", "")
+        matched = _claim_matches(claim, findings_blob)
+        has_cite = _has_citation(findings) if matched else False
+        best_sc = _best_source_class(findings) if matched else "unknown"
+        sc_weight = SOURCE_CLASS_WEIGHTS.get(best_sc, 0.10) if matched else 0.0
+
+        # A fact is "matched" only when both text match AND citation present.
+        fact_matched = matched and has_cite
+        if fact_matched:
+            matched_count += 1
+            quality_weights.append(sc_weight)
+
+        fact_matches.append({
+            "claim": claim,
+            "matched": fact_matched,
+            "text_matched": matched,
+            "has_citation": has_cite,
+            "source_class": best_sc if matched else None,
+            "source_quality_weight": sc_weight,
+            "score": sc_weight if fact_matched else 0.0,
+        })
+
+    total = len(expected_facts)
+    coverage: float = matched_count / total if total > 0 else 0.0
+    source_quality: float = (
+        sum(quality_weights) / len(quality_weights) if quality_weights else 0.0
+    )
+    item_score: float = coverage * source_quality
+
+    return {
+        "item_id": item_id,
+        "item_score": round(item_score, 4),
+        "coverage": round(coverage, 4),
+        "source_quality": round(source_quality, 4),
+        "gaming_flags": gaming_flags,
+        "tripped_guard": tripped_guard,
+        "fact_matches": fact_matches,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aggregate reporting
+# ---------------------------------------------------------------------------
+
+def aggregate_scores(
+    results: list[dict],
+    run_metadata: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Aggregate per-item scores by template / mode / strategy / tactic / technique.
+
+    Parameters
+    ----------
+    results:
+        List of dicts from ``score_item`` calls.
+    run_metadata:
+        Optional list of per-item run metadata dicts (same index as results).
+        Each may contain: strategy, mode, template, tactic_ids, technique_ids.
+
+    Returns
+    -------
+    dict with keys:
+        overall   : {mean_score, total_items, gamed_items, gamed_pct}
+        by_domain : {domain: {mean_score, n}}
+        by_strategy : {strategy_id: {mean_score, n}}
+        by_mode   : {mode: {mean_score, n}}
+        by_technique : {technique_id: {mean_score, n}}
+    """
+    if not results:
+        return {"overall": {"mean_score": 0.0, "total_items": 0, "gamed_items": 0, "gamed_pct": 0.0}}
+
+    meta: list[dict] = run_metadata or [{} for _ in results]
+
+    total = len(results)
+    gamed = sum(1 for r in results if r.get("gaming_flags"))
+    all_scores = [r["item_score"] for r in results]
+    overall_mean = sum(all_scores) / total if total else 0.0
+
+    def _group_mean(key: str) -> dict[str, dict]:
+        groups: dict[str, list[float]] = {}
+        for r, m in zip(results, meta):
+            val = m.get(key) or r.get(key) or "unknown"
+            groups.setdefault(val, []).append(r["item_score"])
+        return {k: {"mean_score": round(sum(v) / len(v), 4), "n": len(v)} for k, v in groups.items()}
+
+    # Technique aggregation: one result may have multiple techniques
+    by_technique: dict[str, list[float]] = {}
+    for r, m in zip(results, meta):
+        for tid in m.get("technique_ids") or []:
+            by_technique.setdefault(tid, []).append(r["item_score"])
+
+    return {
+        "overall": {
+            "mean_score": round(overall_mean, 4),
+            "total_items": total,
+            "gamed_items": gamed,
+            "gamed_pct": round(gamed / total * 100, 1) if total else 0.0,
+        },
+        "by_domain": _group_mean("domain"),
+        "by_strategy": _group_mean("strategy"),
+        "by_mode": _group_mean("mode"),
+        "by_template": _group_mean("template"),
+        "by_technique": {
+            k: {"mean_score": round(sum(v) / len(v), 4), "n": len(v)}
+            for k, v in by_technique.items()
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Human-readable summary
+# ---------------------------------------------------------------------------
+
+def render_summary_table(
+    item_results: list[dict],
+    aggregates: dict[str, Any],
+) -> str:
+    """Return a plain-text summary table for console / log output."""
+    lines: list[str] = []
+    lines.append("=" * 72)
+    lines.append("BENCHMARK RESULTS — per-item")
+    lines.append("=" * 72)
+    header = f"{'ID':<28} {'SCORE':>6} {'COV':>6} {'SQ':>6} {'GUARD':<20}"
+    lines.append(header)
+    lines.append("-" * 72)
+    for r in item_results:
+        guard = r.get("tripped_guard") or "-"
+        lines.append(
+            f"{r['item_id']:<28} {r['item_score']:>6.3f} "
+            f"{r['coverage']:>6.3f} {r['source_quality']:>6.3f} "
+            f"{guard:<20}"
+        )
+    lines.append("=" * 72)
+
+    ov = aggregates.get("overall", {})
+    lines.append(
+        f"OVERALL  mean={ov.get('mean_score', 0):.3f}  "
+        f"items={ov.get('total_items', 0)}  "
+        f"gamed={ov.get('gamed_items', 0)} ({ov.get('gamed_pct', 0):.1f}%)"
+    )
+    lines.append("")
+
+    for group_key in ("by_strategy", "by_mode", "by_domain"):
+        grp = aggregates.get(group_key, {})
+        if grp:
+            lines.append(f"  {group_key}:")
+            for name, stats in sorted(grp.items()):
+                lines.append(
+                    f"    {name:<28} mean={stats['mean_score']:.3f}  n={stats['n']}"
+                )
+
+    return "\n".join(lines)

--- a/tests/benchmarks/test_score.py
+++ b/tests/benchmarks/test_score.py
@@ -1,0 +1,765 @@
+"""Unit tests for benchmarks/score.py.
+
+All tests use INLINE FIXTURES — no live stack, no network, no DB.
+Exercises: the 4 anti-gaming guards, scoring, partial coverage,
+source_quality weighting, gold-set YAML parsing, and module importability.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Ensure repo root is on path
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from benchmarks.score import (  # noqa: E402
+    SOURCE_CLASS_WEIGHTS,
+    _claim_matches,
+    _guard_rag_shortcut,
+    _guard_skipped_phases,
+    _guard_training_only,
+    _guard_unregistered_tools,
+    aggregate_scores,
+    render_summary_table,
+    score_item,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_REGISTERED_IDS: frozenset[str] = frozenset(
+    {
+        "web_search",
+        "image_search",
+        "opencorporates_owner",
+        "apollo_contact",
+        "hunter_email_search",
+        "google_news",
+        "whois_owner",
+        "phone_osint",
+        "pipl_people",
+        "tmdb_search",
+        "prior_research",
+        "apify_listings_search",
+    }
+)
+
+_STRATEGY_PHASES: list[str] = ["extract", "gather", "disconfirm", "synthesize"]
+
+_GOLD_ITEM = {
+    "id": "test-item-001",
+    "query": "Who is Tim Cook and what company does he lead?",
+    "domain": "person",
+    "expected_facts": [
+        {
+            "claim": "Tim Cook is the CEO of Apple Inc",
+            "authoritative_source": "https://www.apple.com/leadership/tim-cook/",
+            "must_be_live": False,
+        },
+        {
+            "claim": "Tim Cook succeeded Steve Jobs as Apple CEO",
+            "authoritative_source": "https://example.com/jobs-apple",
+            "must_be_live": False,
+        },
+    ],
+}
+
+_GOLD_ITEM_LIVE = {
+    "id": "test-live-001",
+    "query": "Who owns One Microsoft Way Redmond WA?",
+    "domain": "real_estate",
+    "expected_facts": [
+        {
+            "claim": "One Microsoft Way Redmond WA is owned by Microsoft Corporation",
+            "authoritative_source": "https://info.kingcounty.gov/",
+            "must_be_live": True,
+        },
+    ],
+}
+
+
+def _make_trail(
+    *,
+    branches: list[dict] | None = None,
+    phases: list[str] | None = None,
+    tool_calls: int = 5,
+) -> dict:
+    return {
+        "branches": branches if branches is not None else [],
+        "phases": phases if phases is not None else _STRATEGY_PHASES[:],
+        "phases_full": [],
+        "tool_calls": tool_calls,
+    }
+
+
+def _make_finding(
+    *,
+    source_class: str = "live_search",
+    source_url: str = "https://example.com/source",
+    claim: str = "",
+    evidence_summary: str = "",
+) -> dict:
+    return {
+        "source_class": source_class,
+        "source_url": source_url,
+        "claim": claim,
+        "evidence_summary": evidence_summary,
+    }
+
+
+def _live_branch(technique_id: str = "web_search") -> dict:
+    return {
+        "technique_id": technique_id,
+        "source_class": "live_search",
+        "confidence": 0.9,
+    }
+
+
+# ===========================================================================
+# Guard 1 — training_only
+# ===========================================================================
+
+
+class TestGuardTrainingOnly:
+    def test_fires_when_zero_tool_calls_and_branches_present(self):
+        trail = _make_trail(
+            branches=[{"technique_id": "web_search", "source_class": "live_search"}],
+            tool_calls=0,
+        )
+        assert _guard_training_only(trail) == "training_only"
+
+    def test_fires_when_all_branches_are_training(self):
+        trail = _make_trail(
+            branches=[
+                {"technique_id": "recall", "source_class": "training_knowledge"},
+                {"technique_id": "recall", "source_class": "training_knowledge"},
+            ],
+            tool_calls=2,
+        )
+        assert _guard_training_only(trail) == "training_only"
+
+    def test_fires_when_no_branches_at_all(self):
+        trail = _make_trail(branches=[], tool_calls=0)
+        assert _guard_training_only(trail) == "training_only"
+
+    def test_clean_when_live_branch_present(self):
+        trail = _make_trail(
+            branches=[_live_branch("web_search")],
+            tool_calls=3,
+        )
+        assert _guard_training_only(trail) is None
+
+    def test_clean_when_mixed_sources(self):
+        trail = _make_trail(
+            branches=[
+                {"technique_id": "web_search", "source_class": "live_search"},
+                {"technique_id": "recall", "source_class": "training_knowledge"},
+            ],
+            tool_calls=1,
+        )
+        assert _guard_training_only(trail) is None
+
+    def test_score_is_zero_when_guard_fires(self):
+        trail = _make_trail(branches=[], tool_calls=0)
+        findings = [_make_finding(claim="Tim Cook is the CEO of Apple Inc", source_class="live_search")]
+        result = score_item(
+            _GOLD_ITEM,
+            trail,
+            findings,
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        assert result["item_score"] == 0.0
+        assert "training_only" in result["gaming_flags"]
+        assert result["tripped_guard"] == "training_only"
+
+
+# ===========================================================================
+# Guard 2 — unregistered_tool
+# ===========================================================================
+
+
+class TestGuardUnregisteredTool:
+    def test_fires_when_unknown_technique(self):
+        trail = _make_trail(
+            branches=[
+                {"technique_id": "web_search", "source_class": "live_search"},
+                {"technique_id": "shadow_scraper", "source_class": "live_search"},
+            ],
+            tool_calls=2,
+        )
+        assert _guard_unregistered_tools(trail, _REGISTERED_IDS) == "unregistered_tool"
+
+    def test_clean_when_all_registered(self):
+        trail = _make_trail(
+            branches=[
+                {"technique_id": "web_search", "source_class": "live_search"},
+                {"technique_id": "image_search", "source_class": "live_search"},
+            ],
+            tool_calls=4,
+        )
+        assert _guard_unregistered_tools(trail, _REGISTERED_IDS) is None
+
+    def test_skips_check_when_empty_registered_ids(self):
+        trail = _make_trail(
+            branches=[{"technique_id": "anything", "source_class": "live_search"}],
+            tool_calls=1,
+        )
+        assert _guard_unregistered_tools(trail, frozenset()) is None
+
+    def test_skips_branches_with_no_technique_id(self):
+        trail = _make_trail(
+            branches=[{"source_class": "live_search"}],  # no technique_id key
+            tool_calls=1,
+        )
+        assert _guard_unregistered_tools(trail, _REGISTERED_IDS) is None
+
+    def test_score_zero_when_guard_fires(self):
+        trail = _make_trail(
+            branches=[
+                {"technique_id": "web_search", "source_class": "live_search"},
+                {"technique_id": "EVIL_TOOL_42", "source_class": "live_search"},
+            ],
+            tool_calls=3,
+        )
+        findings = [_make_finding(claim="Tim Cook is the CEO of Apple Inc")]
+        result = score_item(
+            _GOLD_ITEM,
+            trail,
+            findings,
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        assert result["item_score"] == 0.0
+        assert "unregistered_tool" in result["gaming_flags"]
+        assert result["tripped_guard"] == "unregistered_tool"
+
+
+# ===========================================================================
+# Guard 3 — skipped_phases
+# ===========================================================================
+
+
+class TestGuardSkippedPhases:
+    def test_fires_when_required_phase_missing(self):
+        trail = _make_trail(phases=["extract", "gather"])  # missing disconfirm, synthesize
+        assert _guard_skipped_phases(trail, _STRATEGY_PHASES) == "skipped_phases"
+
+    def test_fires_when_phases_empty(self):
+        trail = _make_trail(phases=[])
+        assert _guard_skipped_phases(trail, _STRATEGY_PHASES) == "skipped_phases"
+
+    def test_clean_when_all_phases_ran(self):
+        trail = _make_trail(phases=["extract", "gather", "disconfirm", "synthesize"])
+        assert _guard_skipped_phases(trail, _STRATEGY_PHASES) is None
+
+    def test_clean_when_extra_phases(self):
+        trail = _make_trail(phases=["extract", "gather", "disconfirm", "synthesize", "bonus"])
+        assert _guard_skipped_phases(trail, _STRATEGY_PHASES) is None
+
+    def test_skips_check_when_no_strategy_phases(self):
+        trail = _make_trail(phases=[])
+        assert _guard_skipped_phases(trail, []) is None
+
+    def test_score_zero_when_guard_fires(self):
+        trail = _make_trail(
+            branches=[_live_branch("web_search")],
+            phases=["extract"],  # missing gather/disconfirm/synthesize
+            tool_calls=3,
+        )
+        findings = [_make_finding(claim="Tim Cook is the CEO of Apple Inc")]
+        result = score_item(
+            _GOLD_ITEM,
+            trail,
+            findings,
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        assert result["item_score"] == 0.0
+        assert "skipped_phases" in result["gaming_flags"]
+        assert result["tripped_guard"] == "skipped_phases"
+
+
+# ===========================================================================
+# Guard 4 — rag_shortcut
+# ===========================================================================
+
+
+class TestGuardRagShortcut:
+    def test_fires_when_live_fact_matched_only_via_prior_research(self):
+        """must_be_live fact matched, but contributing finding is prior_research."""
+        findings = [
+            _make_finding(
+                source_class="prior_research",
+                source_url="https://cache.example.com",
+                claim="One Microsoft Way Redmond WA is owned by Microsoft Corporation",
+            )
+        ]
+        findings_blob = "One Microsoft Way Redmond WA is owned by Microsoft Corporation"
+        result = _guard_rag_shortcut(
+            _GOLD_ITEM_LIVE["expected_facts"], findings, findings_blob
+        )
+        assert result == "rag_shortcut"
+
+    def test_clean_when_live_fact_matched_via_live_search(self):
+        findings = [
+            _make_finding(
+                source_class="live_search",
+                source_url="https://kingcounty.gov/property/123",
+                claim="One Microsoft Way Redmond WA is owned by Microsoft Corporation",
+            )
+        ]
+        findings_blob = "One Microsoft Way Redmond WA is owned by Microsoft Corporation"
+        result = _guard_rag_shortcut(
+            _GOLD_ITEM_LIVE["expected_facts"], findings, findings_blob
+        )
+        assert result is None
+
+    def test_skips_check_when_no_live_facts(self):
+        """Items where must_be_live is always False — guard should not fire."""
+        findings = [
+            _make_finding(source_class="prior_research", claim="Tim Cook is CEO of Apple")
+        ]
+        findings_blob = "Tim Cook is CEO of Apple"
+        result = _guard_rag_shortcut(
+            _GOLD_ITEM["expected_facts"], findings, findings_blob
+        )
+        assert result is None
+
+    def test_skips_check_when_live_fact_did_not_match(self):
+        """If the fact didn't match at all, it's a coverage miss, not a RAG shortcut."""
+        findings = [
+            _make_finding(source_class="prior_research", claim="completely unrelated text")
+        ]
+        findings_blob = "completely unrelated text"
+        result = _guard_rag_shortcut(
+            _GOLD_ITEM_LIVE["expected_facts"], findings, findings_blob
+        )
+        assert result is None
+
+    def test_score_zero_when_guard_fires(self):
+        trail = _make_trail(
+            branches=[_live_branch("prior_research")],
+            tool_calls=1,
+        )
+        # Findings with prior_research source_class
+        findings = [
+            _make_finding(
+                source_class="prior_research",
+                source_url="https://cache.example.com",
+                claim="One Microsoft Way Redmond WA is owned by Microsoft Corporation",
+            )
+        ]
+        result = score_item(
+            _GOLD_ITEM_LIVE,
+            trail,
+            findings,
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=["extract", "gather", "synthesize"],
+        )
+        assert result["item_score"] == 0.0
+        assert "rag_shortcut" in result["gaming_flags"]
+        assert result["tripped_guard"] == "rag_shortcut"
+
+
+# ===========================================================================
+# Clean run — correct scoring
+# ===========================================================================
+
+
+class TestCleanRunScoring:
+    def _clean_trail(self) -> dict:
+        return _make_trail(
+            branches=[
+                _live_branch("web_search"),
+                _live_branch("web_search"),
+            ],
+            phases=["extract", "gather", "disconfirm", "synthesize"],
+            tool_calls=8,
+        )
+
+    def _full_findings(self) -> list[dict]:
+        """Findings that match both expected_facts in _GOLD_ITEM."""
+        return [
+            _make_finding(
+                source_class="live_search",
+                source_url="https://apple.com/leadership/tim-cook/",
+                claim="Tim Cook is the CEO of Apple Inc",
+                evidence_summary="Tim Cook succeeded Steve Jobs as Apple CEO in 2011",
+            ),
+        ]
+
+    def test_full_coverage_scores_high(self):
+        result = score_item(
+            _GOLD_ITEM,
+            self._clean_trail(),
+            self._full_findings(),
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        assert result["item_score"] > 0.0
+        assert result["coverage"] > 0.0
+        assert result["source_quality"] > 0.0
+        assert not result["gaming_flags"]
+        assert result["tripped_guard"] is None
+
+    def test_source_quality_live_search_weight(self):
+        """live_search source_class should give 0.75 quality weight."""
+        result = score_item(
+            _GOLD_ITEM,
+            self._clean_trail(),
+            self._full_findings(),
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        # live_search weight is 0.75 — source_quality should be around that
+        assert abs(result["source_quality"] - SOURCE_CLASS_WEIGHTS["live_search"]) < 0.01
+
+    def test_primary_official_scores_higher_than_live_search(self):
+        """primary_official (1.0) > live_search (0.75)."""
+        official_findings = [
+            _make_finding(
+                source_class="primary_official",
+                source_url="https://apple.com/leadership/tim-cook/",
+                claim="Tim Cook is the CEO of Apple Inc",
+                evidence_summary="Tim Cook succeeded Steve Jobs as Apple CEO",
+            )
+        ]
+        live_findings = [
+            _make_finding(
+                source_class="live_search",
+                source_url="https://news.com/timcook",
+                claim="Tim Cook is the CEO of Apple Inc",
+                evidence_summary="Tim Cook succeeded Steve Jobs as Apple CEO",
+            )
+        ]
+        trail = self._clean_trail()
+        result_official = score_item(
+            _GOLD_ITEM, trail, official_findings,
+            registered_technique_ids=_REGISTERED_IDS, strategy_phases=_STRATEGY_PHASES
+        )
+        result_live = score_item(
+            _GOLD_ITEM, trail, live_findings,
+            registered_technique_ids=_REGISTERED_IDS, strategy_phases=_STRATEGY_PHASES
+        )
+        assert result_official["source_quality"] > result_live["source_quality"]
+
+    def test_no_citation_lowers_score_to_zero(self):
+        """Findings with no source_url should count as unmatched (citation required)."""
+        findings_no_url = [
+            {
+                "source_class": "live_search",
+                "source_url": "",  # empty URL
+                "claim": "Tim Cook is the CEO of Apple Inc",
+                "evidence_summary": "Tim Cook succeeded Steve Jobs as Apple CEO",
+            }
+        ]
+        result = score_item(
+            _GOLD_ITEM,
+            self._clean_trail(),
+            findings_no_url,
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        # No citation → all facts unmatched → coverage = 0, score = 0
+        assert result["item_score"] == 0.0
+        assert result["coverage"] == 0.0
+
+
+# ===========================================================================
+# Partial coverage
+# ===========================================================================
+
+
+class TestPartialCoverage:
+    def _partial_findings(self) -> list[dict]:
+        """Only matches the first of the two expected_facts."""
+        return [
+            _make_finding(
+                source_class="live_search",
+                source_url="https://apple.com/leadership/tim-cook/",
+                claim="Tim Cook is the CEO of Apple Inc",
+                evidence_summary="Tim Cook leads Apple Inc as CEO",
+            ),
+            # Second finding does NOT contain "Steve Jobs" or "succeeded" tokens
+            _make_finding(
+                source_class="live_search",
+                source_url="https://some-other-source.com",
+                claim="Cook earned an MBA from Duke University",
+                evidence_summary="Cook studied at Auburn and Duke",
+            ),
+        ]
+
+    def test_partial_coverage_is_proportional(self):
+        trail = _make_trail(
+            branches=[_live_branch("web_search")],
+            phases=["extract", "gather", "disconfirm", "synthesize"],
+            tool_calls=4,
+        )
+        result = score_item(
+            _GOLD_ITEM,
+            trail,
+            self._partial_findings(),
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        # 1 of 2 facts matched → coverage ≈ 0.5
+        assert result["coverage"] == pytest.approx(0.5, abs=0.01)
+        # item_score = coverage * source_quality = 0.5 * 0.75 ≈ 0.375
+        assert result["item_score"] == pytest.approx(0.5 * 0.75, abs=0.01)
+        assert not result["gaming_flags"]
+
+    def test_zero_coverage_gives_zero_score(self):
+        trail = _make_trail(
+            branches=[_live_branch("web_search")],
+            phases=_STRATEGY_PHASES,
+            tool_calls=3,
+        )
+        # Findings that don't match anything
+        findings = [
+            _make_finding(
+                source_class="live_search",
+                source_url="https://unrelated.com",
+                claim="Completely unrelated content about something else entirely",
+            )
+        ]
+        result = score_item(
+            _GOLD_ITEM,
+            trail,
+            findings,
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        assert result["coverage"] == 0.0
+        assert result["item_score"] == 0.0
+
+
+# ===========================================================================
+# Source-quality weighting
+# ===========================================================================
+
+
+class TestSourceQualityWeighting:
+    _SINGLE_FACT_ITEM = {
+        "id": "sq-test-001",
+        "query": "test query",
+        "domain": "person",
+        "expected_facts": [
+            {
+                "claim": "Tim Cook is the CEO of Apple Inc",
+                "authoritative_source": "https://example.com",
+                "must_be_live": False,
+            }
+        ],
+    }
+
+    def _trail(self) -> dict:
+        return _make_trail(
+            branches=[_live_branch("web_search")],
+            phases=_STRATEGY_PHASES,
+            tool_calls=3,
+        )
+
+    def _finding_with_class(self, sc: str) -> list[dict]:
+        return [
+            _make_finding(
+                source_class=sc,
+                source_url="https://example.com/source",
+                claim="Tim Cook is the CEO of Apple Inc",
+            )
+        ]
+
+    @pytest.mark.parametrize("source_class,expected_weight", [
+        ("live_official",    1.00),
+        ("primary_official", 1.00),
+        ("registry",         0.95),
+        ("live_search",      0.75),
+        ("prior_research",   0.30),
+        ("training_knowledge", 0.10),
+    ])
+    def test_source_quality_matches_weight_table(self, source_class, expected_weight):
+        result = score_item(
+            self._SINGLE_FACT_ITEM,
+            self._trail(),
+            self._finding_with_class(source_class),
+            registered_technique_ids=_REGISTERED_IDS,
+            strategy_phases=_STRATEGY_PHASES,
+        )
+        assert result["source_quality"] == pytest.approx(expected_weight, abs=0.01)
+        assert result["item_score"] == pytest.approx(1.0 * expected_weight, abs=0.01)
+
+
+# ===========================================================================
+# Aggregate scores
+# ===========================================================================
+
+
+class TestAggregateScores:
+    def test_empty_results(self):
+        agg = aggregate_scores([])
+        assert agg["overall"]["total_items"] == 0
+
+    def test_overall_mean_and_gamed_count(self):
+        results = [
+            {"item_id": "a", "item_score": 0.8, "gaming_flags": [], "domain": "person"},
+            {"item_id": "b", "item_score": 0.0, "gaming_flags": ["training_only"], "domain": "company"},
+            {"item_id": "c", "item_score": 0.6, "gaming_flags": [], "domain": "person"},
+        ]
+        meta = [
+            {"strategy": "person", "mode": "investigation", "domain": "person", "technique_ids": ["web_search"]},
+            {"strategy": "company", "mode": "investigation", "domain": "company", "technique_ids": []},
+            {"strategy": "person", "mode": "investigation", "domain": "person", "technique_ids": ["web_search"]},
+        ]
+        agg = aggregate_scores(results, meta)
+        assert agg["overall"]["total_items"] == 3
+        assert agg["overall"]["gamed_items"] == 1
+        assert agg["overall"]["mean_score"] == pytest.approx((0.8 + 0.0 + 0.6) / 3, abs=0.01)
+
+    def test_by_strategy_grouping(self):
+        results = [
+            {"item_id": "a", "item_score": 1.0, "gaming_flags": []},
+            {"item_id": "b", "item_score": 0.5, "gaming_flags": []},
+        ]
+        meta = [
+            {"strategy": "person", "mode": "i", "domain": "x", "technique_ids": []},
+            {"strategy": "company", "mode": "i", "domain": "y", "technique_ids": []},
+        ]
+        agg = aggregate_scores(results, meta)
+        assert "person" in agg["by_strategy"]
+        assert "company" in agg["by_strategy"]
+        assert agg["by_strategy"]["person"]["mean_score"] == pytest.approx(1.0)
+        assert agg["by_strategy"]["company"]["mean_score"] == pytest.approx(0.5)
+
+    def test_render_summary_table_runs(self):
+        results = [
+            {"item_id": "test-001", "item_score": 0.75, "coverage": 1.0,
+             "source_quality": 0.75, "gaming_flags": [], "tripped_guard": None},
+        ]
+        agg = aggregate_scores(results)
+        table = render_summary_table(results, agg)
+        assert "test-001" in table
+        assert "0.750" in table
+
+
+# ===========================================================================
+# Gold-set YAML parsing
+# ===========================================================================
+
+
+class TestGoldSetParsing:
+    GOLDSET_DIR = Path(__file__).resolve().parent.parent.parent / "benchmarks" / "goldset"
+
+    def test_items_yaml_parses(self):
+        items_file = self.GOLDSET_DIR / "items.yaml"
+        assert items_file.exists(), f"items.yaml not found at {items_file}"
+        raw = yaml.safe_load(items_file.read_text())
+        assert isinstance(raw, list)
+        assert len(raw) >= 3  # at least 3 items
+
+    def test_all_items_have_required_fields(self):
+        items_file = self.GOLDSET_DIR / "items.yaml"
+        raw = yaml.safe_load(items_file.read_text())
+        required = ("id", "query", "expected_facts", "domain")
+        for item in raw:
+            for field in required:
+                assert field in item, f"Item {item.get('id')!r} missing field {field!r}"
+
+    def test_all_expected_facts_have_required_fields(self):
+        items_file = self.GOLDSET_DIR / "items.yaml"
+        raw = yaml.safe_load(items_file.read_text())
+        ef_required = ("claim", "authoritative_source", "must_be_live")
+        for item in raw:
+            for ef in item.get("expected_facts", []):
+                for field in ef_required:
+                    assert field in ef, (
+                        f"Item {item.get('id')!r} expected_fact missing {field!r}"
+                    )
+
+    def test_no_duplicate_ids(self):
+        items_file = self.GOLDSET_DIR / "items.yaml"
+        raw = yaml.safe_load(items_file.read_text())
+        ids = [item["id"] for item in raw]
+        assert len(ids) == len(set(ids)), "Duplicate ids in gold-set"
+
+    def test_domains_are_valid(self):
+        valid_domains = {"person", "company", "real_estate", "due_diligence"}
+        items_file = self.GOLDSET_DIR / "items.yaml"
+        raw = yaml.safe_load(items_file.read_text())
+        for item in raw:
+            assert item["domain"] in valid_domains, (
+                f"Item {item['id']!r} has invalid domain {item['domain']!r}"
+            )
+
+    def test_schema_yaml_exists(self):
+        schema_file = self.GOLDSET_DIR / "schema.yaml"
+        assert schema_file.exists()
+
+    def test_goldset_loader_from_run_benchmark(self):
+        """Integration: use the run_benchmark loader (no network)."""
+        from benchmarks.run_benchmark import load_goldset  # noqa: E402
+        items = load_goldset()
+        assert len(items) >= 3
+        for item in items:
+            assert "id" in item
+            assert "expected_facts" in item
+
+    def test_goldset_loader_filter_by_ids(self):
+        from benchmarks.run_benchmark import load_goldset  # noqa: E402
+        items = load_goldset(item_ids=["person-jobs-001"])
+        assert len(items) == 1
+        assert items[0]["id"] == "person-jobs-001"
+
+
+# ===========================================================================
+# Module importability
+# ===========================================================================
+
+
+class TestImportability:
+    def test_score_module_imports(self):
+        import benchmarks.score  # noqa: F401
+
+    def test_run_benchmark_module_imports(self):
+        import benchmarks.run_benchmark  # noqa: F401
+
+    def test_score_item_is_callable(self):
+        from benchmarks.score import score_item as _si
+        assert callable(_si)
+
+    def test_aggregate_scores_is_callable(self):
+        from benchmarks.score import aggregate_scores as _as
+        assert callable(_as)
+
+
+# ===========================================================================
+# Claim matching helpers
+# ===========================================================================
+
+
+class TestClaimMatching:
+    def test_exact_match(self):
+        assert _claim_matches(
+            "Tim Cook is the CEO of Apple Inc",
+            "Tim Cook is the CEO of Apple Inc",
+        )
+
+    def test_partial_token_match_above_threshold(self):
+        # "tim cook ceo apple" — 4 tokens. "tim cook ceo" present = 3/4 = 75%
+        assert _claim_matches(
+            "Tim Cook is the CEO of Apple Inc",
+            "tim cook ceo technology leader at apple company",
+        )
+
+    def test_no_match_on_unrelated_text(self):
+        assert not _claim_matches(
+            "Tim Cook is the CEO of Apple Inc",
+            "The weather today is sunny and warm in Seattle",
+        )
+
+    def test_empty_claim(self):
+        assert not _claim_matches("", "some text")


### PR DESCRIPTION
## Summary

Implements the benchmark harness from issue #145.

- **`benchmarks/goldset/`** — documented YAML schema + 6 curated gold-set items across `person`, `company`, `real_estate`, `due_diligence` domains with real authoritative source URLs
- **`benchmarks/score.py`** — pure, unit-testable scoring engine: `score_item(gold_item, trail, findings)` applies 4 anti-gaming guards (hard-fail → item_score=0, guard named), then computes `coverage × source_quality`; plus `aggregate_scores` by template/mode/strategy/tactic/technique and a console summary table
- **`benchmarks/run_benchmark.py`** — real driver: login → `POST /v3/preflight` → `POST /v3/preflight/confirm` (start_run:true) → poll `/v3/pipelines/runs/{id}` to terminal → fetch `research_trails` row → `score_item`; no mocking
- **`benchmarks/README.md`** — how to run, schema docs, guard explanations, env/key requirements
- **`tests/benchmarks/test_score.py`** — 54 unit tests with inline fixtures; no live runs

## Anti-gaming guards (each tested to zero the score + name the guard)

1. `training_only` — no real tool calls OR all branches have `source_class ∈ {training_knowledge}`
2. `unregistered_tool` — any `technique_id` in trail branches not in the registered catalog (`app/pipeline/catalogs/registries/techniques/`)
3. `skipped_phases` — a required strategy phase did not appear in `trail.phases`
4. `rag_shortcut` — a `must_be_live: true` fact was satisfied only via `source_class == prior_research`

## Test plan

- [x] `tests/benchmarks/test_score.py` — 54 tests, all passed
- [x] Gold-set YAML parses (schema + loader tests included)
- [x] `.venv/bin/python -c "import benchmarks.score, benchmarks.run_benchmark"` — imports cleanly
- [x] Full suite: `1786 passed, 0 failed` (baseline was 1732; delta from other merged branches)
- [x] `ruff check benchmarks` — clean
- [ ] End-to-end live run against the local stack — to be done by the user with `LOCAL_STACK_URL=http://localhost:8000 python -m benchmarks.run_benchmark`

## Notes

- `score.py` is pure — `score_item` has no I/O, no network, no DB access; unit-testable with fake trails
- Live gold-set items (`must_be_live: true`) require search/enrichment API keys; without them the `training_only` guard fires correctly, surfacing key-config gaps (see #131)
- Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)