### PR TITLE
feat(admin): Benchmark Reports page (persist + display + run from UI)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -481,7 +481,9 @@ from app.routers.v3.investigation_templates import router as v3_investigation_te
 from app.routers.v3.absorption import router as v3_absorption_router  # noqa: E402
 from app.routers.v3.modes import router as v3_modes_router  # noqa: E402
 from app.routers.v3.visibility import router as v3_visibility_router  # noqa: E402
+from app.routers.v3.benchmarks import router as v3_benchmarks_router  # noqa: E402
 app.include_router(v3_auth_router)
+app.include_router(v3_benchmarks_router)
 app.include_router(v3_oauth_router)
 app.include_router(v3_users_router)
 app.include_router(v3_plugins_router)

--- a/app/routers/v3/benchmarks.py
+++ b/app/routers/v3/benchmarks.py
@@ -1,0 +1,176 @@
+"""Benchmark reports API — persist + serve gold-set benchmark runs, and trigger
+new runs from the admin UI.
+
+- POST /v3/benchmarks/reports        ingest a report (run_benchmark posts here; API-key auth)
+- GET  /v3/benchmarks/reports        list reports (admin)
+- GET  /v3/benchmarks/reports/{id}   full report (admin)
+- POST /v3/benchmarks/run            trigger a benchmark run in the background (admin)
+- GET  /v3/benchmarks/run/status     is a run active? (admin)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.deps import require_api_key
+from app.routers.v3.auth import require_admin
+from app.routers.v3.db import fetch_all, fetch_one
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v3/benchmarks", tags=["v3-benchmarks"])
+
+# Default leads gold-set items a UI-triggered run benchmarks.
+_DEFAULT_ITEMS = [
+    "leads-gen-fsbo-chicago-001",
+    "leads-gen-rental-austin-001",
+    "leads-gen-fsbo-phoenix-001",
+    "leads-gen-agent-austin-001",
+]
+
+# In-process state for a UI-triggered run (single concurrent run).
+_RUN_STATE: dict = {"active": False, "started_at": None, "proc": None, "items": []}
+
+
+# ---------------------------------------------------------------------------
+# Ingest + read
+# ---------------------------------------------------------------------------
+
+class ReportIn(BaseModel):
+    label: str | None = None
+    report: dict
+
+
+def _summary(report: dict) -> tuple[float | None, int | None, float | None]:
+    overall = (report.get("aggregates") or {}).get("overall") or {}
+    return (
+        overall.get("mean_score"),
+        overall.get("total_items"),
+        overall.get("gamed_pct"),
+    )
+
+
+@router.post("/reports", status_code=201)
+def ingest_report(body: ReportIn, _key: str = Depends(require_api_key)) -> dict:
+    """Store a benchmark report (called by run_benchmark after a run)."""
+    mean_score, total_items, gamed_pct = _summary(body.report)
+    row = fetch_one(
+        """
+        INSERT INTO benchmark_reports (label, mean_score, total_items, gamed_pct, report)
+        VALUES (%s, %s, %s, %s, %s::jsonb)
+        RETURNING id::text, created_at
+        """,
+        (body.label, mean_score, total_items, gamed_pct, json.dumps(body.report)),
+    )
+    log.info("benchmarks: ingested report id=%s mean_score=%s items=%s", row["id"], mean_score, total_items)
+    return {"id": row["id"], "mean_score": mean_score, "total_items": total_items}
+
+
+@router.get("/reports")
+def list_reports(_user: dict = Depends(require_admin)) -> list[dict]:
+    rows = fetch_all(
+        """
+        SELECT id::text, created_at, label, mean_score, total_items, gamed_pct
+          FROM benchmark_reports
+         ORDER BY created_at DESC
+         LIMIT 100
+        """,
+        (),
+    )
+    return [
+        {
+            "id": r["id"],
+            "created_at": str(r["created_at"]),
+            "label": r["label"],
+            "mean_score": r["mean_score"],
+            "total_items": r["total_items"],
+            "gamed_pct": r["gamed_pct"],
+        }
+        for r in rows
+    ]
+
+
+@router.get("/reports/{report_id}")
+def get_report(report_id: str, _user: dict = Depends(require_admin)) -> dict:
+    row = fetch_one(
+        "SELECT id::text, created_at, label, report FROM benchmark_reports WHERE id = %s",
+        (report_id,),
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Report not found")
+    report = row["report"] if isinstance(row["report"], dict) else json.loads(row["report"])
+    return {"id": row["id"], "created_at": str(row["created_at"]), "label": row["label"], "report": report}
+
+
+# ---------------------------------------------------------------------------
+# Run trigger (background subprocess; single concurrent run)
+# ---------------------------------------------------------------------------
+
+class RunIn(BaseModel):
+    items: list[str] | None = None
+    label: str | None = None
+
+
+def _run_active() -> bool:
+    proc = _RUN_STATE.get("proc")
+    if _RUN_STATE.get("active") and proc is not None and proc.poll() is None:
+        return True
+    # process finished (or none) → clear stale active flag
+    if _RUN_STATE.get("active") and (proc is None or proc.poll() is not None):
+        _RUN_STATE["active"] = False
+    return False
+
+
+@router.post("/run", status_code=202)
+def trigger_run(body: RunIn, _user: dict = Depends(require_admin)) -> dict:
+    """Spawn a benchmark run in the background. The run posts its report back to
+    /v3/benchmarks/reports on completion (appears in the list). Single concurrent
+    run — returns 409 if one is already active. NOTE: a run spends real brain time
+    (several minutes per item)."""
+    if _run_active():
+        raise HTTPException(status_code=409, detail="A benchmark run is already in progress")
+
+    items = body.items or _DEFAULT_ITEMS
+    api_key = os.getenv("INFO_BROKER_API_KEY", "")
+    label = body.label or f"UI run {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
+    out_path = f"/tmp/bench_ui_{int(time.time())}.json"
+
+    env = {
+        **os.environ,
+        "LOCAL_STACK_URL": "http://localhost:8000",
+        "BENCH_USERNAME": os.getenv("BENCH_USERNAME", "admin"),
+        "BENCH_PASSWORD": os.getenv("BENCH_PASSWORD", "admin"),
+        "INFO_BROKER_API_KEY": api_key,
+        # tell the CLI to POST its report back to this API on completion
+        "BENCHMARK_INGEST_URL": "http://localhost:8000",
+        "BENCHMARK_INGEST_LABEL": label,
+        "BENCH_TIMEOUT_S": os.getenv("BENCH_TIMEOUT_S", "1200"),
+    }
+    cmd = [sys.executable, "-m", "benchmarks.run_benchmark", "--out-json", out_path,
+           "--items", *items, "--log-level", "WARNING"]
+    try:
+        proc = subprocess.Popen(cmd, env=env, cwd="/app",
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception as exc:
+        log.error("benchmarks: failed to spawn run: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Could not start run: {exc}")
+
+    _RUN_STATE.update({"active": True, "started_at": datetime.now(timezone.utc).isoformat(),
+                       "proc": proc, "items": items})
+    log.info("benchmarks: started UI run pid=%s items=%s", proc.pid, items)
+    return {"status": "started", "items": items, "label": label}
+
+
+@router.get("/run/status")
+def run_status(_user: dict = Depends(require_admin)) -> dict:
+    active = _run_active()
+    return {"active": active, "started_at": _RUN_STATE.get("started_at") if active else None,
+            "items": _RUN_STATE.get("items") if active else []}

--- a/app/routers/v3/db.py
+++ b/app/routers/v3/db.py
@@ -962,6 +962,21 @@ CREATE INDEX IF NOT EXISTS idx_api_key_vault_lookup
 """
 
 
+_MIGRATION_BENCHMARK_REPORTS = """
+CREATE TABLE IF NOT EXISTS benchmark_reports (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    label        TEXT,
+    mean_score   DOUBLE PRECISION,
+    total_items  INT,
+    gamed_pct    DOUBLE PRECISION,
+    report       JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_benchmark_reports_created
+    ON benchmark_reports (created_at DESC)
+"""
+
+
 def _split_sql_statements(sql: str) -> list[str]:
     """Split SQL on ';' but respect string literals and dollar-quoted blocks.
 
@@ -1069,7 +1084,7 @@ def _split_sql_statements(sql: str) -> list[str]:
 def run_migrations() -> None:
     # Ensure each migration block ends with ';' so concatenation doesn't merge
     # the last statement of one block with the first of the next.
-    parts = [_MIGRATION, _SEED, _MIGRATION_WALLET_V2, _MIGRATION_FINDINGS_GRADES, _MIGRATION_SHARE_LINKS, _MIGRATION_SAVED_TEMPLATES, _MIGRATION_WORKING_MEMORY, _MIGRATION_ORG_TENANCY, _MIGRATION_API_KEY_VAULT]
+    parts = [_MIGRATION, _SEED, _MIGRATION_WALLET_V2, _MIGRATION_FINDINGS_GRADES, _MIGRATION_SHARE_LINKS, _MIGRATION_SAVED_TEMPLATES, _MIGRATION_WORKING_MEMORY, _MIGRATION_ORG_TENANCY, _MIGRATION_API_KEY_VAULT, _MIGRATION_BENCHMARK_REPORTS]
     all_sql = "\n".join(p.rstrip().rstrip(";") + ";\n" for p in parts)
     statements = _split_sql_statements(all_sql)
     with get_conn() as conn:

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -597,6 +597,22 @@ def main(argv: list[str] | None = None) -> int:
         print("\nJSON report:")
         print(json.dumps(report, indent=2))
 
+    # Optional: POST the report to the app so it appears on the admin Benchmark
+    # Reports page. Enabled by BENCHMARK_INGEST_URL (set by the UI-triggered run).
+    ingest_url = os.getenv("BENCHMARK_INGEST_URL")
+    if ingest_url:
+        try:
+            resp = requests.post(
+                f"{ingest_url.rstrip('/')}/v3/benchmarks/reports",
+                headers={"X-API-Key": os.getenv("INFO_BROKER_API_KEY", "")},
+                json={"label": os.getenv("BENCHMARK_INGEST_LABEL") or None, "report": report},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            log.info("Report ingested to %s (id=%s)", ingest_url, resp.json().get("id"))
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Report ingest failed: %s", exc)
+
     # Exit code: 0 if any item scored > 0, else 1
     any_scored = any(r["item_score"] > 0 for r in all_results)
     return 0 if any_scored else 1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ const LiveProcessesPage = lazy(() => import('./pages/LiveProcessesPage'))
 const KnowledgeGraphPage = lazy(() => import('./pages/KnowledgeGraphPage'))
 const PerformanceDashboardPage = lazy(() => import('./pages/PerformanceDashboardPage'))
 const AdminUsersPage = lazy(() => import('./pages/AdminUsersPage'))
+const BenchmarkReportsPage = lazy(() => import('./pages/BenchmarkReportsPage'))
 const AssetsPage = lazy(() => import('./pages/AssetsPage'))
 const Wallet = lazy(() => import('./pages/Wallet'))
 const Runs = lazy(() => import('./pages/Runs'))
@@ -64,6 +65,7 @@ export default function App() {
             <Route path="/settings/plugins/:name" element={<AuthGuard><Settings /></AuthGuard>} />
             <Route path="/admin/processes" element={<AuthGuard><LiveProcessesPage /></AuthGuard>} />
             <Route path="/admin/users" element={<AuthGuard><AdminUsersPage /></AuthGuard>} />
+            <Route path="/admin/benchmarks" element={<AuthGuard><BenchmarkReportsPage /></AuthGuard>} />
             <Route path="/knowledge" element={<AuthGuard><KnowledgeGraphPage /></AuthGuard>} />
             <Route path="/performance" element={<AuthGuard><PerformanceDashboardPage /></AuthGuard>} />
             {/* Public share route — NO auth guard */}

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -841,3 +841,25 @@ export const storeSiteCredential = (
 
 export const listSiteCredentials = (): Promise<SiteCredentialEntry[]> =>
   api.get<SiteCredentialEntry[]>('/v3/settings/site-credentials').then(r => r.data)
+
+// --- Benchmark reports (admin) -----------------------------------------------
+export interface BenchmarkReportSummary {
+  id: string
+  created_at: string
+  label: string | null
+  mean_score: number | null
+  total_items: number | null
+  gamed_pct: number | null
+}
+
+export const listBenchmarkReports = (): Promise<BenchmarkReportSummary[]> =>
+  api.get<BenchmarkReportSummary[]>('/v3/benchmarks/reports').then(r => r.data)
+
+export const getBenchmarkReport = (id: string): Promise<{ id: string; created_at: string; label: string | null; report: Record<string, unknown> }> =>
+  api.get(`/v3/benchmarks/reports/${id}`).then(r => r.data)
+
+export const runBenchmark = (items?: string[], label?: string): Promise<{ status: string; items: string[]; label: string }> =>
+  api.post('/v3/benchmarks/run', { items, label }).then(r => r.data)
+
+export const getBenchmarkRunStatus = (): Promise<{ active: boolean; started_at: string | null; items: string[] }> =>
+  api.get('/v3/benchmarks/run/status').then(r => r.data)

--- a/frontend/src/components/layout/IconRail.tsx
+++ b/frontend/src/components/layout/IconRail.tsx
@@ -15,6 +15,7 @@ import {
   BarChart3,
   Settings,
   Users,
+  Gauge,
   Wallet,
   List,
   FolderOpen,
@@ -40,6 +41,7 @@ const NAV = [
 
 const NAV_ADMIN = [
   { icon: <Users size={18} />, path: '/admin/users', label: 'User Management' },
+  { icon: <Gauge size={18} />, path: '/admin/benchmarks', label: 'Benchmark Reports' },
 ]
 
 const RAIL_W = 52

--- a/frontend/src/pages/BenchmarkReportsPage.tsx
+++ b/frontend/src/pages/BenchmarkReportsPage.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import IconRail from '../components/layout/IconRail'
+import { useSessionStore } from '../stores/sessionStore'
+import {
+  listBenchmarkReports,
+  getBenchmarkReport,
+  runBenchmark,
+  getBenchmarkRunStatus,
+} from '../api/v3'
+
+const num = (v: unknown, d = 2): string =>
+  typeof v === 'number' ? v.toFixed(d) : '—'
+
+function grade(mean: number | null | undefined): { letter: string; color: string } {
+  if (mean == null) return { letter: '—', color: 'var(--muted)' }
+  if (mean >= 0.85) return { letter: 'A', color: '#34d399' }
+  if (mean >= 0.70) return { letter: 'B', color: '#34d399' }
+  if (mean >= 0.55) return { letter: 'C', color: '#fbbf24' }
+  if (mean >= 0.40) return { letter: 'D', color: '#fb923c' }
+  return { letter: 'F', color: '#f87171' }
+}
+
+const SEV_COLOR: Record<string, string> = {
+  critical: '#f87171', error: '#f87171', warning: '#fbbf24', info: '#60a5fa',
+}
+
+export default function BenchmarkReportsPage() {
+  const isAdmin = useSessionStore(s => s.isAdmin)
+  const qc = useQueryClient()
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const reportsQ = useQuery({ queryKey: ['benchmarkReports'], queryFn: listBenchmarkReports, enabled: isAdmin })
+  const statusQ = useQuery({
+    queryKey: ['benchmarkRunStatus'], queryFn: getBenchmarkRunStatus, enabled: isAdmin,
+    refetchInterval: 15000,
+  })
+  const reportQ = useQuery({
+    queryKey: ['benchmarkReport', selectedId], queryFn: () => getBenchmarkReport(selectedId!),
+    enabled: isAdmin && !!selectedId,
+  })
+
+  // auto-select the newest report; refresh the list when a run finishes
+  useEffect(() => {
+    const list = reportsQ.data
+    if (list && list.length && !selectedId) setSelectedId(list[0].id)
+  }, [reportsQ.data, selectedId])
+
+  const wasActive = statusQ.data?.active
+  useEffect(() => {
+    if (wasActive === false) { qc.invalidateQueries({ queryKey: ['benchmarkReports'] }) }
+  }, [wasActive, qc])
+
+  const runMut = useMutation({
+    mutationFn: () => runBenchmark(),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['benchmarkRunStatus'] }) },
+  })
+
+  if (!isAdmin) {
+    return (
+      <div style={{ display: 'flex' }}>
+        <div style={{ flex: 1, padding: 24, color: 'var(--text)' }}>Admin only.</div>
+        <IconRail />
+      </div>
+    )
+  }
+
+  const active = statusQ.data?.active
+  const report = (reportQ.data?.report ?? {}) as any
+  const items: any[] = report.item_results ?? []
+  const meta: any[] = report.run_metadata ?? []
+  const overall = report.aggregates?.overall ?? {}
+  const cost = report.aggregates?.cost_summary ?? {}
+  const recs: any[] = report.recommendations ?? []
+  const g = grade(overall.mean_score)
+  const metaById = (id: string) => meta.find(m => m.run_id && items.find(it => it.item_id === id))
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <div style={{ flex: 1, padding: '24px 28px', color: 'var(--text)', maxWidth: 1100, overflow: 'auto' }}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 16 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 700 }}>Benchmark Reports</h1>
+          <button
+            data-testid="bench-run"
+            onClick={() => runMut.mutate()}
+            disabled={active || runMut.isPending}
+            style={{
+              fontSize: 12, padding: '6px 14px', borderRadius: 6, border: 'none',
+              background: active ? 'var(--panel2)' : 'var(--accent)',
+              color: active ? 'var(--muted)' : '#fff',
+              cursor: active || runMut.isPending ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {active ? 'Run in progress…' : runMut.isPending ? 'Starting…' : 'Run benchmark'}
+          </button>
+        </div>
+
+        {active && (
+          <div style={{ marginBottom: 12, padding: '8px 12px', borderRadius: 6, fontSize: 12,
+            background: 'rgba(251,191,36,0.12)', color: '#fbbf24' }}>
+            A benchmark run is in progress (started {statusQ.data?.started_at?.slice(0, 16).replace('T', ' ')} UTC).
+            Real brain time — several minutes per item. The new report appears here when it finishes.
+          </div>
+        )}
+
+        {!reportsQ.data?.length ? (
+          <p style={{ color: 'var(--subtext)', fontSize: 13 }}>
+            No benchmark reports yet. Click <strong>Run benchmark</strong> (or run
+            <code> python -m benchmarks.run_benchmark</code> with <code>BENCHMARK_INGEST_URL</code> set) to create one.
+          </p>
+        ) : (
+          <>
+            {/* Report selector */}
+            <div style={{ marginBottom: 16 }}>
+              <label style={{ fontSize: 11, color: 'var(--muted)', marginRight: 8 }}>Report:</label>
+              <select
+                data-testid="bench-report-select"
+                value={selectedId ?? ''}
+                onChange={e => setSelectedId(e.target.value)}
+                style={{ fontSize: 12, padding: '4px 8px', borderRadius: 4, background: 'var(--panel)', color: 'var(--text)', border: '1px solid var(--border)' }}
+              >
+                {reportsQ.data.map(r => (
+                  <option key={r.id} value={r.id}>
+                    {r.created_at.slice(0, 16).replace('T', ' ')} — {r.label ?? 'run'} ({num(r.mean_score)})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Headline rating */}
+            <div style={{ display: 'flex', gap: 16, alignItems: 'center', marginBottom: 20, flexWrap: 'wrap' }}>
+              <div style={{ padding: '14px 22px', borderRadius: 10, background: 'var(--panel)', border: '1px solid var(--border)', textAlign: 'center' }}>
+                <div style={{ fontSize: 40, fontWeight: 800, color: g.color, lineHeight: 1 }} data-testid="bench-mean-score">
+                  {overall.mean_score != null ? `${(overall.mean_score * 100).toFixed(1)}%` : '—'}
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--muted)', marginTop: 4 }}>mean score · grade {g.letter}</div>
+              </div>
+              <Stat label="items" value={overall.total_items ?? items.length} />
+              <Stat label="gamed" value={`${num(overall.gamed_pct, 0)}%`}
+                color={overall.gamed_items ? '#f87171' : '#34d399'} />
+              <Stat label="RU cost" value={cost.total_ru_consumed ?? '—'} />
+              <Stat label="cost/lead" value={num(cost.cost_per_lead)} />
+              <Stat label="avg duration" value={cost.avg_duration_s ? `${Math.round(cost.avg_duration_s)}s` : '—'} />
+            </div>
+
+            {/* Per-item table */}
+            <table style={{ width: '100%', fontSize: 12, borderCollapse: 'collapse', marginBottom: 24 }}>
+              <thead>
+                <tr style={{ color: 'var(--muted)', textAlign: 'left', borderBottom: '1px solid var(--border)' }}>
+                  <th style={{ padding: '6px 8px' }}>Item</th>
+                  <th style={{ padding: '6px 8px' }}>Score</th>
+                  <th style={{ padding: '6px 8px' }}>Coverage</th>
+                  <th style={{ padding: '6px 8px' }}>Source qual.</th>
+                  <th style={{ padding: '6px 8px' }}>Leads</th>
+                  <th style={{ padding: '6px 8px' }}>Field cov.</th>
+                  <th style={{ padding: '6px 8px' }}>Guard</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((it, i) => {
+                  const rich = it.richness ?? {}
+                  return (
+                    <tr key={it.item_id ?? i} style={{ borderBottom: '1px solid var(--border)' }}>
+                      <td style={{ padding: '6px 8px' }}>{it.item_id}</td>
+                      <td style={{ padding: '6px 8px', fontWeight: 600 }}>{num(it.item_score)}</td>
+                      <td style={{ padding: '6px 8px' }}>{num(it.coverage)}</td>
+                      <td style={{ padding: '6px 8px' }}>{num(it.source_quality)}</td>
+                      <td style={{ padding: '6px 8px' }}>{rich.lead_count ?? '—'}</td>
+                      <td style={{ padding: '6px 8px' }}>{num(rich.field_coverage)}</td>
+                      <td style={{ padding: '6px 8px', color: it.tripped_guard ? '#f87171' : 'var(--muted)' }}>
+                        {it.tripped_guard ?? '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+
+            {/* Recommendations */}
+            {recs.length > 0 && (
+              <section style={{ marginBottom: 24 }}>
+                <h2 style={{ fontSize: 14, fontWeight: 600, marginBottom: 8 }}>Recommendations</h2>
+                {recs.map((r, i) => (
+                  <div key={i} style={{ fontSize: 12, padding: '6px 10px', marginBottom: 6, borderRadius: 4,
+                    background: 'var(--panel)', borderLeft: `3px solid ${SEV_COLOR[r.severity] ?? 'var(--border)'}` }}>
+                    <span style={{ color: SEV_COLOR[r.severity] ?? 'var(--muted)', fontWeight: 600, textTransform: 'uppercase', fontSize: 10 }}>
+                      {r.severity} · {r.category}
+                    </span>
+                    <div style={{ color: 'var(--text)', marginTop: 2 }}>{r.message ?? r.detail}</div>
+                  </div>
+                ))}
+              </section>
+            )}
+
+            {/* Analysis / methodology */}
+            <section style={{ fontSize: 12, color: 'var(--subtext)', lineHeight: 1.7,
+              background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 8, padding: '12px 16px' }}>
+              <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--text)', marginBottom: 6 }}>How to read this</h2>
+              <p><strong>item_score = coverage × source_quality.</strong> Coverage = fraction of the item&apos;s
+                curated authoritative facts matched. Source quality weights provenance
+                (primary_official / live_official = 1.0, live_search = 0.75, training = 0).
+                Four anti-gaming guards hard-zero any run that fabricates from training data, uses
+                unregistered tools, skips phases, or RAG-shortcuts — so a clean run with 0% gamed is
+                doing real live research.</p>
+              <p style={{ marginTop: 6 }}><strong>field_coverage</strong> = fraction of the 10 lead fields
+                (address/price/listing_url/agent &amp; owner name/email/phone/background) surfaced run-wide —
+                it reflects enrichment breadth even when fields land in separate, not-yet-merged leads.</p>
+              <p style={{ marginTop: 6 }}><strong>Known ceilings &amp; caveats:</strong> free enrichment works
+                where data is page-available (agent contact); FSBO-platform <em>seller</em> contact is gated
+                behind logins/forms (a data wall, not a tooling gap); county open-data APIs are the robust
+                free owner source. Runs are <em>stochastic</em> — a single item can swing (e.g. a thin 2-tool-call
+                run), so trust the trend across multiple reports, not one number. Scores shown are the
+                <strong> no-key</strong> free-capability baseline unless a run had keys configured.</p>
+            </section>
+          </>
+        )}
+      </div>
+      <IconRail />
+    </div>
+  )
+}
+
+function Stat({ label, value, color }: { label: string; value: React.ReactNode; color?: string }) {
+  return (
+    <div style={{ padding: '10px 16px', borderRadius: 8, background: 'var(--panel)', border: '1px solid var(--border)', textAlign: 'center', minWidth: 78 }}>
+      <div style={{ fontSize: 18, fontWeight: 700, color: color ?? 'var(--text)' }}>{value}</div>
+      <div style={{ fontSize: 10, color: 'var(--muted)', marginTop: 2 }}>{label}</div>
+    </div>
+  )
+}

--- a/tests/routers/v3/test_benchmarks_router.py
+++ b/tests/routers/v3/test_benchmarks_router.py
@@ -1,0 +1,38 @@
+"""Unit tests for benchmark report summary extraction + run-state logic (pure)."""
+from __future__ import annotations
+
+from app.routers.v3 import benchmarks as b
+
+
+def test_summary_extracts_overall():
+    report = {"aggregates": {"overall": {"mean_score": 0.62, "total_items": 4, "gamed_pct": 25.0}}}
+    mean, items, gamed = b._summary(report)
+    assert mean == 0.62 and items == 4 and gamed == 25.0
+
+
+def test_summary_missing_aggregates_is_none():
+    assert b._summary({}) == (None, None, None)
+    assert b._summary({"aggregates": {}}) == (None, None, None)
+
+
+def test_run_active_false_when_no_proc():
+    b._RUN_STATE.update({"active": False, "proc": None})
+    assert b._run_active() is False
+
+
+def test_run_active_clears_stale_flag_when_proc_finished():
+    class _Done:
+        def poll(self):  # finished process
+            return 0
+    b._RUN_STATE.update({"active": True, "proc": _Done()})
+    assert b._run_active() is False
+    assert b._RUN_STATE["active"] is False
+
+
+def test_run_active_true_while_proc_alive():
+    class _Alive:
+        def poll(self):  # still running
+            return None
+    b._RUN_STATE.update({"active": True, "proc": _Alive()})
+    assert b._run_active() is True
+    b._RUN_STATE.update({"active": False, "proc": None})  # reset


### PR DESCRIPTION
Admin page at /admin/benchmarks surfacing the gold-set benchmark rating + analysis. Backend: benchmark_reports table + ingest/list/get + run-trigger (background subprocess, 409 guard) + status; run_benchmark self-ingests via BENCHMARK_INGEST_URL. Frontend: rating header + grade, run-history selector, per-item table, cost stats, recommendations, methodology/ceilings analysis, Run button + polling. Validated live (ingest/list/get/run/409/status); 5 unit tests + tsc green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)