### PR TITLE
feat(keys): Phase 2 — pre-run missing-key decision gate (#75)

### DIFF
--- a/app/pipeline/catalogs/technique_keys.py
+++ b/app/pipeline/catalogs/technique_keys.py
@@ -1,0 +1,160 @@
+"""Technique → API-key metadata + pre-run missing-key detection (Phase 2, #75).
+
+This is the data + logic behind the pre-run missing-key decision gate. Given a
+strategy_id, it enumerates the techniques the strategy will prefer, looks up
+which of those require an API key, and checks the encrypted vault
+(:func:`app.lib.api_keys.resolve_api_key`) to find which keys are NOT yet
+configured for the calling user/org.
+
+Design notes
+------------
+- Enumeration is *precise*: only techniques reachable via each phase's explicit
+  ``preferred_tactic_id`` (plus that tactic's ``required_techniques``) are
+  considered. We deliberately do NOT scan every phase-compatible tactic, because
+  the leads-enrichment tactic is compatible with the generic ``gather`` phase and
+  would otherwise surface enrichment keys for unrelated strategies (e.g.
+  generic_search) that will never call those tools.
+- Techniques NOT present in :data:`TECHNIQUE_KEY_META` are treated as needing no
+  key (e.g. ``web_search``, ``opencorporates_owner``, ``phone_osint`` are free).
+- SECURITY: this module only ever handles key *names* and public setup metadata.
+  It never returns, logs, or transmits a decrypted key value. The only signal it
+  reads from the vault is presence (resolve returns a value vs. None).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from app.pipeline.catalogs.loader import load_catalog
+
+log = logging.getLogger(__name__)
+
+_CATALOG_BASE = Path(__file__).resolve().parent / "registries"
+
+# technique_id → public metadata for the key it needs. key_name follows the
+# lowercase-snake_case convention the nodes use with resolve_api_key().
+TECHNIQUE_KEY_META: dict[str, dict[str, str]] = {
+    "hunter_email_search": {
+        "key_name": "hunter_io_api_key",
+        "display_name": "Hunter.io (email finder)",
+        "setup_url": "https://hunter.io/api-keys",
+        "setup_instructions": (
+            "Create a free Hunter.io account, open Dashboard → API, and copy the "
+            "API key. The free tier allows 25 searches/month."
+        ),
+    },
+    "apollo_contact": {
+        "key_name": "apollo_api_key",
+        "display_name": "Apollo.io (contact enrichment)",
+        "setup_url": "https://developer.apollo.io/keys/",
+        "setup_instructions": (
+            "Sign in to Apollo.io, go to Settings → Integrations → API, and "
+            "generate an API key. A free plan is available."
+        ),
+    },
+    "whois_owner": {
+        "key_name": "whoisxml_api_key",
+        "display_name": "WhoisXML API (domain/owner lookup)",
+        "setup_url": "https://whois.whoisxmlapi.com/",
+        "setup_instructions": (
+            "Register at whoisxmlapi.com and copy your API key from the My "
+            "Products / API page. The free tier includes 500 lookups."
+        ),
+    },
+    "pipl_people": {
+        "key_name": "pipl_api_key",
+        "display_name": "Pipl (people search)",
+        "setup_url": "https://pipl.com/api",
+        "setup_instructions": (
+            "Request a Pipl API key from pipl.com/api (paid product) and paste "
+            "the key here."
+        ),
+    },
+    "apify_listings_search": {
+        "key_name": "apify_api_token",
+        "display_name": "Apify (Zillow / listings scraper)",
+        "setup_url": "https://console.apify.com/account/integrations",
+        "setup_instructions": (
+            "Create an Apify account, open Settings → Integrations, and copy your "
+            "Personal API token. The free plan includes monthly usage credits."
+        ),
+    },
+}
+
+
+def _enumerate_technique_ids(strategy_id: str) -> set[str]:
+    """Return the technique ids a strategy will prefer.
+
+    Walks each phase's ``preferred_tactic_id`` (and that tactic's
+    ``required_techniques``) only — see module docstring for why we don't scan
+    phase-compatible tactics. Returns an empty set for unknown strategies.
+    """
+    try:
+        strategies = load_catalog("strategy", _CATALOG_BASE / "strategies")
+        tactics = load_catalog("tactic", _CATALOG_BASE / "tactics")
+    except Exception:
+        log.warning("technique_keys: catalog load failed", exc_info=True)
+        return set()
+
+    strat = strategies.get(strategy_id)
+    if strat is None:
+        return set()
+
+    tech_ids: set[str] = set()
+    for phase in strat.phases:
+        tactic_id = getattr(phase, "preferred_tactic_id", None)
+        if not tactic_id:
+            continue
+        tactic = tactics.get(tactic_id)
+        if tactic is None:
+            continue
+        for task in tactic.produces:
+            tech_ids.add(task.technique_id)
+        tech_ids.update(getattr(tactic, "required_techniques", []) or [])
+    return tech_ids
+
+
+def check_missing_keys_for_strategy(
+    strategy_id: str,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+) -> list[dict[str, str]]:
+    """Return descriptors for key-requiring techniques whose key is NOT configured.
+
+    Resolution presence is checked via the scoped vault (user→org→global→
+    core_settings→env). De-duplicated by ``key_name`` so the same key is only
+    surfaced once even if multiple techniques share it. Never returns key values.
+    """
+    from app.lib.api_keys import resolve_api_key
+
+    technique_ids = _enumerate_technique_ids(strategy_id)
+    missing: list[dict[str, str]] = []
+    seen_keys: set[str] = set()
+
+    for tid in technique_ids:
+        meta = TECHNIQUE_KEY_META.get(tid)
+        if meta is None:
+            continue  # technique needs no key
+        key_name = meta["key_name"]
+        if key_name in seen_keys:
+            continue
+        try:
+            present = resolve_api_key(key_name, user_id=user_id, org_id=org_id) is not None
+        except Exception:
+            # A vault/db hiccup must not strand the run — treat as present
+            # (fail-open) so the gate never blocks on infrastructure errors.
+            log.debug("technique_keys: resolve failed key_name=%r", key_name, exc_info=True)
+            present = True
+        if not present:
+            seen_keys.add(key_name)
+            missing.append(
+                {
+                    "technique_id": tid,
+                    "key_name": key_name,
+                    "display_name": meta["display_name"],
+                    "setup_url": meta["setup_url"],
+                    "setup_instructions": meta["setup_instructions"],
+                }
+            )
+    return missing

--- a/app/routers/v3/preflight.py
+++ b/app/routers/v3/preflight.py
@@ -384,6 +384,27 @@ class PreflightConfirmIn(BaseModel):
     strategy_id: str
     # engine_v2: when True, engine_v2 is launched in the background after hold succeeds
     start_run: bool = False
+    # Phase 2 (#75): when True, skip the pre-run missing-key gate and launch even
+    # though some enrichment keys are unconfigured ("Proceed anyway"). Soft gate.
+    bypass_missing_keys: bool = False
+
+
+class MissingKeyToolOut(BaseModel):
+    technique_id: str
+    key_name: str
+    display_name: str
+    setup_url: str
+    setup_instructions: str
+
+
+class PreflightConfirmGateOut(BaseModel):
+    """Returned (in place of starting the run) when the chosen strategy needs API
+    keys that aren't configured. Carries only key NAMES + public setup info —
+    never a key value. The client may store a key then retry, or retry with
+    bypass_missing_keys=True."""
+    status: str = "missing_keys_gate"
+    run_id: str
+    missing_tools: list[MissingKeyToolOut]
 
 
 class PreflightConfirmOut(BaseModel):
@@ -616,6 +637,25 @@ async def preflight_confirm(body: PreflightConfirmIn, user: dict = Depends(get_c
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
+
+    # Phase 2 (#75): pre-run missing-key decision gate. Only relevant when we're
+    # about to launch (start_run) and the caller hasn't chosen to proceed anyway.
+    # Checked BEFORE the wallet hold so a gated (not-started) run strands no RU.
+    if body.start_run and not body.bypass_missing_keys:
+        from app.pipeline.catalogs.technique_keys import check_missing_keys_for_strategy
+        org_id = str(user["org_id"]) if user.get("org_id") else None
+        missing_tools = check_missing_keys_for_strategy(
+            body.strategy_id, user_id=uid, org_id=org_id
+        )
+        if missing_tools:
+            log.info(
+                "preflight: missing-key gate raised strategy=%s missing=%s",
+                body.strategy_id, [t["key_name"] for t in missing_tools],
+            )
+            return PreflightConfirmGateOut(
+                run_id=run_id,
+                missing_tools=[MissingKeyToolOut(**t) for t in missing_tools],
+            )
 
     est = estimate_run(body.strategy_id, envelope)
     p90 = est.estimated_ru_p90

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -811,3 +811,13 @@ export const getRunMetrics = (): Promise<RunMetrics> =>
       avg_duration_seconds: d.avg_latency_seconds ?? d.avg_duration_seconds ?? 0,
     } as RunMetrics
   })
+
+// POST /v3/settings/api-keys — store an API key in the encrypted vault (Phase 2,
+// #75). Used by the pre-run missing-key gate. The value is sent once and never
+// returned by any endpoint. scope: 'user' (default) | 'org' | 'global'.
+export const storeApiKey = (
+  key_name: string,
+  value: string,
+  scope: 'user' | 'org' | 'global' = 'user',
+): Promise<void> =>
+  api.post('/v3/settings/api-keys', { key_name, value, scope }).then(() => undefined)

--- a/frontend/src/components/preflight/MissingKeysGate.tsx
+++ b/frontend/src/components/preflight/MissingKeysGate.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react'
+import { storeApiKey } from '../../api/v3'
+import type { MissingKeyTool } from '../../hooks/usePreflight'
+
+interface Props {
+  /** Tools whose API key is not configured (from the /preflight/confirm gate). */
+  missingTools: MissingKeyTool[]
+  /** Called after a key is stored so the parent can re-issue confirm and refresh. */
+  onKeyStored: () => void
+  /** Called when the user chooses to run without configuring the missing keys. */
+  onProceedAnyway: () => void
+  /** Optional: parent is busy re-issuing confirm / launching. */
+  busy?: boolean
+}
+
+/**
+ * Phase 2 (#75) pre-run missing-key decision gate. Shown in place of starting a
+ * run when the chosen strategy needs API keys that aren't configured. Per tool:
+ * setup instructions + "Get API key" link + an inline key entry. A global
+ * "Proceed anyway" lets the run start without the keys (tools degrade
+ * gracefully). Key values are sent once to the encrypted vault and never echoed.
+ */
+export default function MissingKeysGate({ missingTools, onKeyStored, onProceedAnyway, busy }: Props) {
+  return (
+    <div
+      className="flex flex-col gap-3 p-4 rounded"
+      data-testid="missing-keys-gate"
+      style={{ background: 'var(--panel, #141414)', border: '1px solid var(--border, #333)' }}
+    >
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold" style={{ color: 'var(--text)' }}>
+          Some tools for this run need an API key
+        </span>
+        <span className="text-[11px]" style={{ color: 'var(--subtext)' }}>
+          Add a key to enable richer results (e.g. per-lead contact enrichment), or proceed without
+          them — the affected tools will be skipped and marked unavailable.
+        </span>
+      </div>
+
+      {missingTools.map((tool) => (
+        <MissingKeyCard key={tool.key_name} tool={tool} onStored={onKeyStored} />
+      ))}
+
+      <div className="flex items-center justify-end gap-3 pt-1">
+        <button
+          onClick={onProceedAnyway}
+          disabled={busy}
+          data-testid="missing-keys-proceed-anyway"
+          className="text-xs px-3 py-1.5 rounded"
+          style={{
+            background: 'var(--panel)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            cursor: busy ? 'not-allowed' : 'pointer',
+            opacity: busy ? 0.6 : 1,
+          }}
+        >
+          Proceed anyway
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function MissingKeyCard({ tool, onStored }: { tool: MissingKeyTool; onStored: () => void }) {
+  const [value, setValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const save = async () => {
+    if (!value.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      await storeApiKey(tool.key_name, value.trim(), 'user')
+      setSaved(true)
+      setValue('')
+      onStored()
+    } catch {
+      setError('Failed to save key. Check the value and try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-2 p-3 rounded"
+      data-testid={`missing-key-card-${tool.key_name}`}
+      style={{ background: 'var(--bg, #0f0f0f)', border: '1px solid var(--border, #333)' }}
+    >
+      <span className="text-xs font-medium" style={{ color: 'var(--text)' }}>
+        {tool.display_name}
+      </span>
+      <p className="text-[11px]" style={{ color: 'var(--subtext)' }}>
+        Requires API key: <code style={{ color: 'var(--text)' }}>{tool.key_name}</code>
+      </p>
+      {tool.setup_instructions && (
+        <p className="text-[11px]" style={{ color: 'var(--subtext)', lineHeight: 1.5 }}>
+          {tool.setup_instructions}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2 flex-wrap">
+        {tool.setup_url && (
+          <a
+            href={tool.setup_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px]"
+            data-testid={`missing-key-setup-url-${tool.key_name}`}
+            style={{ color: 'var(--accent)' }}
+          >
+            Get API key →
+          </a>
+        )}
+      </div>
+
+      {saved ? (
+        <span className="text-[11px]" style={{ color: '#34d399' }} data-testid={`missing-key-saved-${tool.key_name}`}>
+          ✓ Key saved
+        </span>
+      ) : (
+        <div className="flex items-center gap-2">
+          <input
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={`Paste ${tool.key_name}`}
+            data-testid={`missing-key-input-${tool.key_name}`}
+            autoComplete="off"
+            className="flex-1 text-[11px] px-2 py-1 rounded"
+            style={{ background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
+          />
+          <button
+            onClick={save}
+            disabled={saving || !value.trim()}
+            data-testid={`missing-key-save-${tool.key_name}`}
+            className="text-[11px] px-3 py-1 rounded"
+            style={{
+              background: 'var(--accent, #2563eb)',
+              color: '#fff',
+              border: 'none',
+              cursor: saving || !value.trim() ? 'not-allowed' : 'pointer',
+              opacity: saving || !value.trim() ? 0.6 : 1,
+            }}
+          >
+            {saving ? 'Saving…' : 'Save key'}
+          </button>
+        </div>
+      )}
+      {error && (
+        <span className="text-[11px]" style={{ color: '#f87171' }}>
+          {error}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/preflight/PreflightPanel.tsx
+++ b/frontend/src/components/preflight/PreflightPanel.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../api/client'
-import { usePreflight } from '../../hooks/usePreflight'
-import type { DialsIn, ModeEntry } from '../../hooks/usePreflight'
+import { usePreflight, isMissingKeysGate } from '../../hooks/usePreflight'
+import type { DialsIn, ModeEntry, PreflightGateResult } from '../../hooks/usePreflight'
+import MissingKeysGate from './MissingKeysGate'
 import { ModePicker } from './ModePicker'
 import { DialPicker } from './DialPicker'
 import { EstimateBreakdown } from './EstimateBreakdown'
@@ -153,6 +154,8 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
 
   const [showSaveDialog, setShowSaveDialog] = useState(false)
   const [showSaveCta, setShowSaveCta] = useState(false)
+  // Phase 2 (#75): pre-run missing-key gate payload, set when /confirm returns it.
+  const [missingGate, setMissingGate] = useState<PreflightGateResult | null>(null)
 
   const { templates, isLoading: templatesLoading, createTemplate, useTemplate } = useTemplates()
 
@@ -260,7 +263,7 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
   const showEstimateSkeleton = useDebouncedLoading(isLoading)
 
   // ---- confirm + run --------------------------------------------------------
-  async function handleRun() {
+  async function handleRun(bypassMissingKeys = false) {
     if (!estimate) return
     setConfirming(true)
     setShowSaveCta(false)
@@ -269,12 +272,19 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
       envelope: { speed, capability, resource, hypothesis_count: hypothesisCount, depth },
       strategy_id: strategy,
       start_run: true,
+      bypass_missing_keys: bypassMissingKeys,
     })
     setConfirming(false)
-    if (result) {
-      setShowSaveCta(true)
-      onConfirmed(result.run_id, result.hold_id)
+    if (!result) return
+    // Phase 2 (#75): the chosen strategy needs unconfigured keys — show the gate
+    // instead of starting. The user can add a key (then re-run) or proceed anyway.
+    if (isMissingKeysGate(result)) {
+      setMissingGate(result)
+      return
     }
+    setMissingGate(null)
+    setShowSaveCta(true)
+    onConfirmed(result.run_id, result.hold_id)
   }
 
   return (
@@ -579,6 +589,18 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
           </div>
         )}
 
+        {/* Phase 2 (#75): pre-run missing-key decision gate */}
+        {missingGate && (
+          <div style={{ marginBottom: 12 }}>
+            <MissingKeysGate
+              missingTools={missingGate.missing_tools}
+              onKeyStored={() => handleRun(false)}
+              onProceedAnyway={() => handleRun(true)}
+              busy={confirming}
+            />
+          </div>
+        )}
+
         {/* Action buttons */}
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
           <button
@@ -592,7 +614,7 @@ export function PreflightPanel({ query, onCancel, onConfirmed }: PreflightPanelP
             Cancel
           </button>
           <button
-            onClick={handleRun}
+            onClick={() => handleRun()}
             disabled={isLoading || confirming || !estimate}
             style={{
               padding: '4px 14px', borderRadius: 4, fontSize: 12,

--- a/frontend/src/hooks/usePreflight.ts
+++ b/frontend/src/hooks/usePreflight.ts
@@ -81,12 +81,38 @@ export interface PreflightConfirmIn {
   strategy_id: string
   /** When true, backend launches engine_v2 in the background after the wallet hold. */
   start_run?: boolean
+  /** Phase 2 (#75): skip the pre-run missing-key gate and launch anyway. */
+  bypass_missing_keys?: boolean
 }
 
 export interface PreflightConfirmResult {
   run_id: string
   hold_id: string
   held_ru: number
+}
+
+/** Phase 2 (#75): one missing-key tool descriptor (NEVER carries a key value). */
+export interface MissingKeyTool {
+  technique_id: string
+  key_name: string
+  display_name: string
+  setup_url: string
+  setup_instructions: string
+}
+
+/** Returned by /preflight/confirm instead of starting the run when the chosen
+ * strategy needs API keys that aren't configured. */
+export interface PreflightGateResult {
+  status: 'missing_keys_gate'
+  run_id: string
+  missing_tools: MissingKeyTool[]
+}
+
+export type ConfirmResult = PreflightConfirmResult | PreflightGateResult
+
+/** Type guard: did confirm return the missing-key gate (vs. a started run)? */
+export function isMissingKeysGate(r: ConfirmResult | null): r is PreflightGateResult {
+  return !!r && (r as PreflightGateResult).status === 'missing_keys_gate'
 }
 
 // ---------------------------------------------------------------------------
@@ -224,11 +250,11 @@ export function usePreflight() {
   // Confirm — place wallet hold
   // ---------------------------------------------------------------------------
 
-  const confirm = useCallback(async (input: PreflightConfirmIn): Promise<PreflightConfirmResult | null> => {
+  const confirm = useCallback(async (input: PreflightConfirmIn): Promise<ConfirmResult | null> => {
     setIsLoading(true)
     setError(null)
     try {
-      const { data } = await api.post<PreflightConfirmResult>('/v3/preflight/confirm', input)
+      const { data } = await api.post<ConfirmResult>('/v3/preflight/confirm', input)
       return data
     } catch (err: unknown) {
       const axiosErr = err as {

--- a/tests/pipeline/test_missing_keys.py
+++ b/tests/pipeline/test_missing_keys.py
@@ -1,0 +1,83 @@
+"""Tests for the pre-run missing-key gate logic (Phase 2, #75).
+
+Covers app/pipeline/catalogs/technique_keys.py: the technique→key map, strategy
+technique enumeration (precise, preferred-tactic-only), and the missing-key
+resolver. resolve_api_key is monkeypatched so no real vault/DB is needed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.pipeline.catalogs.technique_keys import (
+    TECHNIQUE_KEY_META,
+    _enumerate_technique_ids,
+    check_missing_keys_for_strategy,
+)
+
+
+def test_key_meta_shape_no_value_field():
+    """Each entry exposes only key NAME + public setup info — never a value."""
+    for tid, meta in TECHNIQUE_KEY_META.items():
+        assert set(meta) == {"key_name", "display_name", "setup_url", "setup_instructions"}, tid
+        assert "value" not in meta
+        assert meta["key_name"] and meta["key_name"].islower()
+
+
+def test_enumerate_real_estate_leads_includes_enrichment_techniques():
+    tids = _enumerate_technique_ids("real_estate_leads")
+    # leads_enrich_gather is the gather phase's preferred tactic
+    for expected in ("hunter_email_search", "apollo_contact", "whois_owner",
+                     "pipl_people", "apify_listings_search"):
+        assert expected in tids, f"{expected} missing from enumeration: {sorted(tids)}"
+
+
+def test_enumerate_unknown_strategy_is_empty():
+    assert _enumerate_technique_ids("no_such_strategy_xyz") == set()
+
+
+def test_missing_keys_when_none_configured(monkeypatch):
+    """All five key-requiring techniques surface (de-duped by key_name) when the
+    vault has nothing."""
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: None)
+    missing = check_missing_keys_for_strategy("real_estate_leads", user_id="u1", org_id=None)
+    key_names = {m["key_name"] for m in missing}
+    assert key_names == {"hunter_io_api_key", "apollo_api_key", "whoisxml_api_key",
+                         "pipl_api_key", "apify_api_token"}
+    # de-dup: one descriptor per key_name
+    assert len(missing) == len(key_names)
+    # never leaks a value
+    for m in missing:
+        assert "value" not in m
+
+
+def test_no_missing_when_all_keys_present(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: "configured")
+    assert check_missing_keys_for_strategy("real_estate_leads", user_id="u1", org_id="o1") == []
+
+
+def test_free_techniques_never_surface(monkeypatch):
+    """web_search / opencorporates_owner / phone_osint need no key and must never
+    appear in the gate even when nothing is configured."""
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: None)
+    missing = check_missing_keys_for_strategy("real_estate_leads", user_id="u1", org_id=None)
+    surfaced_techniques = {m["technique_id"] for m in missing}
+    for free in ("web_search", "opencorporates_owner", "phone_osint"):
+        assert free not in surfaced_techniques
+
+
+def test_generic_strategy_does_not_surface_enrichment_keys(monkeypatch):
+    """Precision guard: a strategy that does not prefer leads_enrich_gather must
+    NOT prompt for enrichment keys, even though that tactic is gather-compatible."""
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: None)
+    missing = check_missing_keys_for_strategy("generic_search", user_id="u1", org_id=None)
+    key_names = {m["key_name"] for m in missing}
+    assert "hunter_io_api_key" not in key_names
+    assert "apollo_api_key" not in key_names
+
+
+def test_resolve_failure_is_fail_open(monkeypatch):
+    """A vault/DB error must NOT strand the run — treat as present (no gate)."""
+    def boom(k, **kw):
+        raise RuntimeError("db down")
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", boom)
+    assert check_missing_keys_for_strategy("real_estate_leads", user_id="u1", org_id=None) == []


### PR DESCRIPTION
## What
Before launching a run, the confirm endpoint detects which techniques the chosen strategy will prefer that **require an API key** whose key isn't configured in the vault, and returns a **soft decision gate** (`status: "missing_keys_gate"`) instead of starting. The user can add a key (stored in the vault → re-run) or **proceed anyway**. Closes the `c5aff228` enrichment gap surfaced by the leads-gen benchmark (8–10 leads/query at 0% contact enrichment because keys were unset).

## Backend
- `app/pipeline/catalogs/technique_keys.py` — `TECHNIQUE_KEY_META` (hunter_io / apollo / whoisxml / pipl / apify) + `check_missing_keys_for_strategy()`. Enumerates techniques via each phase's **`preferred_tactic_id` only** (precise: won't prompt for enrichment keys on generic strategies even though `leads_enrich_gather` is gather-compatible). De-dups by `key_name`; **fail-open** on vault/db errors; never returns a key value.
- `preflight.py` confirm: added `bypass_missing_keys` flag + `MissingKeyToolOut`/`PreflightConfirmGateOut`; gate checked **before the wallet hold** so a gated (not-started) run strands no RU.

## Frontend
- `usePreflight.ts`: `ConfirmResult` union + `isMissingKeysGate` guard + `bypass_missing_keys`.
- `api/v3.storeApiKey()`; new `MissingKeysGate.tsx` (per-tool setup link + instructions + inline password key entry + "Proceed anyway"), wired into `PreflightPanel` (`handleRun(bypass?)`).

## Security (load-bearing)
Gate payload carries only `key_name` + public setup info — **never a key value**. Key values go only to the existing encrypted `POST /v3/settings/api-keys`. Keys never reach the brain. SQL parameterized; no S608 silenced.

## Tests
- 8 unit (`tests/pipeline/test_missing_keys.py`) + 126 backend regression (preflight/settings/vault) green; frontend `tsc --noEmit` clean.
- **Real-stack** (rebuilt image, live API):

**Gate fires** (real_estate_leads, no keys) → 5 tools, no values, `run_id` issued, and **0 pipeline_runs rows** (no stranded run/hold):
```
status=missing_keys_gate  missing=[apify_api_token, hunter_io_api_key, whoisxml_api_key, pipl_api_key, apollo_api_key]
```
**Bypass** (`bypass_missing_keys=true`) → run starts (held 37 RU).
**Store key then re-check** (`hunter_io_api_key`, user scope, 204) → hunter drops off → `missing=[apify, whoisxml, pipl, apollo]`.

## Follow-ups (not in this PR)
- The leads-gen enrichment nodes don't implement `health_check`; the gate uses an explicit technique→key map instead. Could later derive setup info from node health.
- `pipl_people` node file is missing (technique maps the key but the node would fail at runtime) — separate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)