### PR TITLE
fix(admin): paginate User Management page

### DIFF
--- a/app/routers/v3/auth.py
+++ b/app/routers/v3/auth.py
@@ -8,7 +8,7 @@ import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -141,15 +141,54 @@ def refresh(body: RefreshRequest):
 
 
 @router.get("/users", dependencies=[Depends(require_admin)])
-def list_users(current_user: dict = Depends(get_current_user)) -> list[dict]:
-    """List all users. Admin only."""
-    rows = fetch_all(
-        """SELECT id, username, email, is_admin, role, is_active, org_id, created_at
-           FROM ui_users
-           ORDER BY created_at DESC""",
-        (),
-    )
-    return [dict(r) for r in rows]
+def list_users(
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+    search: str | None = Query(default=None),
+    current_user: dict = Depends(get_current_user),  # noqa: ARG001
+) -> dict:
+    """List users with pagination + optional search. Admin only.
+
+    Returns: { items, total, page, page_size, total_pages }
+    """
+    offset = (page - 1) * page_size
+
+    if search:
+        pattern = f"%{search}%"
+        total_row = fetch_one(
+            """SELECT COUNT(*) AS cnt FROM ui_users
+               WHERE username ILIKE %s OR email ILIKE %s""",
+            (pattern, pattern),
+        )
+        total = total_row["cnt"] if total_row else 0
+        rows = fetch_all(
+            """SELECT id, username, email, is_admin, role, is_active, org_id, created_at
+               FROM ui_users
+               WHERE username ILIKE %s OR email ILIKE %s
+               ORDER BY created_at DESC, id
+               LIMIT %s OFFSET %s""",
+            (pattern, pattern, page_size, offset),
+        )
+    else:
+        total_row = fetch_one("SELECT COUNT(*) AS cnt FROM ui_users", ())
+        total = total_row["cnt"] if total_row else 0
+        rows = fetch_all(
+            """SELECT id, username, email, is_admin, role, is_active, org_id, created_at
+               FROM ui_users
+               ORDER BY created_at DESC, id
+               LIMIT %s OFFSET %s""",
+            (page_size, offset),
+        )
+
+    import math
+    total_pages = max(1, math.ceil(total / page_size))
+    return {
+        "items": [dict(r) for r in rows],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": total_pages,
+    }
 
 
 @router.patch("/users/{user_id}", dependencies=[Depends(require_admin)])

--- a/app/tests/test_users_pagination.py
+++ b/app/tests/test_users_pagination.py
@@ -1,0 +1,177 @@
+"""Real-PG integration tests for paginated GET /v3/auth/users.
+
+Requires a live Postgres instance (POSTGRES_PORT=5433 by default).
+Inserts 60 test users in an isolated prefix, verifies page-1/page-2
+behaviour, then cleans up.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Point at the local dev DB (port 5433); keep other env stubs consistent.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("INFO_BROKER_API_KEY", "test-secret-key")
+os.environ.setdefault("POSTGRES_DB", "info_broker")
+os.environ.setdefault("POSTGRES_USER", "user")
+os.environ.setdefault("POSTGRES_PASSWORD", "password")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5433")
+
+# Stub out qdrant (not needed for these tests)
+sys.modules.setdefault("qdrant_client", MagicMock())
+sys.modules.setdefault("qdrant_client.models", MagicMock())
+
+from fastapi.testclient import TestClient  # noqa: E402
+from app.routers.v3.db import execute, fetch_all  # noqa: E402
+from app.main import app  # noqa: E402
+from app.routers.v3.auth import get_current_user  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ADMIN_USER = {
+    "id": str(uuid.uuid4()),
+    "username": "testadmin",
+    "is_active": True,
+    "role": "admin",
+    "is_admin": True,
+}
+
+# Unique prefix so test rows don't collide with real users
+_PREFIX = f"pgtest_{uuid.uuid4().hex[:8]}_"
+_N = 60
+
+
+@pytest.fixture(scope="module")
+def db_users():
+    """Insert 60 uniquely-prefixed test users; yield; delete them."""
+    inserted_ids: list[str] = []
+    for i in range(_N):
+        uname = f"{_PREFIX}{i:03d}"
+        email = f"{uname}@test.invalid"
+        row = execute(
+            """INSERT INTO ui_users (username, email, password_hash, is_active)
+               VALUES (%s, %s, 'x', true)
+               RETURNING id""",
+            (uname, email),
+        )
+        # execute() may or may not return RETURNING rows; use fetch_all for safety
+    # Fetch the inserted IDs
+    rows = fetch_all(
+        "SELECT id FROM ui_users WHERE username LIKE %s ORDER BY created_at",
+        (f"{_PREFIX}%",),
+    )
+    inserted_ids = [str(r["id"]) for r in rows]
+    yield inserted_ids
+    # Cleanup
+    execute(
+        "DELETE FROM ui_users WHERE username LIKE %s",
+        (f"{_PREFIX}%",),
+    )
+
+
+@pytest.fixture(scope="module")
+def client():
+    app.dependency_overrides[get_current_user] = lambda: ADMIN_USER
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestUsersPagination:
+    def test_default_page_200(self, client, db_users):
+        """GET /v3/auth/users returns 200 with paginated envelope."""
+        r = client.get("/v3/auth/users")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert "items" in data
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "total_pages" in data
+
+    def test_page1_returns_50_items(self, client, db_users):
+        """First page with page_size=50 should return exactly 50 items (we have >=60)."""
+        r = client.get("/v3/auth/users?page=1&page_size=50")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["page"] == 1
+        assert data["page_size"] == 50
+        assert len(data["items"]) == 50
+        # Total should include all test users plus any pre-existing users
+        assert data["total"] >= _N
+
+    def test_page2_contains_remaining_test_users(self, client, db_users):
+        """When filtered by prefix, page 2 of page_size=50 should return exactly 10 items."""
+        # Use search to isolate just our test users
+        r1 = client.get(f"/v3/auth/users?page=1&page_size=50&search={_PREFIX}")
+        assert r1.status_code == 200, r1.text
+        d1 = r1.json()
+        assert d1["total"] == _N, f"Expected {_N} test users, got {d1['total']}"
+        assert len(d1["items"]) == 50
+        assert d1["total_pages"] == 2
+
+        r2 = client.get(f"/v3/auth/users?page=2&page_size=50&search={_PREFIX}")
+        assert r2.status_code == 200, r2.text
+        d2 = r2.json()
+        assert len(d2["items"]) == 10
+        assert d2["total"] == _N
+
+    def test_total_consistent_across_pages(self, client, db_users):
+        """total field must be the same on both pages."""
+        r1 = client.get("/v3/auth/users?page=1&page_size=50")
+        r2 = client.get("/v3/auth/users?page=2&page_size=50")
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json()["total"] == r2.json()["total"]
+
+    def test_search_filters_by_username(self, client, db_users):
+        """search param should reduce results to matching users only."""
+        r = client.get(f"/v3/auth/users?search={_PREFIX}&page=1&page_size=100")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == _N
+        for item in data["items"]:
+            assert _PREFIX in item["username"] or (item["email"] and _PREFIX in item["email"])
+
+    def test_search_no_match_returns_empty(self, client, db_users):
+        """search that matches nothing returns empty items and total=0."""
+        r = client.get("/v3/auth/users?search=ZZZZ_IMPOSSIBLE_MATCH_9999")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+        assert data["total_pages"] == 1
+
+    def test_page_size_max_200(self, client, db_users):
+        """page_size=200 should be accepted."""
+        r = client.get("/v3/auth/users?page=1&page_size=200")
+        assert r.status_code == 200
+
+    def test_page_size_over_limit_rejected(self, client, db_users):
+        """page_size=201 should be rejected with 422."""
+        r = client.get("/v3/auth/users?page=1&page_size=201")
+        assert r.status_code == 422
+
+    def test_page_zero_rejected(self, client, db_users):
+        """page=0 should be rejected with 422."""
+        r = client.get("/v3/auth/users?page=0")
+        assert r.status_code == 422
+
+    def test_items_schema(self, client, db_users):
+        """Each item in the response should have the expected fields."""
+        r = client.get("/v3/auth/users?page=1&page_size=1")
+        assert r.status_code == 200
+        item = r.json()["items"][0]
+        for field in ("id", "username", "is_admin", "role", "is_active", "created_at"):
+            assert field in item, f"Missing field: {field}"

--- a/frontend/src/api/v3.ts
+++ b/frontend/src/api/v3.ts
@@ -665,8 +665,23 @@ export interface UserRecord {
   created_at: string
 }
 
-export const listUsers = (): Promise<UserRecord[]> =>
-  api.get('/v3/auth/users').then(r => r.data)
+export interface UserPage {
+  items: UserRecord[]
+  total: number
+  page: number
+  page_size: number
+  total_pages: number
+}
+
+export const listUsers = (
+  page = 1,
+  page_size = 50,
+  search?: string,
+): Promise<UserPage> => {
+  const params: Record<string, string | number> = { page, page_size }
+  if (search) params.search = search
+  return api.get('/v3/auth/users', { params }).then(r => r.data)
+}
 
 export const patchUser = (
   userId: string,

--- a/frontend/src/pages/AdminUsersPage.test.tsx
+++ b/frontend/src/pages/AdminUsersPage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import AdminUsersPage from './AdminUsersPage'
+
+vi.mock('@/components/layout/IconRail', () => ({ default: () => null }))
+vi.mock('@/stores/sessionStore', () => ({
+  useSessionStore: () => ({ userId: 'current-user-id' }),
+}))
+
+const makeUser = (i: number) => ({
+  id: `user-${i}`,
+  username: `user${i}`,
+  email: `user${i}@example.com`,
+  is_admin: false,
+  role: 'analyst' as const,
+  is_active: true,
+  org_id: '',
+  created_at: '2026-01-01T00:00:00Z',
+})
+
+const PAGE1 = Array.from({ length: 50 }, (_, i) => makeUser(i))
+const PAGE2 = Array.from({ length: 10 }, (_, i) => makeUser(i + 50))
+
+vi.mock('@/api/v3', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/api/v3')>()),
+  listUsers: vi.fn().mockResolvedValue({
+    items: Array.from({ length: 50 }, (_, i) => ({
+      id: `user-${i}`, username: `user${i}`, email: `user${i}@example.com`,
+      is_admin: false, role: 'analyst', is_active: true,
+      org_id: '', created_at: '2026-01-01T00:00:00Z',
+    })),
+    total: 60,
+    page: 1,
+    page_size: 50,
+    total_pages: 2,
+  }),
+  patchUser: vi.fn().mockResolvedValue({}),
+}))
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><AdminUsersPage /></MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('AdminUsersPage', () => {
+  it('renders total user count from the paginated response', async () => {
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText(/60 users total/)).toBeInTheDocument()
+    )
+  })
+
+  it('shows page 1 of 2 in the pagination controls', async () => {
+    renderPage()
+    await waitFor(() =>
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+    )
+  })
+
+  it('Previous button is disabled on page 1', async () => {
+    renderPage()
+    const prev = await screen.findByRole('button', { name: /previous/i })
+    expect(prev).toBeDisabled()
+  })
+
+  it('Next button is enabled on page 1', async () => {
+    renderPage()
+    const next = await screen.findByRole('button', { name: /next/i })
+    expect(next).not.toBeDisabled()
+  })
+
+  it('navigates to page 2 when Next is clicked', async () => {
+    const { listUsers } = await import('@/api/v3')
+    ;(listUsers as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      items: PAGE1, total: 60, page: 1, page_size: 50, total_pages: 2,
+    }).mockResolvedValueOnce({
+      items: PAGE2, total: 60, page: 2, page_size: 50, total_pages: 2,
+    })
+
+    renderPage()
+    const next = await screen.findByRole('button', { name: /next/i })
+    fireEvent.click(next)
+    await waitFor(() =>
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+    )
+  })
+
+  it('renders search input and Search button', async () => {
+    renderPage()
+    expect(await screen.findByPlaceholderText(/search username or email/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^search$/i })).toBeInTheDocument()
+  })
+
+  it('shows 50-item page-size button as active by default', async () => {
+    renderPage()
+    // Wait for the table to render, then check per-page buttons
+    await screen.findByRole('button', { name: /next/i })
+    const buttons = screen.getAllByRole('button')
+    const btn50 = buttons.find(b => b.textContent === '50')
+    expect(btn50).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/AdminUsersPage.tsx
+++ b/frontend/src/pages/AdminUsersPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listUsers, patchUser, UserRecord, UserRole } from '../api/v3'
 import IconRail from '../components/layout/IconRail'
@@ -46,14 +47,25 @@ function Toggle({
   )
 }
 
+const PAGE_SIZE_OPTIONS = [25, 50, 100] as const
+
 export default function AdminUsersPage() {
   const qc = useQueryClient()
   const { userId } = useSessionStore()
 
-  const { data: users = [], isLoading, error } = useQuery<UserRecord[]>({
-    queryKey: ['admin-users'],
-    queryFn: listUsers,
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(50)
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-users', page, pageSize, search],
+    queryFn: () => listUsers(page, pageSize, search || undefined),
   })
+
+  const users: UserRecord[] = data?.items ?? []
+  const total = data?.total ?? 0
+  const totalPages = data?.total_pages ?? 1
 
   const patch = useMutation({
     mutationFn: ({ id, body }: { id: string; body: Partial<Pick<UserRecord, 'is_admin' | 'is_active' | 'role'>> }) =>
@@ -61,8 +73,21 @@ export default function AdminUsersPage() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-users'] }),
   })
 
+  const handleSearch = useCallback(() => {
+    setPage(1)
+    setSearch(searchInput.trim())
+  }, [searchInput])
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleSearch()
+  }
+
+  const handlePageSizeChange = (newSize: number) => {
+    setPageSize(newSize)
+    setPage(1)
+  }
+
   const adminCount = users.filter(u => u.is_admin).length
-  const totalCount = users.length
 
   return (
     <div
@@ -81,13 +106,63 @@ export default function AdminUsersPage() {
               User Management
             </h1>
             <p style={{ fontSize: 11, color: 'var(--subtext)', margin: 0 }}>
-              {totalCount} {totalCount === 1 ? 'user' : 'users'} — {adminCount} admin{adminCount !== 1 ? 's' : ''}
+              {total} {total === 1 ? 'user' : 'users'} total — {adminCount} admin{adminCount !== 1 ? 's' : ''} on this page
             </p>
+          </div>
+
+          {/* Search */}
+          <div className="flex items-center gap-2" style={{ marginLeft: 'auto' }}>
+            <input
+              type="text"
+              placeholder="Search username or email…"
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              style={{
+                background: 'var(--panel)',
+                color: 'var(--text)',
+                border: '1px solid var(--border)',
+                borderRadius: 4,
+                fontSize: 12,
+                padding: '4px 8px',
+                width: 220,
+              }}
+            />
+            <button
+              onClick={handleSearch}
+              style={{
+                background: 'var(--accent)',
+                color: 'var(--bg)',
+                border: 'none',
+                borderRadius: 4,
+                fontSize: 12,
+                padding: '4px 10px',
+                cursor: 'pointer',
+              }}
+            >
+              Search
+            </button>
+            {search && (
+              <button
+                onClick={() => { setSearchInput(''); setSearch(''); setPage(1) }}
+                style={{
+                  background: 'transparent',
+                  color: 'var(--subtext)',
+                  border: '1px solid var(--border)',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  padding: '4px 8px',
+                  cursor: 'pointer',
+                }}
+              >
+                Clear
+              </button>
+            )}
           </div>
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-auto p-6">
+        <div className="flex-1 overflow-auto p-6" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           {isLoading && (
             <p style={{ color: 'var(--muted)', fontSize: 12 }}>Loading users…</p>
           )}
@@ -99,7 +174,9 @@ export default function AdminUsersPage() {
           )}
 
           {!isLoading && !error && users.length === 0 && (
-            <p style={{ color: 'var(--muted)', fontSize: 12 }}>No users found.</p>
+            <p style={{ color: 'var(--muted)', fontSize: 12 }}>
+              {search ? `No users matching "${search}".` : 'No users found.'}
+            </p>
           )}
 
           {!isLoading && !error && users.length > 0 && (
@@ -206,6 +283,78 @@ export default function AdminUsersPage() {
                   })}
                 </tbody>
               </table>
+            </div>
+          )}
+
+          {/* Pagination controls */}
+          {!isLoading && !error && total > 0 && (
+            <div
+              className="flex items-center gap-3"
+              style={{ marginTop: 'auto', paddingTop: 8, flexWrap: 'wrap' }}
+            >
+              <button
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                style={{
+                  background: 'var(--panel)',
+                  color: 'var(--text)',
+                  border: '1px solid var(--border)',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  padding: '4px 10px',
+                  cursor: page <= 1 ? 'not-allowed' : 'pointer',
+                  opacity: page <= 1 ? 0.4 : 1,
+                }}
+              >
+                Previous
+              </button>
+
+              <span style={{ fontSize: 12, color: 'var(--subtext)' }}>
+                Page {page} of {totalPages}
+              </span>
+
+              <button
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                style={{
+                  background: 'var(--panel)',
+                  color: 'var(--text)',
+                  border: '1px solid var(--border)',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  padding: '4px 10px',
+                  cursor: page >= totalPages ? 'not-allowed' : 'pointer',
+                  opacity: page >= totalPages ? 0.4 : 1,
+                }}
+              >
+                Next
+              </button>
+
+              <span style={{ fontSize: 12, color: 'var(--muted)', marginLeft: 4 }}>
+                {total} total
+              </span>
+
+              {/* Page size selector */}
+              <div className="flex items-center gap-1" style={{ marginLeft: 'auto' }}>
+                <span style={{ fontSize: 12, color: 'var(--subtext)' }}>Per page:</span>
+                {PAGE_SIZE_OPTIONS.map(s => (
+                  <button
+                    key={s}
+                    onClick={() => handlePageSizeChange(s)}
+                    style={{
+                      background: pageSize === s ? 'var(--accent)' : 'var(--panel)',
+                      color: pageSize === s ? 'var(--bg)' : 'var(--text)',
+                      border: '1px solid var(--border)',
+                      borderRadius: 4,
+                      fontSize: 11,
+                      padding: '3px 8px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
The User Management page was loading all users in a single request, which is slow as the user count grows (currently 3,473 users). Backend gains \`page\`/\`page_size\` query params (default page=1, page_size=50, max 200) and returns a paginated envelope (items, total, page, page_size, total_pages). Frontend gets Prev/Next controls + a search input.

## Changes

### Backend — \`app/routers/v3/auth.py\`
- \`GET /v3/auth/users\` now accepts \`page\`, \`page_size\`, and \`search\` query params
- Returns \`{ items, total, page, page_size, total_pages }\` envelope
- Stable \`ORDER BY created_at DESC, id\` for deterministic paging
- \`ILIKE\` search on username or email
- One \`COUNT\` + one \`SELECT\` per request (no N+1)
- Auth unchanged: still requires \`require_admin\`

### Frontend — \`frontend/src/api/v3.ts\` + \`AdminUsersPage.tsx\`
- \`listUsers(page, pageSize, search?)\` replaces the old no-arg call
- \`AdminUsersPage\` uses \`useQuery\` keyed on \`[page, pageSize, search]\`
- Pagination controls: Previous / Next, Page X of Y, total count
- Page-size selector: 25 / 50 / 100
- Search input (Enter key or Search button), Clear button to reset

### Tests
- 10 real-PG integration tests (\`app/tests/test_users_pagination.py\`): inserts 60 test users, verifies page-1 returns 50, page-2 returns 10, total=60, search filtering, edge cases (page=0, page_size=201 rejected)
- 7 Vitest unit tests (\`frontend/src/pages/AdminUsersPage.test.tsx\`): pagination controls, disabled states, navigation, search input

## Compat note
Only one caller of \`GET /v3/auth/users\` existed (the Admin Users page). The response shape changed from a flat list to a paginated envelope; both the API helper and the page component were updated in the same commit.

## Test matrix
| Layer | Command | Result |
|---|---|---|
| TS check | \`pnpm tsc --noEmit\` | clean |
| Frontend | \`pnpm test run\` | 147/147 pass (23 files) |
| Backend PG | \`POSTGRES_PORT=5433 uv run pytest app/tests/test_users_pagination.py\` | 10/10 pass |
| Backend full | \`POSTGRES_PORT=5433 uv run pytest app/tests/\` | 85/88 pass (3 pre-existing playlist_source failures unrelated to this change) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)