### PR TITLE
fix(ui): transparent download dropdown + broken download button

### DIFF
--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -554,21 +554,15 @@ export const exportResearch = (runId: string, format: 'pdf' | 'csv' | 'xlsx') =>
 
 export type ExportFormat = 'csv' | 'xlsx'
 
-export interface RunExport {
-  id: string
-  run_id: string
-  format: ExportFormat
-  status: 'pending' | 'ready' | 'failed'
-  size_bytes: number | null
-  error: string | null
-  download_url: string | null
+export interface ExportResult {
+  filename: string
+  url: string
 }
 
-export const createExport = (runId: string, format: ExportFormat): Promise<RunExport> =>
-  api.post<RunExport>(`/v3/exports/research/${runId}`, { format }).then(r => r.data)
-
-export const getExport = (exportId: string): Promise<RunExport> =>
-  api.get<RunExport>(`/v3/exports/${exportId}`).then(r => r.data)
+// Synchronous: the backend generates the file immediately and returns its
+// filename + relative download URL ( /v3/exports/files/<filename> ).
+export const createExport = (runId: string, format: ExportFormat): Promise<ExportResult> =>
+  api.post<ExportResult>(`/v3/exports/research/${runId}`, { format, include_analysis: true }).then(r => r.data)
 
 // --- Scorecard ---
 

--- a/frontend/src/components/runs/DownloadMenu.test.tsx
+++ b/frontend/src/components/runs/DownloadMenu.test.tsx
@@ -5,18 +5,20 @@ import { DownloadMenu } from './DownloadMenu'
 
 vi.mock('@/api/v3', () => ({
   createExport: vi.fn(),
-  getExport: vi.fn(),
+}))
+vi.mock('@/api/client', () => ({
+  api: { get: vi.fn() },
 }))
 
-import { createExport, getExport } from '@/api/v3'
+import { createExport } from '@/api/v3'
+import { api } from '@/api/client'
 
 describe('DownloadMenu', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, assign: vi.fn(), href: '' },
-      writable: true,
-    })
+    // jsdom lacks URL.createObjectURL
+    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn(() => 'blob:mock'), writable: true })
+    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), writable: true })
   })
 
   it('shows the Download trigger button', () => {
@@ -24,20 +26,30 @@ describe('DownloadMenu', () => {
     expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument()
   })
 
-  it('on CSV click, POSTs export then polls until ready and triggers download', async () => {
+  it('on CSV click, creates the export then downloads the returned file as a blob', async () => {
     ;(createExport as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      id: 'exp-1', run_id: 'run-1', format: 'csv',
-      status: 'pending', size_bytes: null, error: null, download_url: null,
+      filename: 'run-1.csv',
+      url: '/v3/exports/files/run-1.csv',
     })
-    ;(getExport as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ id: 'exp-1', run_id: 'run-1', format: 'csv', status: 'pending', size_bytes: null, error: null, download_url: null })
-      .mockResolvedValueOnce({ id: 'exp-1', run_id: 'run-1', format: 'csv', status: 'ready', size_bytes: 42, error: null, download_url: '/v3/exports/exp-1/download' })
+    ;(api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: new Blob(['a,b\n1,2']) })
 
-    render(<DownloadMenu runId="run-1" pollIntervalMs={10} />)
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    render(<DownloadMenu runId="run-1" />)
     await userEvent.click(screen.getByRole('button', { name: /download/i }))
     await userEvent.click(await screen.findByText(/export as csv/i))
 
     await waitFor(() => expect(createExport).toHaveBeenCalledWith('run-1', 'csv'))
-    await waitFor(() => expect(window.location.href).toContain('/v3/exports/exp-1/download'), { timeout: 1000 })
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/v3/exports/files/run-1.csv', { responseType: 'blob' }))
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+    clickSpy.mockRestore()
+  })
+
+  it('surfaces an error if the export fails', async () => {
+    ;(createExport as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('export generation failed'))
+    render(<DownloadMenu runId="run-1" />)
+    await userEvent.click(screen.getByRole('button', { name: /download/i }))
+    await userEvent.click(await screen.findByText(/export as csv/i))
+    await waitFor(() => expect(screen.getByText(/export generation failed/i)).toBeInTheDocument())
   })
 })

--- a/frontend/src/components/runs/DownloadMenu.tsx
+++ b/frontend/src/components/runs/DownloadMenu.tsx
@@ -7,39 +7,34 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Button } from '@/components/ui/button'
 import { Download, Loader2, ChevronDown } from 'lucide-react'
-import { createExport, getExport, type ExportFormat } from '@/api/v3'
+import { createExport, type ExportFormat } from '@/api/v3'
+import { api } from '@/api/client'
 
 interface Props {
   runId: string
-  pollIntervalMs?: number
 }
 
-export function DownloadMenu({ runId, pollIntervalMs = 2000 }: Props) {
+export function DownloadMenu({ runId }: Props) {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  async function pollUntilReady(exportId: string): Promise<void> {
-    while (true) {
-      const exp = await getExport(exportId)
-      if (exp.status === 'ready') {
-        window.location.href = exp.download_url ?? `/v3/exports/${exportId}/download`
-        return
-      }
-      if (exp.status === 'failed') throw new Error(exp.error ?? 'export failed')
-      await new Promise<void>((r) => setTimeout(r, pollIntervalMs))
-    }
-  }
 
   async function start(format: ExportFormat) {
     setBusy(true)
     setError(null)
     try {
+      // Export is synchronous: returns { filename, url }. Fetch the file through
+      // the authenticated API client as a blob, then trigger a browser download
+      // (robust across dev proxy / prod origin, vs window.location on a relative URL).
       const exp = await createExport(runId, format)
-      if (exp.status === 'ready' && exp.download_url) {
-        window.location.href = exp.download_url
-      } else {
-        await pollUntilReady(exp.id)
-      }
+      const resp = await api.get(exp.url, { responseType: 'blob' })
+      const blobUrl = URL.createObjectURL(resp.data as Blob)
+      const a = document.createElement('a')
+      a.href = blobUrl
+      a.download = exp.filename
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(blobUrl)
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'export error')
     } finally {
@@ -48,21 +43,25 @@ export function DownloadMenu({ runId, pollIntervalMs = 2000 }: Props) {
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" disabled={busy} aria-label="Download">
-          {busy
-            ? <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-            : <Download className="h-3 w-3 mr-1" />}
-          Download
-          <ChevronDown className="h-3 w-3 ml-1" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => start('csv')}>Export as CSV</DropdownMenuItem>
-        <DropdownMenuItem onClick={() => start('xlsx')}>Export as XLSX</DropdownMenuItem>
-        {error && <DropdownMenuItem disabled className="text-red-600">{error}</DropdownMenuItem>}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div className="inline-flex flex-col items-end">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" disabled={busy} aria-label="Download">
+            {busy
+              ? <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+              : <Download className="h-3 w-3 mr-1" />}
+            Download
+            <ChevronDown className="h-3 w-3 ml-1" />
+          </Button>
+        </DropdownMenuTrigger>
+        {/* solid bg: bg-popover now resolves (popover color added to the theme) */}
+        <DropdownMenuContent align="end" className="bg-popover">
+          <DropdownMenuItem onClick={() => start('csv')}>Export as CSV</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => start('xlsx')}>Export as XLSX</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {/* error shown OUTSIDE the dropdown (which closes on select), so it stays visible */}
+      {error && <span role="alert" className="text-xs text-red-500 mt-1 max-w-[200px] text-right">{error}</span>}
+    </div>
   )
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -23,6 +23,7 @@ export default {
         muted: { DEFAULT: 'var(--muted)', foreground: 'var(--muted-foreground)' },
         accent: { DEFAULT: 'var(--accent)', foreground: 'var(--accent-foreground)' },
         card: { DEFAULT: 'var(--card)', foreground: 'var(--card-foreground)' },
+        popover: { DEFAULT: 'var(--popover)', foreground: 'var(--popover-foreground)' },
         navy: {
           bg:      '#070e1a',
           panel:   '#0d1b2a',


### PR DESCRIPTION
**Dropdown transparency:** `popover` was missing from tailwind.config.js colors, so `bg-popover` resolved to nothing → added the mapping (fixes all popovers/dropdowns). **Download error:** frontend expected an async export+poll, but the backend is synchronous (`{filename,url}`) → it polled `getExport(undefined)` and errored. Rewrote createExport to the real shape + DownloadMenu to blob-download via the authenticated client; moved the error outside the (auto-closing) dropdown. Backend export verified live (200, valid CSV). 3 tests + tsc green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)