### PR TITLE
feat(keys): scoped encrypted API-key vault (user→org→global→env)

### DIFF
--- a/app/lib/api_keys.py
+++ b/app/lib/api_keys.py
@@ -1,0 +1,138 @@
+"""Scoped API-key resolution helper.
+
+Resolution order (first match wins):
+    1. User-scoped vault row (``api_key_vault`` WHERE scope='user' AND owner_id=user_id)
+    2. Org-scoped vault row  (``api_key_vault`` WHERE scope='org'  AND owner_id=org_id)
+    3. Global vault row      (``api_key_vault`` WHERE scope='global' AND owner_id IS NULL)
+    4. ``core_settings`` row (legacy; may be Fernet-encrypted with app.crypto prefix)
+    5. Environment variable  (key_name.upper() — e.g. hunter_io_api_key → HUNTER_IO_API_KEY)
+
+Security guarantees
+-------------------
+- Resolved values are NEVER logged. Only key_name, scope, and source are logged.
+- Callers receive the decrypted string value or None.
+- DB errors are swallowed (non-fatal) so a misconfigured DB doesn't break the
+  resolution chain — the function falls through to the env fallback.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+
+def _vault_fetch(key_name: str, scope: str, owner_id: str) -> dict | None:
+    """Fetch a scoped vault row by (key_name, scope, owner_id). Non-fatal."""
+    try:
+        from app.routers.v3.db import fetch_one
+        return fetch_one(
+            """
+            SELECT value_encrypted
+              FROM api_key_vault
+             WHERE key_name = %s AND scope = %s AND owner_id = %s::uuid
+            """,
+            (key_name, scope, owner_id),
+        )
+    except Exception:
+        log.debug(
+            "api_keys: vault fetch failed key_name=%r scope=%r",
+            key_name, scope, exc_info=True,
+        )
+        return None
+
+
+def _vault_fetch_global(key_name: str) -> dict | None:
+    """Fetch the global vault row (owner_id IS NULL). Non-fatal."""
+    try:
+        from app.routers.v3.db import fetch_one
+        return fetch_one(
+            """
+            SELECT value_encrypted
+              FROM api_key_vault
+             WHERE key_name = %s AND scope = 'global' AND owner_id IS NULL
+            """,
+            (key_name,),
+        )
+    except Exception:
+        log.debug(
+            "api_keys: global vault fetch failed key_name=%r",
+            key_name, exc_info=True,
+        )
+        return None
+
+
+def resolve_api_key(
+    key_name: str,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+) -> str | None:
+    """Return the best-scoped API key for *key_name*, or None if not configured.
+
+    NEVER logs the resolved value — only key_name, scope, and source.
+    """
+    from app.lib.secret_box import decrypt
+
+    # 1. User-scoped vault
+    if user_id and user_id not in ("mcp-system", ""):
+        row = _vault_fetch(key_name, "user", user_id)
+        if row and row.get("value_encrypted"):
+            log.info(
+                "api_keys: resolved key_name=%r scope=user source=vault",
+                key_name,
+            )
+            return decrypt(row["value_encrypted"])
+
+    # 2. Org-scoped vault
+    if org_id:
+        row = _vault_fetch(key_name, "org", org_id)
+        if row and row.get("value_encrypted"):
+            log.info(
+                "api_keys: resolved key_name=%r scope=org source=vault",
+                key_name,
+            )
+            return decrypt(row["value_encrypted"])
+
+    # 3. Global vault row
+    row = _vault_fetch_global(key_name)
+    if row and row.get("value_encrypted"):
+        log.info(
+            "api_keys: resolved key_name=%r scope=global source=vault",
+            key_name,
+        )
+        return decrypt(row["value_encrypted"])
+
+    # 4. core_settings (legacy — may carry a Fernet-encrypted value with enc: prefix)
+    try:
+        from app.routers.v3.db import fetch_one
+        cs_row = fetch_one(
+            "SELECT value FROM core_settings WHERE key = %s",
+            (key_name,),
+        )
+        if cs_row and cs_row.get("value"):
+            log.info(
+                "api_keys: resolved key_name=%r source=core_settings",
+                key_name,
+            )
+            raw = cs_row["value"]
+            if raw.startswith("enc:"):
+                from app.crypto import decrypt_value
+                raw = decrypt_value(raw)
+            return raw
+    except Exception:
+        log.debug(
+            "api_keys: core_settings lookup failed key_name=%r",
+            key_name, exc_info=True,
+        )
+
+    # 5. Environment variable
+    env_value = os.getenv(key_name.upper())
+    if env_value:
+        log.info(
+            "api_keys: resolved key_name=%r source=env",
+            key_name,
+        )
+        return env_value
+
+    return None

--- a/app/lib/secret_box.py
+++ b/app/lib/secret_box.py
@@ -1,0 +1,72 @@
+"""Fernet-based symmetric encryption for the API-key vault.
+
+Keys are encrypted before being written to ``api_key_vault`` and decrypted only
+at the server-side node-execute path. Decrypted values NEVER leave the process
+via logs, WS payloads, or HTTP responses.
+
+Environment variable
+--------------------
+``VAULT_ENCRYPTION_KEY`` — 32-byte URL-safe base64-encoded key (44 chars).
+Generate with::
+
+    python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+A dev fallback is derived from a fixed secret when the env var is absent. The
+fallback logs a LOUD warning at every startup so it can't be silently used in
+production.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+_warned_dev_key: bool = False
+
+
+def _get_fernet_key() -> bytes:
+    """Return the Fernet key bytes, warning loudly if falling back to dev key."""
+    global _warned_dev_key
+    raw = os.getenv("VAULT_ENCRYPTION_KEY", "")
+    if raw:
+        return raw.encode("ascii")
+
+    # Dev fallback: deterministic but NOT secret — any production deploy MUST
+    # set VAULT_ENCRYPTION_KEY or encrypted values are trivially reversible.
+    if not _warned_dev_key:
+        log.warning(
+            "VAULT_ENCRYPTION_KEY is not set — using insecure dev fallback. "
+            "Set VAULT_ENCRYPTION_KEY to a real Fernet key before going to production."
+        )
+        _warned_dev_key = True
+
+    digest = hashlib.sha256(b"info-broker-dev-vault-key-do-not-use-in-prod").digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+def encrypt(plaintext: str) -> str:
+    """Encrypt *plaintext* and return a URL-safe base64 Fernet token."""
+    from cryptography.fernet import Fernet
+
+    fernet = Fernet(_get_fernet_key())
+    return fernet.encrypt(plaintext.encode("utf-8")).decode("ascii")
+
+
+def decrypt(token: str) -> str:
+    """Decrypt a Fernet *token* and return the plaintext.
+
+    Raises :exc:`ValueError` on invalid token or key mismatch — callers should
+    treat this as a configuration error, not a user-visible failure.
+    """
+    from cryptography.fernet import Fernet, InvalidToken
+
+    fernet = Fernet(_get_fernet_key())
+    try:
+        return fernet.decrypt(token.encode("ascii")).decode("utf-8")
+    except InvalidToken as exc:
+        raise ValueError(
+            "vault decrypt failed — token is invalid or key mismatch"
+        ) from exc

--- a/app/pipeline/nodes/apollo_zoominfo.py
+++ b/app/pipeline/nodes/apollo_zoominfo.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 
 import httpx
 
@@ -18,21 +17,12 @@ _APOLLO_PEOPLE_URL = "https://api.apollo.io/v1/mixed_people/search"
 _APOLLO_COMPANIES_URL = "https://api.apollo.io/v1/mixed_companies/search"
 
 
-def _resolve_api_key() -> str | None:
-    """Env var takes priority; fall back to DB setting."""
-    key = os.getenv("APOLLO_API_KEY")
-    if key:
-        return key
-    try:
-        from app.routers.v3.db import fetch_one
-        row = fetch_one(
-            "SELECT value FROM core_settings WHERE key = 'apollo_api_key'", ()
-        )
-        if row and row.get("value"):
-            return row["value"]
-    except Exception:
-        pass
-    return None
+def _resolve_api_key(context: "RunContext | None" = None) -> str | None:
+    """Resolve Apollo API key via scoped vault → core_settings → env var."""
+    from app.lib.api_keys import resolve_api_key
+    user_id = getattr(context, "user_id", None)
+    org_id = getattr(context, "org_id", None)
+    return resolve_api_key("apollo_api_key", user_id=user_id, org_id=org_id)
 
 
 class ApolloZoominfoNode:
@@ -70,7 +60,7 @@ class ApolloZoominfoNode:
     async def execute(
         self, config: dict, inputs: list[dict], context: RunContext
     ) -> list[dict]:
-        api_key = config.get("api_key") or _resolve_api_key()
+        api_key = config.get("api_key") or _resolve_api_key(context)
         if not api_key:
             log.warning("apollo_zoominfo: no API key configured")
             return [

--- a/app/pipeline/nodes/base.py
+++ b/app/pipeline/nodes/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Protocol, TypedDict
 
 
@@ -9,7 +9,8 @@ class RunContext:
     user_id: str
     run_id: str
     node_id: str
-    push_event: Callable = lambda *a, **kw: None
+    push_event: Callable = field(default=lambda *a, **kw: None)
+    org_id: str | None = None
 
 
 class HealthStatus(TypedDict):

--- a/app/pipeline/nodes/hunter_io.py
+++ b/app/pipeline/nodes/hunter_io.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
-from urllib.parse import urlencode
 
 import httpx
 
@@ -17,23 +15,23 @@ _REASON = "Hunter.io surfaces verified email patterns and individual addresses �
 _BASE_URL = "https://api.hunter.io/v2"
 
 
-def _resolve_api_key(config_key: str | None = None) -> str | None:
-    """Config value takes priority, then env var, then DB setting."""
+def _resolve_api_key(
+    config_key: str | None = None,
+    context: "RunContext | None" = None,
+) -> str | None:
+    """Resolve Hunter.io API key via scoped vault → core_settings → env var.
+
+    Config value from node config takes highest priority (explicit override).
+    Resolution order for the automatic path: user-scoped vault → org-scoped
+    vault → global vault → core_settings → HUNTER_IO_API_KEY env var.
+    The resolved value is never logged.
+    """
     if config_key:
         return config_key
-    key = os.getenv("HUNTER_IO_API_KEY") or os.getenv("HUNTER_API_KEY")
-    if key:
-        return key
-    try:
-        from app.routers.v3.db import fetch_one
-        row = fetch_one(
-            "SELECT value FROM core_settings WHERE key = 'hunter_io_api_key'", ()
-        )
-        if row and row.get("value"):
-            return row["value"]
-    except Exception:
-        pass
-    return None
+    from app.lib.api_keys import resolve_api_key
+    user_id = getattr(context, "user_id", None)
+    org_id = getattr(context, "org_id", None)
+    return resolve_api_key("hunter_io_api_key", user_id=user_id, org_id=org_id)
 
 
 class HunterIoNode:
@@ -78,7 +76,7 @@ class HunterIoNode:
     async def execute(
         self, config: dict, inputs: list[dict], context: RunContext
     ) -> list[dict]:
-        api_key = _resolve_api_key(config.get("api_key"))
+        api_key = _resolve_api_key(config.get("api_key"), context)
         if not api_key:
             log.warning("hunter_io: no API key configured")
             return [

--- a/app/pipeline/nodes/whois_lookup.py
+++ b/app/pipeline/nodes/whois_lookup.py
@@ -18,24 +18,21 @@ _WHOIS_JSON_URL = "https://www.whoisxmlapi.com/whoisserver/WhoisService"
 _WHOIS_FREE_URL = "https://api.whois.vu/"
 
 
-def _resolve_api_key(config_key: str | None = None) -> str | None:
-    """Return WHOISXML API key if configured; None falls back to free endpoint."""
-    import os
+def _resolve_api_key(
+    config_key: str | None = None,
+    context: "RunContext | None" = None,
+) -> str | None:
+    """Return WHOISXML API key if configured; None falls back to free endpoint.
+
+    Resolution order: user-scoped vault → org-scoped vault → global vault →
+    core_settings → WHOISXML_API_KEY env var.  The resolved value is never logged.
+    """
     if config_key:
         return config_key
-    key = os.getenv("WHOISXML_API_KEY")
-    if key:
-        return key
-    try:
-        from app.routers.v3.db import fetch_one
-        row = fetch_one(
-            "SELECT value FROM core_settings WHERE key = 'whoisxml_api_key'", ()
-        )
-        if row and row.get("value"):
-            return row["value"]
-    except Exception:
-        pass
-    return None
+    from app.lib.api_keys import resolve_api_key
+    user_id = getattr(context, "user_id", None)
+    org_id = getattr(context, "org_id", None)
+    return resolve_api_key("whoisxml_api_key", user_id=user_id, org_id=org_id)
 
 
 class WhoisLookupNode:
@@ -61,7 +58,7 @@ class WhoisLookupNode:
     async def execute(
         self, config: dict, inputs: list[dict], context: RunContext
     ) -> list[dict]:
-        api_key = _resolve_api_key(config.get("api_key"))
+        api_key = _resolve_api_key(config.get("api_key"), context)
         loop = asyncio.get_running_loop()
         results: list[dict] = []
 

--- a/app/pipeline/runners/scoped_brain.py
+++ b/app/pipeline/runners/scoped_brain.py
@@ -509,6 +509,8 @@ async def scoped_brain_runner(
     run_id: str = "",
     slot_idx: int = 0,
     on_failure: Callable[[BrainFailure], None] | None = None,
+    run_user_id: str | None = None,
+    run_org_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Spawn ONE Claude Code subprocess scoped to this tactician's unit_of_work.
 
@@ -521,6 +523,10 @@ async def scoped_brain_runner(
         event_emit:       Async callable for pushing WS events.
         run_id:           Run ID for event correlation.
         slot_idx:         Hypothesis slot index for event correlation.
+        run_user_id:      Non-secret user UUID forwarded to MCP calls for vault
+                          scoping. NEVER a decrypted key value.
+        run_org_id:       Non-secret org UUID forwarded to MCP calls for vault
+                          scoping. NEVER a decrypted key value.
 
     Returns:
         list of TaskSpec-compatible dicts (technique_id + params_template).
@@ -569,6 +575,18 @@ async def scoped_brain_runner(
         if _creds_file.exists() and _creds_file.stat().st_size > 0:
             spawn_env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
             spawn_env.pop("CLAUDE_CODE_OAUTH_REFRESH_TOKEN", None)
+
+    # Thread non-secret user/org IDs into the subprocess env so the MCP client
+    # can forward them as X-Caller-User-Id / X-Caller-Org-Id headers on every
+    # api_call. NEVER put decrypted key values here — only opaque UUID strings.
+    if run_user_id:
+        spawn_env["IS_RUN_USER_ID"] = run_user_id
+    else:
+        spawn_env.pop("IS_RUN_USER_ID", None)
+    if run_org_id:
+        spawn_env["IS_RUN_ORG_ID"] = run_org_id
+    else:
+        spawn_env.pop("IS_RUN_ORG_ID", None)
 
     log.info(
         "scoped_brain: spawning subprocess tactic=%s slot=%d model=%s",

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -952,7 +952,10 @@ CREATE TABLE IF NOT EXISTS api_key_vault (
     value_encrypted TEXT NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE (key_name, scope, owner_id)
+    -- NULLS NOT DISTINCT (PG15+) so global rows (owner_id IS NULL) collide on
+    -- (key_name, scope) — otherwise NULL≠NULL means ON CONFLICT never fires and
+    -- re-upserting a global key inserts a duplicate instead of updating it.
+    UNIQUE NULLS NOT DISTINCT (key_name, scope, owner_id)
 );
 CREATE INDEX IF NOT EXISTS idx_api_key_vault_lookup
     ON api_key_vault (key_name, scope, owner_id)

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -943,6 +943,22 @@ CREATE INDEX IF NOT EXISTS ix_agent_sessions_user_org   ON agent_sessions (user_
 """
 
 
+_MIGRATION_API_KEY_VAULT = """
+CREATE TABLE IF NOT EXISTS api_key_vault (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key_name        TEXT NOT NULL,
+    scope           TEXT NOT NULL CHECK (scope IN ('user', 'org', 'global')),
+    owner_id        UUID,
+    value_encrypted TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (key_name, scope, owner_id)
+);
+CREATE INDEX IF NOT EXISTS idx_api_key_vault_lookup
+    ON api_key_vault (key_name, scope, owner_id)
+"""
+
+
 def _split_sql_statements(sql: str) -> list[str]:
     """Split SQL on ';' but respect string literals and dollar-quoted blocks.
 
@@ -1050,7 +1066,7 @@ def _split_sql_statements(sql: str) -> list[str]:
 def run_migrations() -> None:
     # Ensure each migration block ends with ';' so concatenation doesn't merge
     # the last statement of one block with the first of the next.
-    parts = [_MIGRATION, _SEED, _MIGRATION_WALLET_V2, _MIGRATION_FINDINGS_GRADES, _MIGRATION_SHARE_LINKS, _MIGRATION_SAVED_TEMPLATES, _MIGRATION_WORKING_MEMORY, _MIGRATION_ORG_TENANCY]
+    parts = [_MIGRATION, _SEED, _MIGRATION_WALLET_V2, _MIGRATION_FINDINGS_GRADES, _MIGRATION_SHARE_LINKS, _MIGRATION_SAVED_TEMPLATES, _MIGRATION_WORKING_MEMORY, _MIGRATION_ORG_TENANCY, _MIGRATION_API_KEY_VAULT]
     all_sql = "\n".join(p.rstrip().rstrip(";") + ";\n" for p in parts)
     statements = _split_sql_statements(all_sql)
     with get_conn() as conn:

--- a/app/routers/v3/nodes_api.py
+++ b/app/routers/v3/nodes_api.py
@@ -91,6 +91,10 @@ async def execute_node(
     """
     caller_identity: str = request.headers.get("X-Caller-Identity", "unknown")
     session_id: str | None = request.headers.get("X-Session-Id")
+    # Non-secret user/org IDs threaded from the brain subprocess via env vars
+    # forwarded as headers by the MCP server.  Never carry decrypted key values.
+    caller_user_id: str | None = request.headers.get("X-Caller-User-Id") or None
+    caller_org_id: str | None = request.headers.get("X-Caller-Org-Id") or None
     call_id = str(uuid.uuid4())
 
     node = _get_node(node_type)
@@ -101,9 +105,10 @@ async def execute_node(
     inputs = _wrap_payload_as_input(inputs, body)
 
     ctx = RunContext(
-        user_id="mcp-system",
+        user_id=caller_user_id or "mcp-system",
         run_id="mcp-adhoc",
         node_id="mcp-adhoc",
+        org_id=caller_org_id,
     )
 
     # --- observability: record call start (non-fatal) ---
@@ -200,6 +205,7 @@ async def execute_node(
 async def tool_invoke_node(
     node_type: str,
     body: dict,
+    request: Request,
     _key: str = Depends(require_api_key),
 ) -> dict:
     """Invoke a ToolCallable node directly with LLM-provided params.
@@ -207,6 +213,9 @@ async def tool_invoke_node(
     Only nodes that implement the ``ToolCallable`` protocol (datastores such as
     obsidian_vault and local_files) support this endpoint.
     """
+    caller_user_id: str | None = request.headers.get("X-Caller-User-Id") or None
+    caller_org_id: str | None = request.headers.get("X-Caller-Org-Id") or None
+
     node = _get_node(node_type)
 
     if not hasattr(node, "tool_invoke"):
@@ -216,9 +225,10 @@ async def tool_invoke_node(
         )
 
     ctx = RunContext(
-        user_id="mcp-system",
+        user_id=caller_user_id or "mcp-system",
         run_id="mcp-adhoc",
         node_id="mcp-adhoc",
+        org_id=caller_org_id,
     )
 
     try:

--- a/app/routers/v3/settings.py
+++ b/app/routers/v3/settings.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 
 from app.crypto import decrypt_value, encrypt_value
 from app.modes.loader import get_default_mode_id
@@ -8,6 +11,8 @@ from app.routers.v3.auth import get_current_user, require_admin
 from app.routers.v3.db import execute, fetch_all, fetch_one
 from app.routers.v3.models import CoreSettingIn, CoreSettingsOut, DefaultModeIn, DefaultModeOut
 from app.routers.v3.preflight import valid_preflight_mode_ids
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v3/settings", tags=["v3-settings"])
 
@@ -158,3 +163,122 @@ def put_default_mode(
             )
 
     return get_default_mode(user=user)
+
+
+# ---------------------------------------------------------------------------
+# API-key vault endpoints
+# ---------------------------------------------------------------------------
+
+
+class ApiKeyIn(BaseModel):
+    key_name: str
+    value: str
+    scope: str  # 'user' | 'org' | 'global'
+
+
+class ApiKeyEntry(BaseModel):
+    key_name: str
+    scope: str
+    owner_id: str | None
+
+
+@router.post("/api-keys", status_code=204)
+def upsert_api_key(body: ApiKeyIn, user: dict = Depends(get_current_user)) -> None:
+    """Store or update an API key in the encrypted vault.
+
+    Authorization:
+    - scope='user'   → the calling user's own entry (no elevation needed)
+    - scope='org'    → requires org-admin role
+    - scope='global' → requires is_admin
+
+    The value is Fernet-encrypted before storage and is NEVER returned in any
+    response — GET /v3/settings/api-keys returns presence only.
+    """
+    from app.lib.secret_box import encrypt
+
+    scope = body.scope
+    if scope not in ("user", "org", "global"):
+        raise HTTPException(status_code=400, detail="scope must be 'user', 'org', or 'global'")
+
+    if scope == "global":
+        if not user.get("is_admin"):
+            raise HTTPException(status_code=403, detail="Global scope requires admin")
+        owner_id = None
+    elif scope == "org":
+        if user.get("role") != "admin":
+            raise HTTPException(status_code=403, detail="Org scope requires org-admin role")
+        if not user.get("org_id"):
+            raise HTTPException(status_code=400, detail="User has no org")
+        owner_id = str(user["org_id"])
+    else:  # user
+        owner_id = str(user["id"])
+
+    encrypted = encrypt(body.value)
+
+    if owner_id is None:
+        execute(
+            """
+            INSERT INTO api_key_vault (key_name, scope, owner_id, value_encrypted, updated_at)
+            VALUES (%s, %s, NULL, %s, now())
+            ON CONFLICT (key_name, scope, owner_id) DO UPDATE
+            SET value_encrypted = EXCLUDED.value_encrypted, updated_at = now()
+            """,
+            (body.key_name, scope, encrypted),
+        )
+    else:
+        execute(
+            """
+            INSERT INTO api_key_vault (key_name, scope, owner_id, value_encrypted, updated_at)
+            VALUES (%s, %s, %s::uuid, %s, now())
+            ON CONFLICT (key_name, scope, owner_id) DO UPDATE
+            SET value_encrypted = EXCLUDED.value_encrypted, updated_at = now()
+            """,
+            (body.key_name, scope, owner_id, encrypted),
+        )
+
+    # For global scope also mirror into core_settings so legacy resolvers still work
+    if scope == "global":
+        from app.crypto import encrypt_value as _enc
+        execute(
+            """
+            INSERT INTO core_settings (key, value, is_secret)
+            VALUES (%s, %s, true)
+            ON CONFLICT (key) DO UPDATE
+            SET value = EXCLUDED.value, is_secret = true, updated_at = now()
+            """,
+            (body.key_name, _enc(body.value)),
+        )
+
+    # Log only the key name and scope — never the value.
+    log.info(
+        "api_keys: upserted key_name=%r scope=%r owner_id=%r by user=%r",
+        body.key_name, scope, owner_id, str(user.get("id")),
+    )
+
+
+@router.get("/api-keys", response_model=list[ApiKeyEntry])
+def list_api_keys(user: dict = Depends(get_current_user)) -> list[ApiKeyEntry]:
+    """List configured API key names and their scopes.
+
+    Returns presence info only — encrypted values are NEVER included in the response.
+    Each caller sees:
+    - Their own user-scoped entries
+    - Org-scoped entries for their org (if they have one)
+    - All global entries (visible to everyone; admin-only write)
+    """
+    user_id = str(user["id"])
+    org_id = str(user["org_id"]) if user.get("org_id") else None
+
+    rows = fetch_all(
+        """
+        SELECT key_name, scope, owner_id::text AS owner_id
+          FROM api_key_vault
+         WHERE
+            (scope = 'global' AND owner_id IS NULL)
+            OR (scope = 'user'   AND owner_id = %s::uuid)
+            OR (scope = 'org'    AND owner_id = %s::uuid AND %s IS NOT NULL)
+         ORDER BY scope, key_name
+        """,
+        (user_id, org_id or user_id, org_id),
+    )
+    return [ApiKeyEntry(**r) for r in rows]

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -17,6 +17,13 @@ _CALLER_IDENTITY = os.getenv("MCP_CALLER_IDENTITY", "mcp-server")
 _SESSION_ID: str | None = None
 _MCP_SECRET = os.environ.get("MCP_SIGNING_SECRET", "")
 
+# Non-secret user/org IDs — set by scoped_brain.py in the subprocess spawn_env.
+# Forwarded as HTTP headers on every api_call so the API layer can resolve
+# user-scoped and org-scoped API keys from the vault.  Values are opaque UUIDs;
+# decrypted key values NEVER enter the subprocess env or the MCP client.
+_RUN_USER_ID: str | None = os.environ.get("IS_RUN_USER_ID") or None
+_RUN_ORG_ID: str | None = os.environ.get("IS_RUN_ORG_ID") or None
+
 
 def _sign_request(body: bytes) -> dict[str, str]:
     """Return HMAC-SHA256 signing headers. No-op if MCP_SIGNING_SECRET not set."""
@@ -57,6 +64,10 @@ async def api_call(method: str, path: str, **kwargs) -> dict:
         }
         if _SESSION_ID:
             headers["X-Session-Id"] = _SESSION_ID
+        if _RUN_USER_ID:
+            headers["X-Caller-User-Id"] = _RUN_USER_ID
+        if _RUN_ORG_ID:
+            headers["X-Caller-Org-Id"] = _RUN_ORG_ID
         resp = await client.request(method, path, headers=headers, **kwargs)
         resp.raise_for_status()
         return resp.json()

--- a/tests/test_api_key_vault.py
+++ b/tests/test_api_key_vault.py
@@ -285,6 +285,44 @@ def test_vault_upsert_and_resolve():
 
 
 @pytest.mark.skipif(not _HAS_DB, reason="requires POSTGRES_HOST")
+def test_global_reupsert_updates_not_duplicates():
+    """Re-upserting a GLOBAL key (owner_id IS NULL) must UPDATE the existing row,
+    not insert a duplicate. Requires UNIQUE NULLS NOT DISTINCT — otherwise NULL≠NULL
+    means ON CONFLICT never fires and global key rotation silently fails."""
+    from app.routers.v3.db import execute, fetch_all
+    from app.lib.secret_box import encrypt
+    from app.lib.api_keys import resolve_api_key
+
+    import uuid
+    key_name = f"test_global_{uuid.uuid4().hex[:8]}"
+
+    def _upsert(value: str) -> None:
+        execute(
+            """INSERT INTO api_key_vault (key_name, scope, owner_id, value_encrypted)
+               VALUES (%s, 'global', NULL, %s)
+               ON CONFLICT (key_name, scope, owner_id) DO UPDATE
+               SET value_encrypted = EXCLUDED.value_encrypted""",
+            (key_name, encrypt(value)),
+        )
+
+    try:
+        _upsert("first-value")
+        _upsert("rotated-value")  # second upsert must UPDATE, not duplicate
+
+        rows = fetch_all(
+            "SELECT id FROM api_key_vault WHERE key_name = %s AND scope = 'global'",
+            (key_name,),
+        )
+        assert len(rows) == 1, f"expected 1 global row after re-upsert, got {len(rows)}"
+        assert resolve_api_key(key_name, user_id=None, org_id=None) == "rotated-value"
+    finally:
+        execute(
+            "DELETE FROM api_key_vault WHERE key_name = %s AND scope = 'global'",
+            (key_name,),
+        )
+
+
+@pytest.mark.skipif(not _HAS_DB, reason="requires POSTGRES_HOST")
 def test_vault_migration_creates_table():
     """run_migrations() must create api_key_vault with the correct columns."""
     from app.routers.v3.db import fetch_one

--- a/tests/test_api_key_vault.py
+++ b/tests/test_api_key_vault.py
@@ -1,0 +1,300 @@
+"""Tests for the scoped API-key vault (Phase 1).
+
+Most tests run without a real DB by monkeypatching the DB fetch functions.
+DB-integration tests are skipped when POSTGRES_HOST is not set.
+"""
+from __future__ import annotations
+
+import os
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# secret_box tests
+# ---------------------------------------------------------------------------
+
+
+def test_encrypt_decrypt_roundtrip():
+    """Fernet round-trip with the dev key."""
+    from app.lib.secret_box import decrypt, encrypt
+
+    plaintext = "super-secret-api-key-12345"
+    token = encrypt(plaintext)
+    assert isinstance(token, str)
+    assert token != plaintext
+    assert decrypt(token) == plaintext
+
+
+def test_decrypt_invalid_token_raises():
+    from app.lib.secret_box import decrypt
+
+    with pytest.raises(ValueError, match="vault decrypt failed"):
+        decrypt("not-a-valid-fernet-token")
+
+
+def test_dev_key_warning_emitted(caplog):
+    """Dev fallback MUST log a LOUD warning so it can't be silent in prod."""
+    import app.lib.secret_box as sb
+
+    # Reset warning flag so it fires again
+    sb._warned_dev_key = False
+    with caplog.at_level("WARNING", logger="app.lib.secret_box"):
+        sb._get_fernet_key()
+    assert any("VAULT_ENCRYPTION_KEY" in r.message for r in caplog.records)
+
+
+def test_custom_vault_key_no_warning(monkeypatch, caplog):
+    """When VAULT_ENCRYPTION_KEY is set, no dev-key warning should be emitted."""
+    import app.lib.secret_box as sb
+    from cryptography.fernet import Fernet
+
+    real_key = Fernet.generate_key().decode()
+    monkeypatch.setenv("VAULT_ENCRYPTION_KEY", real_key)
+    sb._warned_dev_key = False
+    with caplog.at_level("WARNING", logger="app.lib.secret_box"):
+        sb._get_fernet_key()
+    assert not any("VAULT_ENCRYPTION_KEY" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# api_keys resolution tests (no real DB)
+# ---------------------------------------------------------------------------
+
+
+def test_user_scope_wins(monkeypatch):
+    """User-scoped vault entry resolves before org / global / env."""
+    from app.lib.secret_box import encrypt
+
+    encrypted = encrypt("user-key")
+    monkeypatch.setattr(
+        "app.routers.v3.db.fetch_one",
+        lambda q, p: {"value_encrypted": encrypted} if "owner_id = %s::uuid" in q and "scope = %s" in q else None,
+    )
+    from app.lib.api_keys import resolve_api_key
+
+    result = resolve_api_key("some_api_key", user_id="user-uuid", org_id="org-uuid")
+    assert result == "user-key"
+
+
+def test_org_scope_when_no_user_row(monkeypatch):
+    """Falls through to org scope when no user-scoped row exists."""
+    from app.lib.secret_box import encrypt
+
+    encrypted = encrypt("org-key")
+
+    call_count = {"n": 0}
+
+    def fake_fetch(q, p):
+        call_count["n"] += 1
+        # First call: user-scoped → None; second call: org-scoped → row
+        if call_count["n"] == 1:
+            return None
+        return {"value_encrypted": encrypted}
+
+    monkeypatch.setattr("app.routers.v3.db.fetch_one", fake_fetch)
+    from app.lib.api_keys import resolve_api_key
+
+    result = resolve_api_key("some_api_key", user_id="user-uuid", org_id="org-uuid")
+    assert result == "org-key"
+
+
+def test_env_fallback(monkeypatch):
+    """Falls through to env var when vault and core_settings have nothing."""
+    monkeypatch.setattr("app.routers.v3.db.fetch_one", lambda q, p: None)
+    monkeypatch.setenv("SOME_API_KEY", "env-value")
+    from app.lib.api_keys import resolve_api_key
+
+    result = resolve_api_key("some_api_key", user_id=None, org_id=None)
+    assert result == "env-value"
+
+
+def test_none_returned_when_nothing_configured(monkeypatch):
+    """Returns None when key is not in vault, core_settings, or env."""
+    monkeypatch.setattr("app.routers.v3.db.fetch_one", lambda q, p: None)
+    from app.lib.api_keys import resolve_api_key
+
+    result = resolve_api_key("no_such_key_xyz", user_id=None, org_id=None)
+    assert result is None
+
+
+def test_mcp_system_user_skips_user_vault(monkeypatch):
+    """mcp-system pseudo-user should not attempt a user-scoped vault lookup."""
+    called = {"user_lookup": False}
+
+    def fake_fetch(q, p):
+        if "owner_id = %s::uuid" in q:
+            called["user_lookup"] = True
+        return None
+
+    monkeypatch.setattr("app.routers.v3.db.fetch_one", fake_fetch)
+    monkeypatch.setenv("SOME_API_KEY", "fallback")
+
+    from app.lib.api_keys import resolve_api_key
+
+    resolve_api_key("some_api_key", user_id="mcp-system", org_id=None)
+    assert not called["user_lookup"], "mcp-system should not trigger user-vault lookup"
+
+
+# ---------------------------------------------------------------------------
+# RunContext org_id field test
+# ---------------------------------------------------------------------------
+
+
+def test_run_context_org_id_field():
+    """RunContext must carry org_id; defaults to None."""
+    from app.pipeline.nodes.base import RunContext
+
+    ctx = RunContext(user_id="u1", run_id="r1", node_id="n1")
+    assert ctx.org_id is None
+
+    ctx2 = RunContext(user_id="u1", run_id="r1", node_id="n1", org_id="org-123")
+    assert ctx2.org_id == "org-123"
+
+
+# ---------------------------------------------------------------------------
+# nodes_api header threading test
+# ---------------------------------------------------------------------------
+
+
+def _make_nodes_test_app(monkeypatch, captured_ctx: dict):
+    """Build a minimal FastAPI app that mounts the nodes_api router with a fake node."""
+    from fastapi import FastAPI
+
+    class FakeNode:
+        node_type = "fake"
+        display_name = "Fake"
+        category = "source"
+        config_schema = {}
+
+        async def execute(self, config, inputs, context):
+            captured_ctx["user_id"] = context.user_id
+            captured_ctx["org_id"] = context.org_id
+            return []
+
+    monkeypatch.setattr("app.pipeline.nodes.NodeRegistry.get", lambda nt: FakeNode())
+    monkeypatch.setattr("app.pipeline.nodes.NodeRegistry.auto_discover", lambda: None)
+
+    # Patch async tracker + push_event with coroutine stubs
+    async def _anoop(*a, **kw):
+        return None
+
+    monkeypatch.setattr("app.routers.v3.nodes_api.tracker.start_session", _anoop)
+    monkeypatch.setattr("app.routers.v3.nodes_api.tracker.log_call_start", _anoop)
+    monkeypatch.setattr("app.routers.v3.nodes_api.tracker.log_call_complete", _anoop)
+    monkeypatch.setattr("app.routers.v3.nodes_api.push_event", _anoop)
+    monkeypatch.setenv("INFO_BROKER_API_KEY", "test-key")
+
+    from app.routers.v3.nodes_api import router as nodes_router
+
+    mini_app = FastAPI()
+    mini_app.include_router(nodes_router)
+    return mini_app
+
+
+def test_execute_node_populates_run_context_from_headers(monkeypatch):
+    """execute_node must pass X-Caller-User-Id / X-Caller-Org-Id to RunContext."""
+    from fastapi.testclient import TestClient
+
+    captured_ctx: dict = {}
+    mini_app = _make_nodes_test_app(monkeypatch, captured_ctx)
+
+    client = TestClient(mini_app)
+    resp = client.post(
+        "/v3/nodes/fake/execute",
+        json={},
+        headers={
+            "X-API-Key": "test-key",
+            "X-Caller-User-Id": "test-user-uuid",
+            "X-Caller-Org-Id": "test-org-uuid",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured_ctx.get("user_id") == "test-user-uuid"
+    assert captured_ctx.get("org_id") == "test-org-uuid"
+
+
+def test_execute_node_defaults_to_mcp_system_without_headers(monkeypatch):
+    """execute_node defaults user_id to 'mcp-system' when no headers provided."""
+    from fastapi.testclient import TestClient
+
+    captured_ctx: dict = {}
+    mini_app = _make_nodes_test_app(monkeypatch, captured_ctx)
+
+    client = TestClient(mini_app)
+    resp = client.post(
+        "/v3/nodes/fake/execute",
+        json={},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured_ctx.get("user_id") == "mcp-system"
+    assert captured_ctx.get("org_id") is None
+
+
+# ---------------------------------------------------------------------------
+# ApiKeyEntry response model — presence only (no value field)
+# ---------------------------------------------------------------------------
+
+
+def test_get_api_keys_never_returns_value():
+    """ApiKeyEntry model MUST NOT have a 'value' or 'value_encrypted' field."""
+    from app.routers.v3.settings import ApiKeyEntry
+
+    fields = set(ApiKeyEntry.model_fields.keys())
+    assert "value" not in fields, "ApiKeyEntry must not expose value"
+    assert "value_encrypted" not in fields, "ApiKeyEntry must not expose value_encrypted"
+    assert "key_name" in fields
+    assert "scope" in fields
+
+
+# ---------------------------------------------------------------------------
+# DB integration tests (skipped without POSTGRES_HOST)
+# ---------------------------------------------------------------------------
+
+_HAS_DB = bool(os.getenv("POSTGRES_HOST"))
+
+
+@pytest.mark.skipif(not _HAS_DB, reason="requires POSTGRES_HOST")
+def test_vault_upsert_and_resolve():
+    """Round-trip: store a key via execute(), resolve via resolve_api_key()."""
+    from app.routers.v3.db import execute, fetch_one
+    from app.lib.secret_box import encrypt
+    from app.lib.api_keys import resolve_api_key
+
+    import uuid
+    test_user = str(uuid.uuid4())
+    key_name = f"test_key_{test_user[:8]}"
+    plaintext = "integration-test-value"
+
+    execute(
+        """INSERT INTO api_key_vault (key_name, scope, owner_id, value_encrypted)
+           VALUES (%s, 'user', %s::uuid, %s)
+           ON CONFLICT (key_name, scope, owner_id) DO UPDATE
+           SET value_encrypted = EXCLUDED.value_encrypted""",
+        (key_name, test_user, encrypt(plaintext)),
+    )
+
+    resolved = resolve_api_key(key_name, user_id=test_user, org_id=None)
+    assert resolved == plaintext
+
+    # Cleanup
+    execute(
+        "DELETE FROM api_key_vault WHERE key_name = %s AND owner_id = %s::uuid",
+        (key_name, test_user),
+    )
+
+
+@pytest.mark.skipif(not _HAS_DB, reason="requires POSTGRES_HOST")
+def test_vault_migration_creates_table():
+    """run_migrations() must create api_key_vault with the correct columns."""
+    from app.routers.v3.db import fetch_one
+
+    row = fetch_one(
+        """
+        SELECT column_name
+          FROM information_schema.columns
+         WHERE table_name = 'api_key_vault' AND column_name = 'value_encrypted'
+        """,
+        (),
+    )
+    assert row is not None, "api_key_vault.value_encrypted column not found"


### PR DESCRIPTION
## Summary

- **Encrypted vault table**: new `api_key_vault` DB table (scope: user/org/global, Fernet-encrypted values, idempotent migration in `db.py`)
- **Resolution helper** (`app/lib/api_keys.py`): user → org → global vault → core_settings → env var; NEVER logs decrypted values, only key_name + source
- **Fernet encryption** (`app/lib/secret_box.py`): `VAULT_ENCRYPTION_KEY` env var (32-byte URL-safe base64); loud WARN if using dev fallback
- **Settings endpoints**: `POST /v3/settings/api-keys` (encrypted write, auth-gated per scope) + `GET /v3/settings/api-keys` (presence only, no values)
- **Header threading**: `X-Caller-User-Id` / `X-Caller-Org-Id` non-secret UUIDs forwarded MCP client → API → `RunContext.org_id`; `scoped_brain_runner` gets `run_user_id`/`run_org_id` params and sets `IS_RUN_USER_ID`/`IS_RUN_ORG_ID` in subprocess env
- **Node integration**: apollo_zoominfo, hunter_io, whois_lookup now resolve via vault before falling back to env

## Security invariants upheld

- Decrypted key values stay server-side (node-execute path only)
- Never logged, never in WS payloads, never in HTTP responses
- Only opaque non-secret user_id/org_id UUIDs cross the subprocess boundary
- GET endpoint returns `ApiKeyEntry` model with no `value` or `value_encrypted` field

## Test plan

- [ ] 13 non-DB unit tests pass (`tests/test_api_key_vault.py`: encryption roundtrip, resolution order, mcp-system bypass, RunContext field, nodes_api header threading, presence-only model)
- [ ] 2 DB integration tests skip cleanly without `POSTGRES_HOST`
- [ ] All ruff checks pass on modified files
- [ ] Run `POST /v3/settings/api-keys` with scope=user, verify resolved value appears in node execution
- [ ] Verify GET never returns `value` field
- [ ] Verify global scope mirrors to core_settings for backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)