### PR TITLE
feat(keys): authenticated sessions — own-credential site login via stealth browser (item 4)

### DIFF
--- a/app/lib/api_keys.py
+++ b/app/lib/api_keys.py
@@ -136,3 +136,34 @@ def resolve_api_key(
         return env_value
 
     return None
+
+
+def resolve_site_credential(
+    site: str,
+    *,
+    user_id: str | None,
+    org_id: str | None,
+) -> dict | None:
+    """Return the caller's stored login ``{"username":.., "password":..}`` for
+    *site*, or None. Resolved server-side ONLY (user → org scope) — the password
+    must never be threaded toward the brain. Never logs the credential values.
+    """
+    import json
+
+    from app.lib.secret_box import decrypt
+
+    key_name = "sitecred:" + (site or "").strip().lower()
+    for scope, owner in (("user", user_id), ("org", org_id)):
+        if not owner or owner in ("mcp-system", ""):
+            continue
+        row = _vault_fetch(key_name, scope, owner)
+        if row and row.get("value_encrypted"):
+            try:
+                cred = json.loads(decrypt(row["value_encrypted"]))
+            except Exception:
+                log.debug("api_keys: site-cred decode failed site=%r scope=%r", site, scope)
+                return None
+            if cred.get("username") and cred.get("password"):
+                log.info("api_keys: resolved site-credential key_name=%r scope=%s", key_name, scope)
+                return {"username": cred["username"], "password": cred["password"]}
+    return None

--- a/app/pipeline/nodes/stealth_browser.py
+++ b/app/pipeline/nodes/stealth_browser.py
@@ -113,14 +113,69 @@ class StealthBrowserNode:
 
         wait_s = float(config.get("wait_s", 2.5))
         timeout = int(config.get("timeout", 25))
+
+        # Optional authenticated session: log in with the user's OWN stored
+        # credential (resolved server-side here — the password NEVER came from the
+        # brain, which only passed the site name + form selectors).
+        login = self._build_login(config, context)
+
         try:
-            return await _render_pages(safe, wait_s=wait_s, timeout=timeout)
+            return await _render_pages(safe, wait_s=wait_s, timeout=timeout, login=login)
         except Exception as exc:  # noqa: BLE001
             log.warning("stealth_browser: render failed: %s", exc)
             return [{"error": str(exc), "source": "stealth_browser"}]
 
+    @staticmethod
+    def _build_login(config: dict, context: RunContext) -> dict | None:
+        login_url = config.get("login_url")
+        site = config.get("site") or config.get("credential_ref")
+        if not (login_url and site):
+            return None
+        if not _url_is_safe(login_url):
+            log.warning("stealth_browser: login_url failed SSRF check — skipping login")
+            return None
+        from app.lib.api_keys import resolve_site_credential
+        cred = resolve_site_credential(
+            site,
+            user_id=getattr(context, "user_id", None),
+            org_id=getattr(context, "org_id", None),
+        )
+        if not cred:
+            log.info("stealth_browser: no stored credential for site=%r — fetching unauthenticated", site)
+            return None
+        return {
+            "url": login_url,
+            "username_selector": config.get("username_selector") or "input[type=email], input[name*=user], input[name*=email], input[name=login]",
+            "password_selector": config.get("password_selector") or "input[type=password]",
+            "submit_selector": config.get("submit_selector") or "button[type=submit], input[type=submit]",
+            "username": cred["username"],
+            "password": cred["password"],
+            "wait_s": float(config.get("login_wait_s", 4)),
+        }
 
-async def _render_pages(urls: list[str], *, wait_s: float, timeout: int) -> list[dict]:
+
+async def _do_login(browser, login: dict) -> None:
+    """Fill + submit a site login form in the live browser, persisting the
+    session for subsequent fetches. NEVER logs the username/password."""
+    import asyncio
+
+    ltab = await asyncio.wait_for(browser.get(login["url"]), timeout=30)
+    await ltab.sleep(2)
+    ufield = await ltab.select(login["username_selector"])
+    if ufield:
+        await ufield.send_keys(login["username"])
+    pfield = await ltab.select(login["password_selector"])
+    if pfield:
+        await pfield.send_keys(login["password"])
+    submit = await ltab.select(login["submit_selector"])
+    if submit:
+        await submit.click()
+    await ltab.sleep(login.get("wait_s", 4))
+
+
+async def _render_pages(
+    urls: list[str], *, wait_s: float, timeout: int, login: dict | None = None
+) -> list[dict]:
     import asyncio
 
     try:
@@ -136,6 +191,11 @@ async def _render_pages(urls: list[str], *, wait_s: float, timeout: int) -> list
     )
     results: list[dict] = []
     try:
+        if login:
+            try:
+                await _do_login(browser, login)  # session persists for the fetches below
+            except Exception as exc:  # noqa: BLE001 — never surface credential values
+                log.warning("stealth_browser: login step failed (continuing unauthenticated): %s", exc)
         for url in urls:
             try:
                 tab = await asyncio.wait_for(browser.get(url), timeout=timeout)

--- a/app/routers/v3/settings.py
+++ b/app/routers/v3/settings.py
@@ -274,11 +274,114 @@ def list_api_keys(user: dict = Depends(get_current_user)) -> list[ApiKeyEntry]:
         SELECT key_name, scope, owner_id::text AS owner_id
           FROM api_key_vault
          WHERE
-            (scope = 'global' AND owner_id IS NULL)
-            OR (scope = 'user'   AND owner_id = %s::uuid)
-            OR (scope = 'org'    AND owner_id = %s::uuid AND %s IS NOT NULL)
+            key_name NOT LIKE 'sitecred:%%'
+            AND (
+                (scope = 'global' AND owner_id IS NULL)
+                OR (scope = 'user'   AND owner_id = %s::uuid)
+                OR (scope = 'org'    AND owner_id = %s::uuid AND %s IS NOT NULL)
+            )
          ORDER BY scope, key_name
         """,
         (user_id, org_id or user_id, org_id),
     )
     return [ApiKeyEntry(**r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Site-credential vault (Phase: authenticated sessions, #item-4)
+# Stores the user's OWN login for a site (username+password) encrypted in the
+# same vault, so the stealth browser can log in and access gated data. The
+# password is NEVER returned by any endpoint and NEVER reaches the brain — it is
+# resolved server-side at node-execute via resolve_site_credential().
+# ---------------------------------------------------------------------------
+
+_SITECRED_PREFIX = "sitecred:"
+
+
+class SiteCredentialIn(BaseModel):
+    site: str            # e.g. "fsbo.com"
+    username: str
+    password: str
+    scope: str = "user"  # 'user' (own login) | 'org' (shared team account)
+
+
+class SiteCredentialEntry(BaseModel):
+    site: str
+    scope: str
+    username: str        # shown (not secret); password is NEVER returned
+
+
+@router.post("/site-credentials", status_code=204)
+def upsert_site_credential(body: SiteCredentialIn, user: dict = Depends(get_current_user)) -> None:
+    """Store the user's OWN login for a site (encrypted). Password is never
+    returned and never reaches the brain. The user is responsible for ensuring
+    they are authorized to automate access to the site per its ToS."""
+    import json
+
+    from app.lib.secret_box import encrypt
+
+    scope = body.scope
+    if scope not in ("user", "org"):
+        raise HTTPException(status_code=400, detail="scope must be 'user' or 'org'")
+    if scope == "org":
+        if user.get("role") != "admin":
+            raise HTTPException(status_code=403, detail="Org scope requires org-admin role")
+        if not user.get("org_id"):
+            raise HTTPException(status_code=400, detail="User has no org")
+        owner_id = str(user["org_id"])
+    else:
+        owner_id = str(user["id"])
+
+    site = body.site.strip().lower()
+    if not site:
+        raise HTTPException(status_code=400, detail="site is required")
+    key_name = _SITECRED_PREFIX + site
+    encrypted = encrypt(json.dumps({"username": body.username, "password": body.password}))
+
+    execute(
+        """
+        INSERT INTO api_key_vault (key_name, scope, owner_id, value_encrypted, updated_at)
+        VALUES (%s, %s, %s::uuid, %s, now())
+        ON CONFLICT (key_name, scope, owner_id) DO UPDATE
+        SET value_encrypted = EXCLUDED.value_encrypted, updated_at = now()
+        """,
+        (key_name, scope, owner_id, encrypted),
+    )
+    # Log site + scope only — NEVER the username or password.
+    log.info(
+        "site_credentials: upserted site=%r scope=%r owner_id=%r by user=%r",
+        site, scope, owner_id, str(user.get("id")),
+    )
+
+
+@router.get("/site-credentials", response_model=list[SiteCredentialEntry])
+def list_site_credentials(user: dict = Depends(get_current_user)) -> list[SiteCredentialEntry]:
+    """List configured site logins (site + scope + username). Password is NEVER
+    returned. Each caller sees their own user-scoped + their org-scoped entries."""
+    import json
+
+    from app.lib.secret_box import decrypt
+
+    user_id = str(user["id"])
+    org_id = str(user["org_id"]) if user.get("org_id") else None
+    rows = fetch_all(
+        """
+        SELECT key_name, scope, value_encrypted
+          FROM api_key_vault
+         WHERE key_name LIKE 'sitecred:%%'
+           AND ((scope = 'user' AND owner_id = %s::uuid)
+                OR (scope = 'org' AND owner_id = %s::uuid AND %s IS NOT NULL))
+         ORDER BY scope, key_name
+        """,
+        (user_id, org_id or user_id, org_id),
+    )
+    out: list[SiteCredentialEntry] = []
+    for r in rows:
+        site = r["key_name"][len(_SITECRED_PREFIX):]
+        username = ""
+        try:
+            username = json.loads(decrypt(r["value_encrypted"])).get("username", "")
+        except Exception:
+            pass
+        out.append(SiteCredentialEntry(site=site, scope=r["scope"], username=username))
+    return out

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -821,3 +821,23 @@ export const storeApiKey = (
   scope: 'user' | 'org' | 'global' = 'user',
 ): Promise<void> =>
   api.post('/v3/settings/api-keys', { key_name, value, scope }).then(() => undefined)
+
+// --- Site credentials (authenticated-session vault, #item-4) -----------------
+export interface SiteCredentialEntry {
+  site: string
+  scope: string
+  username: string   // shown for identification; password is NEVER returned
+}
+
+// Store the user's OWN login for a site (encrypted server-side; password never
+// returned and never reaches the brain). Used by the authenticated stealth browser.
+export const storeSiteCredential = (
+  site: string,
+  username: string,
+  password: string,
+  scope: 'user' | 'org' = 'user',
+): Promise<void> =>
+  api.post('/v3/settings/site-credentials', { site, username, password, scope }).then(() => undefined)
+
+export const listSiteCredentials = (): Promise<SiteCredentialEntry[]> =>
+  api.get<SiteCredentialEntry[]>('/v3/settings/site-credentials').then(r => r.data)

--- a/frontend/src/components/settings/SiteCredentialsSection.tsx
+++ b/frontend/src/components/settings/SiteCredentialsSection.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback } from 'react'
+import { storeSiteCredential, listSiteCredentials, type SiteCredentialEntry } from '../../api/v3'
+
+/**
+ * Site Logins (authenticated-session vault, #item-4). Lets a user store their
+ * OWN login for a site (e.g. fsbo.com, an MLS/IDX portal) so the stealth browser
+ * can log in and access data gated behind that account. The password is
+ * encrypted at rest, never returned by any endpoint, and never reaches the brain
+ * (resolved server-side only). The user is responsible for ensuring they're
+ * authorized to automate access per the site's terms.
+ */
+export default function SiteCredentialsSection() {
+  const [entries, setEntries] = useState<SiteCredentialEntry[]>([])
+  const [site, setSite] = useState('')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  const refresh = useCallback(() => {
+    listSiteCredentials().then(setEntries).catch(() => setEntries([]))
+  }, [])
+  useEffect(() => { refresh() }, [refresh])
+
+  const save = async () => {
+    if (!site.trim() || !username.trim() || !password) return
+    setSaving(true); setError(null); setSaved(false)
+    try {
+      await storeSiteCredential(site.trim().toLowerCase(), username.trim(), password, 'user')
+      setSaved(true); setPassword(''); refresh()
+    } catch {
+      setError('Failed to save credential. Try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const inputStyle = {
+    flex: 1, fontSize: 12, padding: '5px 8px', borderRadius: 4,
+    background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)',
+  } as const
+
+  return (
+    <div style={{ maxWidth: 560 }}>
+      <p className="text-xs" style={{ color: 'var(--subtext)', lineHeight: 1.6, marginBottom: 12 }}>
+        Store a login for a site you have an account on (e.g. <code>fsbo.com</code>, an MLS/IDX portal).
+        The stealth browser uses it to access data gated behind that account. Your password is
+        encrypted at rest, is never shown again, and never reaches the research brain. Only store
+        credentials for accounts you own and are permitted to automate per the site&apos;s terms.
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 16 }}>
+        <input data-testid="sitecred-site" style={inputStyle} placeholder="site (e.g. fsbo.com)"
+          value={site} onChange={e => setSite(e.target.value)} autoComplete="off" />
+        <input data-testid="sitecred-username" style={inputStyle} placeholder="username / email"
+          value={username} onChange={e => setUsername(e.target.value)} autoComplete="off" />
+        <div style={{ display: 'flex', gap: 6 }}>
+          <input data-testid="sitecred-password" type="password" style={inputStyle} placeholder="password"
+            value={password} onChange={e => setPassword(e.target.value)} autoComplete="new-password" />
+          <button
+            onClick={save}
+            disabled={saving || !site.trim() || !username.trim() || !password}
+            data-testid="sitecred-save"
+            style={{
+              fontSize: 12, padding: '5px 14px', borderRadius: 4, border: 'none',
+              background: 'var(--accent)', color: '#fff',
+              cursor: saving ? 'not-allowed' : 'pointer',
+              opacity: (saving || !site.trim() || !username.trim() || !password) ? 0.6 : 1,
+            }}
+          >
+            {saving ? 'Saving…' : 'Save login'}
+          </button>
+        </div>
+        {error && <span className="text-[11px]" style={{ color: '#f87171' }}>{error}</span>}
+        {saved && <span className="text-[11px]" style={{ color: '#34d399' }} data-testid="sitecred-saved">✓ Login saved (encrypted)</span>}
+      </div>
+
+      <div className="text-[10px] font-semibold mb-2" style={{ color: 'var(--muted)' }}>SAVED LOGINS</div>
+      {entries.length === 0 ? (
+        <p className="text-[11px]" style={{ color: 'var(--subtext)' }}>No site logins stored yet.</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {entries.map(e => (
+            <div key={`${e.scope}:${e.site}`} data-testid={`sitecred-row-${e.site}`}
+              className="flex items-center gap-2 text-[11px] px-2 py-1 rounded"
+              style={{ background: 'var(--panel)', border: '1px solid var(--border)', color: 'var(--text)' }}>
+              <span style={{ fontWeight: 600 }}>{e.site}</span>
+              <span style={{ color: 'var(--subtext)' }}>{e.username}</span>
+              <span className="ml-auto text-[10px] px-2 py-0.5 rounded"
+                style={{ background: 'var(--panel2)', color: 'var(--subtext)' }}>{e.scope}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import IconRail from '../components/layout/IconRail'
 import { useSessionStore } from '../stores/sessionStore'
 import AccountSection from '../components/settings/AccountSection'
 import AdminActionItems from '../components/settings/AdminActionItems'
+import SiteCredentialsSection from '../components/settings/SiteCredentialsSection'
 import { api } from '../api/client'
 
 const CORE_FIELDS = [
@@ -666,7 +667,7 @@ export default function Settings() {
   const role = useSessionStore(s => s.role)
   const canSeeDefaultMode = isAdmin || role === 'admin'
   const canSeeVisibility = isAdmin || role === 'admin'
-  const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health' | 'account' | 'default-mode' | 'visibility' | 'action-items'>(
+  const [section, setSection] = useState<'core' | 'plugins' | 'agent' | 'node-health' | 'account' | 'default-mode' | 'visibility' | 'action-items' | 'site-logins'>(
     isAdmin ? 'action-items' : 'account',
   )
 
@@ -685,6 +686,17 @@ export default function Settings() {
             }}
           >
             Account
+          </button>
+          <button
+            onClick={() => setSection('site-logins')}
+            className="w-full text-left px-2 py-1 rounded text-xs mb-1"
+            style={{
+              background: section === 'site-logins' ? 'var(--panel2)' : 'transparent',
+              color: section === 'site-logins' ? 'var(--accent)' : 'var(--text)',
+              border: 'none', cursor: 'pointer',
+            }}
+          >
+            Site Logins
           </button>
           {canSeeDefaultMode && (
             <button
@@ -796,9 +808,11 @@ export default function Settings() {
               : section === 'default-mode' ? 'Default Mode'
               : section === 'visibility' ? 'Modes & Templates'
               : section === 'action-items' ? 'Action Items'
+              : section === 'site-logins' ? 'Site Logins'
               : 'Plugin Settings'}
           </h2>
           {section === 'account' && <AccountSection />}
+          {section === 'site-logins' && <SiteCredentialsSection />}
           {isAdmin && section === 'action-items' && (
             <AdminActionItems onNavigateToCoreSettings={() => setSection('core')} />
           )}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -102,21 +102,45 @@ async def run_web_crawl(
 
 
 @mcp.tool()
-async def run_stealth_browser(urls: str, wait_s: float = 2.5) -> str:
+async def run_stealth_browser(
+    urls: str,
+    wait_s: float = 2.5,
+    site: str = "",
+    login_url: str = "",
+    username_selector: str = "",
+    password_selector: str = "",
+    submit_selector: str = "",
+) -> str:
     """Render JS-heavy or bot-protected pages in an undetected headless Chromium
     and return their extracted text. Free — NO API key.
 
     Use this as the FALLBACK when run_web_crawl / run_web_search_fetch return an
-    empty or blocked page on a dynamic site (e.g. a Zillow / Realtor listing
-    detail page that needs JavaScript). It defeats most TLS/headless bot
-    detection. urls: a JSON array, a single bare URL, or a comma/space-separated
-    list (max 12).
+    empty or blocked page on a dynamic site (e.g. a listing detail page that needs
+    JavaScript). It defeats most TLS/headless bot detection. urls: a JSON array, a
+    single bare URL, or a comma/space-separated list (max 12).
+
+    AUTHENTICATED MODE — for data gated behind a login the user has an account for:
+    pass `site` (the credential reference the user stored in Settings, e.g.
+    "fsbo.com") + `login_url` + the form CSS selectors (`username_selector`,
+    `password_selector`, `submit_selector` — inspect the login page to find them).
+    The server logs in with the user's stored credential (the password is NEVER
+    exposed to this tool or to you) and fetches the urls in that authenticated
+    session. Only works if the user has saved a credential for that site.
     """
     url_list = _parse_url_arg(urls)
+    body: dict = {"urls": url_list, "wait_s": wait_s}
+    if site and login_url:
+        body.update({
+            "site": site,
+            "login_url": login_url,
+            "username_selector": username_selector,
+            "password_selector": password_selector,
+            "submit_selector": submit_selector,
+        })
     result = await api_call(
         "POST",
         "/v3/nodes/stealth_browser/execute",
-        json={"urls": url_list, "wait_s": wait_s},
+        json=body,
     )
     return json.dumps(result)
 

--- a/tests/pipeline/nodes/test_stealth_browser.py
+++ b/tests/pipeline/nodes/test_stealth_browser.py
@@ -84,7 +84,7 @@ def test_execute_filters_to_safe_urls_before_render(monkeypatch):
     import app.pipeline.nodes.stealth_browser as sb
     captured = {}
 
-    async def _fake_render(urls, *, wait_s, timeout):
+    async def _fake_render(urls, *, wait_s, timeout, login=None):
         captured["urls"] = urls
         return [{"url": u, "content": "ok", "source_class": "live_search"} for u in urls]
     monkeypatch.setattr(sb, "_render_pages", _fake_render)
@@ -95,3 +95,37 @@ def test_execute_filters_to_safe_urls_before_render(monkeypatch):
     # internal URL filtered out; only the public one reaches render
     assert captured["urls"] == ["https://www.zillow.com/x"]
     assert out[0]["content"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _build_login — authenticated-session credential resolution (#item-4)
+# ---------------------------------------------------------------------------
+
+def test_build_login_none_without_site_or_login_url():
+    assert StealthBrowserNode._build_login({}, _ctx()) is None
+    assert StealthBrowserNode._build_login({"login_url": "https://x.com/login"}, _ctx()) is None
+    assert StealthBrowserNode._build_login({"site": "x.com"}, _ctx()) is None
+
+
+def test_build_login_resolves_credential(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_site_credential",
+                        lambda site, **kw: {"username": "u", "password": "p"})
+    login = StealthBrowserNode._build_login(
+        {"login_url": "https://fsbo.com/login", "site": "fsbo.com"}, _ctx())
+    assert login is not None
+    assert login["url"] == "https://fsbo.com/login"
+    assert login["username"] == "u" and login["password"] == "p"
+
+
+def test_build_login_rejects_internal_login_url(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_site_credential",
+                        lambda site, **kw: {"username": "u", "password": "p"})
+    # SSRF check runs before credential use
+    assert StealthBrowserNode._build_login(
+        {"login_url": "http://127.0.0.1/login", "site": "x"}, _ctx()) is None
+
+
+def test_build_login_none_when_no_stored_credential(monkeypatch):
+    monkeypatch.setattr("app.lib.api_keys.resolve_site_credential", lambda site, **kw: None)
+    assert StealthBrowserNode._build_login(
+        {"login_url": "https://fsbo.com/login", "site": "fsbo.com"}, _ctx()) is None

--- a/tests/test_api_key_vault.py
+++ b/tests/test_api_key_vault.py
@@ -336,3 +336,39 @@ def test_vault_migration_creates_table():
         (),
     )
     assert row is not None, "api_key_vault.value_encrypted column not found"
+
+
+# ---------------------------------------------------------------------------
+# resolve_site_credential — authenticated-session credential vault (#item-4)
+# ---------------------------------------------------------------------------
+
+def test_resolve_site_credential_roundtrip(monkeypatch):
+    import json
+    from app.lib.secret_box import encrypt
+    enc = encrypt(json.dumps({"username": "alice", "password": "s3cret"}))
+    # user-scoped row matches (scope = %s present in _vault_fetch query)
+    monkeypatch.setattr(
+        "app.routers.v3.db.fetch_one",
+        lambda q, p: {"value_encrypted": enc} if "scope = %s" in q else None,
+    )
+    from app.lib.api_keys import resolve_site_credential
+    cred = resolve_site_credential("FSBO.com", user_id="uid", org_id=None)
+    assert cred == {"username": "alice", "password": "s3cret"}
+
+
+def test_resolve_site_credential_none_when_absent(monkeypatch):
+    monkeypatch.setattr("app.routers.v3.db.fetch_one", lambda q, p: None)
+    from app.lib.api_keys import resolve_site_credential
+    assert resolve_site_credential("nope.com", user_id="uid", org_id=None) is None
+
+
+def test_resolve_site_credential_skips_mcp_system(monkeypatch):
+    called = {"n": 0}
+    def fake(q, p):
+        called["n"] += 1
+        return None
+    monkeypatch.setattr("app.routers.v3.db.fetch_one", fake)
+    from app.lib.api_keys import resolve_site_credential
+    # mcp-system pseudo-user + no org → no lookup attempted
+    assert resolve_site_credential("x.com", user_id="mcp-system", org_id=None) is None
+    assert called["n"] == 0


### PR DESCRIPTION
Final item of the push-the-ceiling program. Lets the stealth browser log in with the user's OWN stored credential to reach data gated behind an account — never auto-creating accounts.

## Backend
- `POST/GET /v3/settings/site-credentials` — store the user's site login (username+password) encrypted in the vault under `sitecred:<site>`; GET returns site+scope+username only (**password never returned**); excluded from the api-keys list.
- `resolve_site_credential()` — server-side-only (user→org scope); password never threaded to the brain; values not logged.
- `stealth_browser` optional login: resolves the credential server-side, fills+submits the login form in nodriver, persists the session, fetches targets authenticated. SSRF-checks the login_url; degrades to unauthenticated if no credential.
- `run_stealth_browser` MCP tool authenticated mode (site reference + selectors — brain never sees the password).

## Frontend
Settings → **Site Logins** section to store/list logins (password input, never displayed back).

## Validation (live)
- Store→204; GET shows site+username, **no password**; not in api-keys list; **0 password occurrences in logs**; encrypt/decrypt roundtrip confirmed (GET shows the decrypted username).
- **End-to-end login proven**: stored published test creds for the public automation-practice site, called stealth_browser in authenticated mode → it logged in + fetched `/secure` returning "Welcome to the Secure Area … Logout" (the post-login page). nodriver form-fill + session persistence work.

## Security
Own-credentials only; **no account creation**; password encrypted at rest, never returned/logged, never reaches the brain; login_url SSRF-guarded. Backend tests + frontend tsc + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)