### PR TITLE
feat(keys): Phase 3 — reactive mid-run missing-key gate (#76)

### DIFF
--- a/app/pipeline/catalogs/technique_keys.py
+++ b/app/pipeline/catalogs/technique_keys.py
@@ -114,6 +114,47 @@ def _enumerate_technique_ids(strategy_id: str) -> set[str]:
     return tech_ids
 
 
+# node_type → the technique whose key metadata applies. Used by the reactive
+# mid-run gate (#76), which sees node_type (not technique_id) on the node-execute
+# path. Only nodes that actually call resolve_api_key with a real key appear here
+# (pipl_people has no node implementation, so it's intentionally absent).
+_NODE_TO_TECHNIQUE: dict[str, str] = {
+    "hunter_io": "hunter_email_search",
+    "apollo_zoominfo": "apollo_contact",
+    "whois_lookup": "whois_owner",
+    "apify_actor": "apify_listings_search",
+}
+
+
+def node_missing_key(
+    node_type: str,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+) -> dict[str, str] | None:
+    """For the reactive mid-run gate: if *node_type* needs an API key that is NOT
+    configured in the vault, return its descriptor
+    ``{node_type, key_name, display_name, setup_url, setup_instructions}``; else
+    None. Never returns a key value. Fail-open (returns None) on any error so a
+    vault hiccup can't break node execution.
+    """
+    tid = _NODE_TO_TECHNIQUE.get(node_type)
+    if tid is None:
+        return None
+    meta = TECHNIQUE_KEY_META.get(tid)
+    if meta is None:
+        return None
+    from app.lib.api_keys import resolve_api_key
+
+    try:
+        if resolve_api_key(meta["key_name"], user_id=user_id, org_id=org_id) is not None:
+            return None
+    except Exception:
+        log.debug("node_missing_key: resolve failed node_type=%r", node_type, exc_info=True)
+        return None
+    return {"node_type": node_type, **meta}
+
+
 def check_missing_keys_for_strategy(
     strategy_id: str,
     *,

--- a/app/pipeline/runners/scoped_brain.py
+++ b/app/pipeline/runners/scoped_brain.py
@@ -587,6 +587,13 @@ async def scoped_brain_runner(
         spawn_env["IS_RUN_ORG_ID"] = run_org_id
     else:
         spawn_env.pop("IS_RUN_ORG_ID", None)
+    # Thread the run_id so the MCP client tags node-execute calls with X-Run-Id,
+    # letting the server tie a mid-run missing-key gate event (#76) back to this
+    # live run's event stream. Non-secret.
+    if run_id:
+        spawn_env["IS_RUN_ID"] = run_id
+    else:
+        spawn_env.pop("IS_RUN_ID", None)
 
     log.info(
         "scoped_brain: spawning subprocess tactic=%s slot=%d model=%s",

--- a/app/routers/v3/nodes_api.py
+++ b/app/routers/v3/nodes_api.py
@@ -76,6 +76,44 @@ def _get_node(node_type: str):
         raise HTTPException(status_code=404, detail=f"Unknown node type: {node_type!r}")
 
 
+# Reactive mid-run missing-key gate (#76): (run_id, key_name) pairs already
+# surfaced this process, so the gate isn't re-emitted on every tool call. In-memory
+# like injection_queue; resetting on restart only means a gate may re-appear once.
+_MISSING_KEY_GATE_SENT: set[tuple[str, str]] = set()
+
+
+async def _maybe_emit_missing_key_gate(
+    node_type: str, run_id: str, user_id: str, org_id: str | None
+) -> None:
+    """Push a ``missing.key`` gate event to the run's user stream if *node_type*
+    needs an unconfigured API key. Deduped per (run_id, key_name). Never carries a
+    key value; fully non-fatal."""
+    try:
+        from app.pipeline.catalogs.technique_keys import node_missing_key
+        desc = node_missing_key(node_type, user_id=user_id, org_id=org_id)
+        if not desc:
+            return
+        dedup = (run_id, desc["key_name"])
+        if dedup in _MISSING_KEY_GATE_SENT:
+            return
+        _MISSING_KEY_GATE_SENT.add(dedup)
+        await push_event(
+            user_id,
+            {
+                "type": "missing.key",
+                "run_id": run_id,
+                "node_type": desc["node_type"],
+                "key_name": desc["key_name"],
+                "display_name": desc["display_name"],
+                "setup_url": desc["setup_url"],
+                "setup_instructions": desc["setup_instructions"],
+            },
+        )
+        log.info("nodes_api: missing-key gate emitted run_id=%s key=%s", run_id, desc["key_name"])
+    except Exception:
+        log.debug("nodes_api: missing-key gate emission failed", exc_info=True)
+
+
 @router.post("/{node_type}/execute")
 async def execute_node(
     node_type: str,
@@ -95,6 +133,8 @@ async def execute_node(
     # forwarded as headers by the MCP server.  Never carry decrypted key values.
     caller_user_id: str | None = request.headers.get("X-Caller-User-Id") or None
     caller_org_id: str | None = request.headers.get("X-Caller-Org-Id") or None
+    # Real run id (#76) so a mid-run missing-key gate can be tied to the live run.
+    caller_run_id: str | None = request.headers.get("X-Run-Id") or None
     call_id = str(uuid.uuid4())
 
     node = _get_node(node_type)
@@ -106,10 +146,18 @@ async def execute_node(
 
     ctx = RunContext(
         user_id=caller_user_id or "mcp-system",
-        run_id="mcp-adhoc",
+        run_id=caller_run_id or "mcp-adhoc",
         node_id="mcp-adhoc",
         org_id=caller_org_id,
     )
+
+    # Reactive mid-run missing-key gate (#76): if this node needs an API key that
+    # isn't configured, surface a decision gate into the run's live stream so the
+    # user can add the key. Non-intrusive — the node still executes (and degrades)
+    # as before; once the key is stored, per-call resolution picks it up on the
+    # next tool call. Deduped per (run_id, key_name) so it isn't spammed.
+    if caller_run_id and caller_user_id:
+        await _maybe_emit_missing_key_gate(node_type, caller_run_id, caller_user_id, caller_org_id)
 
     # --- observability: record call start (non-fatal) ---
     try:

--- a/frontend/src/components/agent/AgentChat.tsx
+++ b/frontend/src/components/agent/AgentChat.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, KeyboardEvent } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import MessageBubble from './MessageBubble'
-import { sendMessage, getBrainStatus, archiveSession, listSessions, getSession } from '../../api/v3'
+import { sendMessage, getBrainStatus, archiveSession, listSessions, getSession, storeApiKey } from '../../api/v3'
 import type { AgentMessageOut, AgentSession } from '../../api/v3'
 import { api } from '../../api/client'
 import { useWebSocket, type WsEvent } from '../../hooks/useWebSocket'
@@ -154,6 +154,93 @@ function QuestionBubble({ m, isAdmin, answered, customVal, onAnswer, onCustomCha
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+// MidRunKeyCard — Phase 3 (#76) reactive mid-run missing-key gate card. A node
+// hit a missing API key during the run; the user can add it here (stored in the
+// vault) and the run picks it up on the next tool call. A retry hint is injected
+// to nudge the brain. Key values go only to the vault — never echoed.
+function MidRunKeyCard({ m, onResolved }: { m: Message; onResolved: (id: string) => void }) {
+  const [value, setValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const keyName = (m.payload?.key_name ?? '') as string
+  const displayName = (m.payload?.display_name ?? keyName) as string
+  const setupUrl = (m.payload?.setup_url ?? '') as string
+  const setupInstructions = (m.payload?.setup_instructions ?? '') as string
+  const runId = (m.payload?.run_id ?? '') as string
+
+  const save = async () => {
+    if (!value.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      await storeApiKey(keyName, value.trim(), 'user')
+      if (runId) {
+        void brainApi.injectNode(runId, {
+          instruction: `The ${displayName} API key (${keyName}) has now been configured — retry that tool for any items still missing enrichment.`,
+        })
+      }
+      onResolved(m.id)
+    } catch {
+      setError('Failed to save key. Check the value and try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div key={m.id} style={{ margin: '6px 0 12px' }}>
+      <div
+        data-testid={`midrun-key-card-${keyName}`}
+        style={{
+          background: 'var(--panel2)', border: '1px solid var(--accent)',
+          borderRadius: '4px 12px 12px 12px', padding: '10px 14px',
+          maxWidth: '90%', fontSize: 11, color: 'var(--text)', lineHeight: 1.5,
+        }}
+      >
+        <span style={{ fontSize: 8, color: '#f59e0b', fontWeight: 700, display: 'block', marginBottom: 4, letterSpacing: '0.06em' }}>
+          TOOL NEEDS AN API KEY
+        </span>
+        <div style={{ marginBottom: 4 }}>
+          <strong>{displayName}</strong> needs <code>{keyName}</code> to enrich results.
+        </div>
+        {setupInstructions && (
+          <div style={{ color: 'var(--subtext)', marginBottom: 4 }}>{setupInstructions}</div>
+        )}
+        {setupUrl && (
+          <a href={setupUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)' }}>
+            Get API key →
+          </a>
+        )}
+        <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+          <input
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={`Paste ${keyName}`}
+            data-testid={`midrun-key-input-${keyName}`}
+            autoComplete="off"
+            style={{ flex: 1, fontSize: 11, padding: '3px 6px', borderRadius: 4, background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
+          />
+          <button
+            onClick={save}
+            disabled={saving || !value.trim()}
+            data-testid={`midrun-key-save-${keyName}`}
+            style={{
+              fontSize: 11, padding: '3px 10px', borderRadius: 4, border: 'none',
+              background: 'var(--accent)', color: '#fff',
+              cursor: saving || !value.trim() ? 'not-allowed' : 'pointer',
+              opacity: saving || !value.trim() ? 0.6 : 1,
+            }}
+          >
+            {saving ? 'Saving…' : 'Save & continue'}
+          </button>
+        </div>
+        {error && <div style={{ color: '#f87171', marginTop: 4 }}>{error}</div>}
+      </div>
     </div>
   )
 }
@@ -384,6 +471,35 @@ export default function AgentChat() {
             // keep `question` key on payload for any downstream consumers that
             // still read it during rollout
             question: summary,
+          },
+        }]
+      })
+    }
+    if (event.type === 'missing.key') {
+      // Phase 3 (#76): a node hit a missing API key mid-run. Surface a gate card
+      // so the user can add the key; subsequent tool calls pick it up.
+      const kEvent = event as WsEvent & {
+        node_type?: string; key_name?: string; display_name?: string
+        setup_url?: string; setup_instructions?: string
+      }
+      if (!kEvent.key_name) return
+      setMessages(prev => {
+        // Dedup: one card per key_name (backend also dedups per run+key).
+        if (prev.some(m => m.type === 'missing_key' && m.payload?.key_name === kEvent.key_name)) {
+          return prev
+        }
+        return [...prev, {
+          id: `missingkey-${kEvent.key_name}-${Date.now()}`,
+          role: 'agent',
+          content: `${kEvent.display_name ?? kEvent.key_name} needs an API key to enrich results`,
+          type: 'missing_key',
+          payload: {
+            run_id: event.run_id,
+            node_type: kEvent.node_type,
+            key_name: kEvent.key_name,
+            display_name: kEvent.display_name,
+            setup_url: kEvent.setup_url,
+            setup_instructions: kEvent.setup_instructions,
           },
         }]
       })
@@ -725,6 +841,21 @@ export default function AgentChat() {
                   handleBrainAnswer(runId, value, msgId)
                   setCustomAnswers(prev => ({ ...prev, [msgId]: '' }))
                 }}
+              />
+            )
+          }
+
+          // Mid-run missing-key gate card (#76)
+          if (m.type === 'missing_key') {
+            return (
+              <MidRunKeyCard
+                key={m.id}
+                m={m}
+                onResolved={(id) => setMessages(prev => prev.map(msg =>
+                  msg.id === id
+                    ? { ...msg, type: 'message', content: `✓ ${(m.payload?.display_name ?? m.payload?.key_name) as string} key added — the run will use it on the next tool call.` }
+                    : msg,
+                ))}
               />
             )
           }

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -6,7 +6,7 @@ export interface Message {
   role: 'user' | 'assistant' | 'agent'
   content: string
   status?: 'pending' | 'running' | 'done' | 'error'
-  type?: 'message' | 'question' | 'plan' | 'confirm'
+  type?: 'message' | 'question' | 'plan' | 'confirm' | 'missing_key'
   payload?: Record<string, unknown>
 }
 

--- a/mcp_server/client.py
+++ b/mcp_server/client.py
@@ -23,6 +23,9 @@ _MCP_SECRET = os.environ.get("MCP_SIGNING_SECRET", "")
 # decrypted key values NEVER enter the subprocess env or the MCP client.
 _RUN_USER_ID: str | None = os.environ.get("IS_RUN_USER_ID") or None
 _RUN_ORG_ID: str | None = os.environ.get("IS_RUN_ORG_ID") or None
+# Non-secret run id — lets the server tie a mid-run missing-key gate (#76) to
+# this run's live event stream.
+_RUN_ID: str | None = os.environ.get("IS_RUN_ID") or None
 
 
 def _sign_request(body: bytes) -> dict[str, str]:
@@ -68,6 +71,8 @@ async def api_call(method: str, path: str, **kwargs) -> dict:
             headers["X-Caller-User-Id"] = _RUN_USER_ID
         if _RUN_ORG_ID:
             headers["X-Caller-Org-Id"] = _RUN_ORG_ID
+        if _RUN_ID:
+            headers["X-Run-Id"] = _RUN_ID
         resp = await client.request(method, path, headers=headers, **kwargs)
         resp.raise_for_status()
         return resp.json()

--- a/tests/pipeline/test_missing_keys.py
+++ b/tests/pipeline/test_missing_keys.py
@@ -12,6 +12,7 @@ from app.pipeline.catalogs.technique_keys import (
     TECHNIQUE_KEY_META,
     _enumerate_technique_ids,
     check_missing_keys_for_strategy,
+    node_missing_key,
 )
 
 
@@ -81,3 +82,64 @@ def test_resolve_failure_is_fail_open(monkeypatch):
         raise RuntimeError("db down")
     monkeypatch.setattr("app.lib.api_keys.resolve_api_key", boom)
     assert check_missing_keys_for_strategy("real_estate_leads", user_id="u1", org_id=None) == []
+
+
+# ---------------------------------------------------------------------------
+# node_missing_key — reactive mid-run gate (#76)
+# ---------------------------------------------------------------------------
+
+
+def test_node_missing_key_surfaces_when_absent(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: None)
+    desc = node_missing_key("hunter_io", user_id="u1", org_id=None)
+    assert desc is not None
+    assert desc["node_type"] == "hunter_io"
+    assert desc["key_name"] == "hunter_io_api_key"
+    assert "value" not in desc  # never a key value
+
+
+def test_node_missing_key_none_when_present(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: "configured")
+    assert node_missing_key("apollo_zoominfo", user_id="u1", org_id="o1") is None
+
+
+def test_node_missing_key_none_for_unmapped_node(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: None)
+    assert node_missing_key("web_search", user_id="u1", org_id=None) is None
+    assert node_missing_key("totally_unknown_node", user_id="u1", org_id=None) is None
+
+
+def test_node_missing_key_fail_open(monkeypatch):
+    def boom(k, **kw):
+        raise RuntimeError("db down")
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", boom)
+    assert node_missing_key("hunter_io", user_id="u1", org_id=None) is None
+
+
+def test_gate_event_emitted_and_deduped(monkeypatch):
+    """_maybe_emit_missing_key_gate pushes one missing.key event per (run, key)."""
+    import asyncio
+    import app.routers.v3.nodes_api as na
+
+    pushed: list[tuple[str, dict]] = []
+
+    async def fake_push(user_id, event):
+        pushed.append((user_id, event))
+
+    monkeypatch.setattr(na, "push_event", fake_push)
+    monkeypatch.setattr("app.lib.api_keys.resolve_api_key", lambda k, **kw: None)
+    na._MISSING_KEY_GATE_SENT.clear()
+
+    async def go():
+        await na._maybe_emit_missing_key_gate("hunter_io", "run-xyz", "user-1", None)
+        await na._maybe_emit_missing_key_gate("hunter_io", "run-xyz", "user-1", None)  # dup
+
+    asyncio.run(go())
+
+    assert len(pushed) == 1, "gate should be emitted once per (run_id, key_name)"
+    user_id, event = pushed[0]
+    assert user_id == "user-1"
+    assert event["type"] == "missing.key"
+    assert event["run_id"] == "run-xyz"
+    assert event["key_name"] == "hunter_io_api_key"
+    assert "value" not in event


### PR DESCRIPTION
## What
When a node is invoked **mid-run** and needs an API key that isn't configured, the server emits a `missing.key` gate into the run's **live agent stream** so the user can add the key inline. Completes the API-key trilogy: vault (#74) → pre-run gate (#75) → mid-run gate (#76).

## Design (per the agreed feasibility finding)
True in-call pause/resume isn't feasible (the brain is an autonomous subprocess; an in-flight MCP tool call can't safely block, and its tool list is fixed at spawn). So this is **reactive surfacing + retry**, non-blocking:
- The node still executes and degrades exactly as before — no behavior change to the run.
- Because `resolve_api_key` runs **per node-call**, once the user stores the key the **next** call to that tool uses it; an injected retry hint nudges the brain.

## Backend
- `scoped_brain.py`: thread `IS_RUN_ID` into the subprocess env (non-secret).
- `mcp_server/client.py`: forward it as `X-Run-Id` on every node-execute call.
- `nodes_api.py`: put the real run_id on `RunContext`; before executing, emit a **deduped** (per `run_id`+`key_name`) `missing.key` event when the node needs an unconfigured key. Fully non-fatal; never blocks execution.
- `technique_keys.py`: `_NODE_TO_TECHNIQUE` map (hunter_io / apollo_zoominfo / whois_lookup / apify_actor) + `node_missing_key()` (vault presence check; fail-open; never returns a key value).

## Frontend
- `AgentChat.tsx`: handle the `missing.key` event → render `MidRunKeyCard` (setup link + instructions + inline password entry). On save: `storeApiKey` (vault) + inject a retry hint; the card flips to a confirmation.
- `chatStore.ts`: add the `missing_key` message type.

## Security (load-bearing)
The gate event and UI carry only `key_name` + public setup info — **never a key value**. Values go only to the encrypted vault endpoint. Keys never reach the brain.

## Tests
- 13 unit (`tests/pipeline/test_missing_keys.py` — incl. `node_missing_key` cases + a deduped async emission test) + **675 backend regression** (nodes/scoped_brain/mcp/preflight/vault) green; frontend `tsc --noEmit` clean.
- **Real-stack (WS)**: keyed `hunter_io` node-execute with `X-Run-Id`/`X-Caller-User-Id` and no key → `missing.key` event delivered to the user's stream (correct run_id, setup info, **no value**); storing `hunter_io_api_key` then re-firing → **suppressed** (no event).

## Note on interplay with #144
#144 tells the brain to *deprioritize* keyless tools, so in practice the brain may avoid them — meaning this gate fires mainly when the brain calls a keyed tool anyway. The pre-run gate (#75) remains the primary surface; this is the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)