### PR TITLE
chore(benchmarks+ui): real RU cost metric + gate UI component tests

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -274,12 +274,16 @@ def fetch_trail(session: requests.Session, run_id: str) -> tuple[dict, list[dict
     run_resp.raise_for_status()
     run_data = run_resp.json()
 
-    ru_consumed: int = (
-        run_data.get("ru_consumed")
-        or run_data.get("run_budget")
-        or run_data.get("budget_consumed")
-        or 0
-    )
+    # Real RU consumption lives in the wallet_operations ledger, exposed via
+    # GET /v3/runs/{run_id}/cost_breakdown.total_ru — NOT on the run record
+    # (pipeline_runs has no ru_consumed column). Fall back to 0 if unavailable.
+    ru_consumed: int = 0
+    try:
+        cb = session.get(f"{BASE_URL}/v3/runs/{run_id}/cost_breakdown", timeout=30)
+        if cb.status_code == 200:
+            ru_consumed = int(cb.json().get("total_ru") or 0)
+    except Exception:
+        log.debug("cost_breakdown fetch failed for %s", run_id, exc_info=True)
     started_at = run_data.get("started_at") or run_data.get("created_at") or ""
     finished_at = run_data.get("finished_at") or run_data.get("updated_at") or ""
     duration_s = 0.0

--- a/frontend/src/components/preflight/MissingKeysGate.test.tsx
+++ b/frontend/src/components/preflight/MissingKeysGate.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+vi.mock('../../api/v3', () => ({
+  storeApiKey: vi.fn().mockResolvedValue(undefined),
+}))
+
+import MissingKeysGate from './MissingKeysGate'
+import type { MissingKeyTool } from '../../hooks/usePreflight'
+
+const TOOLS: MissingKeyTool[] = [
+  {
+    technique_id: 'hunter_email_search',
+    key_name: 'hunter_io_api_key',
+    display_name: 'Hunter.io (email finder)',
+    setup_url: 'https://hunter.io/api-keys',
+    setup_instructions: 'Create a free Hunter.io account and copy the API key.',
+  },
+  {
+    technique_id: 'apollo_contact',
+    key_name: 'apollo_api_key',
+    display_name: 'Apollo.io (contact enrichment)',
+    setup_url: 'https://developer.apollo.io/keys/',
+    setup_instructions: 'Generate an API key in Apollo settings.',
+  },
+]
+
+describe('MissingKeysGate', () => {
+  it('renders a card per missing tool with setup info', () => {
+    render(<MissingKeysGate missingTools={TOOLS} onKeyStored={vi.fn()} onProceedAnyway={vi.fn()} />)
+    expect(screen.getByTestId('missing-key-card-hunter_io_api_key')).toBeInTheDocument()
+    expect(screen.getByTestId('missing-key-card-apollo_api_key')).toBeInTheDocument()
+    expect(screen.getByText(/Hunter.io \(email finder\)/)).toBeInTheDocument()
+    // setup link points at the real URL
+    expect(screen.getByTestId('missing-key-setup-url-hunter_io_api_key')).toHaveAttribute(
+      'href', 'https://hunter.io/api-keys',
+    )
+  })
+
+  it('"Proceed anyway" invokes the callback', () => {
+    const onProceed = vi.fn()
+    render(<MissingKeysGate missingTools={TOOLS} onKeyStored={vi.fn()} onProceedAnyway={onProceed} />)
+    fireEvent.click(screen.getByTestId('missing-keys-proceed-anyway'))
+    expect(onProceed).toHaveBeenCalledTimes(1)
+  })
+
+  it('entering a key stores it (user scope) and notifies the parent', async () => {
+    const { storeApiKey } = await import('../../api/v3')
+    const onKeyStored = vi.fn()
+    render(<MissingKeysGate missingTools={TOOLS} onKeyStored={onKeyStored} onProceedAnyway={vi.fn()} />)
+
+    fireEvent.change(screen.getByTestId('missing-key-input-hunter_io_api_key'), {
+      target: { value: 'secret-key-123' },
+    })
+    fireEvent.click(screen.getByTestId('missing-key-save-hunter_io_api_key'))
+
+    await waitFor(() => expect(storeApiKey).toHaveBeenCalledWith('hunter_io_api_key', 'secret-key-123', 'user'))
+    await waitFor(() => expect(onKeyStored).toHaveBeenCalled())
+    // card flips to a saved confirmation
+    await waitFor(() => expect(screen.getByTestId('missing-key-saved-hunter_io_api_key')).toBeInTheDocument())
+  })
+
+  it('Save is disabled until a value is entered', () => {
+    render(<MissingKeysGate missingTools={TOOLS} onKeyStored={vi.fn()} onProceedAnyway={vi.fn()} />)
+    expect(screen.getByTestId('missing-key-save-hunter_io_api_key')).toBeDisabled()
+  })
+})


### PR DESCRIPTION
Polish + verify pass after the API-key trilogy.

## 1. Benchmark cost metric (was `ru_consumed=0`)
`pipeline_runs` has **no** `ru_consumed` column, and `ru_consumed` is only emitted in the ephemeral `is.run_complete` WS event — so the benchmark's `cost_per_lead`/`cost_per_matched_fact` always read 0. Fixed `fetch_trail` to read real consumption from `GET /v3/runs/{run_id}/cost_breakdown.total_ru` (the `wallet_operations` ledger). Non-fatal fallback to 0.
**Verified:** completed leads runs return `total_ru` = 8 / 9 across 3 phases (was 0).

## 2. Gate UI verification
Added `MissingKeysGate.test.tsx` (vitest + testing-library) — 4 passing tests: renders a card per missing tool with setup link, "Proceed anyway" callback, key entry stores at `user` scope + flips to a saved confirmation, and Save disabled until input. Automated stand-in for a manual browser check of the Phase 2/3 gate surface.

## Tests
99 benchmark unit tests green; 4 new gate-UI tests green; ruff clean. The Phase 2/3 frontend is also live on the running dev server (bind-mounted) for a final visual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)