### PR TITLE
docs: run exports + benchmark reports (+ reconcile #165–#168)

### DIFF
--- a/docs/TICKET-TRACKING.md
+++ b/docs/TICKET-TRACKING.md
@@ -1,6 +1,6 @@
 # Ticket Tracking — issues ↔ code ↔ PRs ↔ branches
 
-> Last reconciled: **2026-05-26** (PRs #118, #120–#129, #132–#140, #142–#144, #146–#163 merged; #68, #89, #90, #94, #95, #110, #111, #130 closed; #131 open/downgraded; API-key vault+gates #74/#75/#76 DONE (#150/#153/#154); benchmark #79/#145 DONE+live-validated; **free-enrichment/stealth program #159–#163 DONE**)
+> Last reconciled: **2026-05-26** (PRs #118, #120–#129, #132–#140, #142–#144, #146–#168 merged; #68, #89, #90, #94, #95, #110, #111, #130 closed; #131 open/downgraded; API-key vault+gates #74/#75/#76 DONE (#150/#153/#154); benchmark #79/#145 DONE+live-validated; **free-enrichment/stealth program #159–#163 DONE**)
 
 ## Free-enrichment / stealth-scraping program (#159–#163)
 
@@ -13,6 +13,10 @@ Driven by the directive: don't gate capability behind the easiest method (paid A
 | #161 | `lead_richness` scores synthesized `ranked_candidates` (not raw findings) + `field_coverage` metric (honest measurement of what the run surfaced). |
 | #162 | Public-records owner identity via county OPEN-DATA APIs (Socrata/ArcGIS) — validated Cook County `datacatalog.cookcountyil.gov` returns owner mailing address as JSON. |
 | #163 | Authenticated sessions: own-credential site-login vault (`sitecred:<site>`, password never returned/logged/to-brain) + nodriver login form-fill (validated end-to-end on a public test-login site). |
+| #165 | Authoritative source classification (best of brain/technique/URL → primary_official/live_official; `live_official` added to live-source sets) + property history/tax/financial records (`property_history_records` technique). Lifted source_quality 0.75→1.0. |
+| #166 | Admin **Benchmark Reports** page (`/admin/benchmarks`): rating + grade, per-item table, recommendations, analysis; **Run** button. `benchmark_reports` table + `/v3/benchmarks` router; run_benchmark self-ingests via `BENCHMARK_INGEST_URL`. |
+| #167 | Fixed transparent download dropdown (`popover` missing from tailwind color map) + broken download button (frontend expected async export+poll; backend is synchronous → blob download). |
+| #168 | Rich run exports — fixed field-name mismatch (near-empty → full content) + PDF (detailed) / Word (.docx) / JSON added alongside CSV/XLSX. See `docs/run-exports-and-benchmarks.md`. |
 > Maintainer note: this is the **source of truth for "what is actually shipped vs. in-flight."**
 > The older `TODO.md` (root) describes a tier roadmap and **lags reality** — trust this file and the code, not `TODO.md`.
 

--- a/docs/run-exports-and-benchmarks.md
+++ b/docs/run-exports-and-benchmarks.md
@@ -1,0 +1,88 @@
+# Run Exports & Benchmark Reports
+
+Two admin/user-facing reporting surfaces: **downloadable run reports** (PDF / Word / Excel / CSV / JSON) and the **admin Benchmark Reports page**.
+
+---
+
+## Run exports
+
+Every research run can be downloaded as a detailed report via the **Download** menu
+(on the run list / result drawer / results panel). Five formats are offered:
+
+| Format | What it contains | Best for |
+|--------|------------------|----------|
+| **PDF report (detailed)** | Run-info header (query, status, dates, tool-calls, phases, counts) → **ranked candidates** (each with evidence snippets + source URLs) → **full findings** → analysis (entities / relationships / insights) | A shareable human report |
+| **Word (.docx)** | Same structure as the PDF, as an editable Word document (headings, run info, ranked candidates, findings, analysis) | Editing / pasting into other docs |
+| **Excel (.xlsx)** | Sheets: **Run Info**, **Ranked Candidates**, **Findings**, **Entities**, **Relationships**, **Insights** | Spreadsheet analysis / filtering |
+| **CSV** | One row per finding: `rank, title, source_class, url, confidence, phase, content` | Quick import / grep |
+| **JSON (full data)** | The complete structured report: `metadata + findings + ranked_candidates + analysis` | Programmatic use / archival |
+
+### How it works
+
+`POST /v3/exports/research/{run_id}` with `{ "format": "pdf|csv|xlsx|json|docx", "include_analysis": true }`
+generates the file **synchronously** and returns `{ "filename", "url" }`. The file is
+fetched from `GET /v3/exports/files/{filename}` (ephemeral; the URL is the token).
+The frontend downloads it as a blob through the authenticated API client.
+
+The export reads the run's `research_trails` row (findings, trail, analysis) plus
+`pipeline_runs` metadata (status, started/finished, tool_calls). Findings are passed
+through `_normalize_finding`, which maps the real trail shape
+(`candidate_name` / `source_url` / `source_class` / `evidence_snippet` / `phase_id`)
+onto the export columns — earlier exports were near-empty because the generators read
+`title`/`source`/`content`/`url`, which the findings don't use.
+
+> **Note:** PDF text uses `wrapmode="CHAR"` so long unbreakable tokens (e.g. listing
+> URLs) don't raise fpdf2's "Not enough horizontal space" error.
+
+### Validated end-to-end
+
+A fresh run (preflight → confirm → engine_v2 → trail, status `succeeded`, 20 findings)
+exported cleanly in all five formats: PDF (valid `%PDF-`), DOCX (valid zip), XLSX,
+CSV (21 rows — addresses, prices, source URLs, confidence, phase), JSON (metadata +
+20 findings + 20 ranked candidates + analysis).
+
+---
+
+## Benchmark Reports (admin)
+
+`/admin/benchmarks` (admin nav → **Benchmark Reports**) surfaces gold-set benchmark
+runs: the headline **mean-score rating** + letter grade + a 0-gamed badge, a
+run-history selector, a per-item table, aggregate cost stats, severity-ranked
+recommendations, and a methodology/analysis section.
+
+### Scoring model
+
+`item_score = coverage × source_quality`, with four anti-gaming guards that **hard-zero**
+any run that fabricates from training data, uses unregistered tools, skips phases, or
+RAG-shortcuts. So a clean run with 0% gamed is doing real live research.
+
+- `coverage` — fraction of the item's curated authoritative facts matched.
+- `source_quality` — best source-class weight: `primary_official`/`live_official` = 1.0,
+  `registry` = 0.95, `live_search` = 0.75, `news`/`aggregator`/`social` lower,
+  `training` = 0.
+- `field_coverage` — fraction of the 10 lead fields surfaced run-wide (enrichment breadth).
+
+### Endpoints
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/v3/benchmarks/reports` | API-key | Ingest a report (run_benchmark posts here) |
+| GET | `/v3/benchmarks/reports` | admin | List run history |
+| GET | `/v3/benchmarks/reports/{id}` | admin | Full report |
+| POST | `/v3/benchmarks/run` | admin | Trigger a run in the background (single concurrent; 409 if active) |
+| GET | `/v3/benchmarks/run/status` | admin | Is a run active? |
+
+### Running the benchmark
+
+- **From the UI:** the **Run benchmark** button spawns a background run (real brain
+  time — several minutes per item); the new report appears in the list when done.
+- **From the CLI:** `python -m benchmarks.run_benchmark --items <ids> --out-json <path>`.
+  Set `BENCHMARK_INGEST_URL=http://localhost:8000` (+ `INFO_BROKER_API_KEY`) to have the
+  run POST its report to the page automatically.
+
+### Honest caveats (shown on the page)
+
+- Scores are the **no-key** free-capability baseline unless a run had keys configured.
+- Runs are **stochastic** — a single item can swing (e.g. a thin run); trust the trend
+  across multiple reports, not one number.
+- The leads gold-set is curated (4 items), not a broad statistical sample.


### PR DESCRIPTION
Documents the 5-format run exports (PDF/Word/Excel/CSV/JSON), the export API + data flow + field-normalization, and the admin Benchmark Reports page. Records the end-to-end validation (fresh succeeded run, 20 findings, all 5 formats valid). Reconciles TICKET-TRACKING for #165–#168. Docs-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)